### PR TITLE
Add v2 API support for ProviderDetails & providerResourceDetails

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -87,6 +87,7 @@ func TestE2E(t *testing.T) {
 				require.True(t, ok, "expected content to be of type TextContent")
 				t.Logf("Content length: %d", len(textContent.Text))
 
+				// TODO: Implement a better way to test this
 				if testCase.TestContentType == CONST_TYPE_DATA_SOURCE {
 					require.NotContains(t, textContent.Text, "**Category:** resources", "expected content not to contain resources")
 				} else if testCase.TestContentType == CONST_TYPE_RESOURCE {
@@ -94,6 +95,10 @@ func TestE2E(t *testing.T) {
 				} else if testCase.TestContentType == CONST_TYPE_BOTH {
 					require.Contains(t, textContent.Text, "**Category:** resources", "expected content to contain resources")
 					require.Contains(t, textContent.Text, "**Category:** data-sources", "expected content to contain data-sources")
+				} else if testCase.TestContentType == CONST_TYPE_GUIDES {
+					require.Contains(t, textContent.Text, "**Category:** guides", "expected content to contain guides")
+				} else if testCase.TestContentType == CONST_TYPE_FUNCTIONS {
+					require.Contains(t, textContent.Text, "**Category:** functions", "expected content to contain functions")
 				}
 			}
 		})
@@ -133,6 +138,10 @@ func TestE2E(t *testing.T) {
 				} else if testCase.TestContentType == CONST_TYPE_BOTH {
 					require.Contains(t, textContent.Text, "resource", "expected content to contain resources")
 					require.Contains(t, textContent.Text, "data source", "expected content to contain data-sources")
+				} else if testCase.TestContentType == CONST_TYPE_GUIDES {
+					require.Contains(t, textContent.Text, "guide", "expected content to contain guide")
+				} else if testCase.TestContentType == CONST_TYPE_FUNCTIONS {
+					require.Contains(t, textContent.Text, "functions", "expected content to contain functions")
 				}
 			}
 		})

--- a/e2e/payloads.go
+++ b/e2e/payloads.go
@@ -6,12 +6,15 @@ const (
 	CONST_TYPE_RESOURCE    ContentType = "resources"
 	CONST_TYPE_DATA_SOURCE ContentType = "data-sources"
 	CONST_TYPE_BOTH        ContentType = "both"
+	CONST_TYPE_GUIDES      ContentType = "guides"
+	CONST_TYPE_FUNCTIONS   ContentType = "functions"
+	CONST_TYPE_OVERVIEW    ContentType = "overview"
 )
 
 type RegistryTestCase struct {
 	TestShouldFail  bool                   `json:"testShouldFail"`
 	TestDescription string                 `json:"testDescription"`
-	TestContentType ContentType            `json:"testResourceOnly,omitempty"`
+	TestContentType ContentType            `json:"testContentType,omitempty"`
 	TestPayload     map[string]interface{} `json:"testPayload,omitempty"`
 }
 
@@ -102,6 +105,42 @@ var providerDetailsTestCases = []RegistryTestCase{
 			"providerName":      "vaults",
 			"providerNamespace": "hashicorp",
 			"providerVersion":   "latest",
+		},
+	},
+	{
+		TestShouldFail:  false,
+		TestDescription: "Testing guides documentation with v2 API",
+		TestContentType: CONST_TYPE_GUIDES,
+		TestPayload: map[string]interface{}{
+			"providerName":      "aws",
+			"providerNamespace": "hashicorp",
+			"providerVersion":   "latest",
+			"providerDataType":  "guides",
+			"serviceName":       "custom-service-endpoints",
+		},
+	},
+	{
+		TestShouldFail:  false,
+		TestDescription: "Testing functions documentation with v2 API",
+		TestContentType: CONST_TYPE_FUNCTIONS,
+		TestPayload: map[string]interface{}{
+			"providerName":      "google",
+			"providerNamespace": "hashicorp",
+			"providerVersion":   "latest",
+			"providerDataType":  "functions",
+			"serviceName":       "name_from_id",
+		},
+	},
+	{
+		TestShouldFail:  false,
+		TestDescription: "Testing overview documentation with v2 API",
+		TestContentType: CONST_TYPE_OVERVIEW,
+		TestPayload: map[string]interface{}{
+			"providerName":      "google",
+			"providerNamespace": "hashicorp",
+			"providerVersion":   "latest",
+			"providerDataType":  "overview",
+			"serviceName":       "index",
 		},
 	},
 }

--- a/pkg/hashicorp/tfregistry/handlers.go
+++ b/pkg/hashicorp/tfregistry/handlers.go
@@ -22,8 +22,8 @@ func ProviderDetails(registryClient *http.Client, logger *log.Logger) (tool mcp.
 			mcp.WithString("providerName", mcp.Required(), mcp.Description("The name of the Terraform provider to perform the read or deployment operation.")),
 			mcp.WithString("providerNamespace", mcp.Required(), mcp.Description("The publisher of the Terraform provider, typically the name of the company, or their GitHub organization name that created the provider.")),
 			mcp.WithString("providerVersion", mcp.Description("The version of the Terraform provider to retrieve in the format 'x.y.z', or 'latest' to get the latest version.")),
-			mcp.WithString("providerDataType", mcp.Description("The source type of the Terraform provider to retrieve, can be 'resources' or 'data-sources'."),
-				mcp.Enum("resources", "data-sources")), // TODO: Limitation due to the v1 API, we need to implement v2
+			mcp.WithString("providerDataType", mcp.Description("The source type of the Terraform provider to retrieve."),
+				mcp.Enum("resources", "data-sources", "functions", "guides", "overview")),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 
@@ -34,6 +34,22 @@ func ProviderDetails(registryClient *http.Client, logger *log.Logger) (tool mcp.
 				return nil, err
 			}
 
+			// Check if we need to use v2 API for guides, functions, or overview
+			if isV2ProviderDataType(providerDetail.ProviderDataType) {
+				content, err := GetProviderDocsV2(registryClient, providerDetail, logger)
+				if err != nil {
+					errMessage := fmt.Sprintf(`No %s documentation found for provider '%s' in the '%s' namespace, %s`,
+						providerDetail.ProviderDataType, providerDetail.ProviderName, providerDetail.ProviderNamespace, defaultErrorGuide)
+					return nil, logAndReturnError(logger, errMessage, err)
+				}
+
+				fullContent := fmt.Sprintf("# %s provider docs\n\n%s",
+					providerDetail.ProviderName, content)
+
+				return mcp.NewToolResultText(fullContent), nil
+			}
+
+			// For resources/data-sources, use the v1 API for better performance (single response)
 			uri := fmt.Sprintf("providers/%s/%s/%s", providerDetail.ProviderNamespace, providerDetail.ProviderName, providerDetail.ProviderVersion)
 			response, err := sendRegistryCall(registryClient, "GET", uri, logger)
 			if err != nil {
@@ -77,7 +93,7 @@ func providerResourceDetails(registryClient *http.Client, logger *log.Logger) (t
 			mcp.WithString("providerNamespace", mcp.Required(), mcp.Description("The publisher of the Terraform provider, typically the name of the company or their GitHub organization name that created the provider.")),
 			mcp.WithString("providerVersion", mcp.Description("The version of the Terraform provider to retrieve in the format 'x.y.z', or 'latest' to get the latest version.")),
 			mcp.WithString("providerDataType", mcp.Description("The source type of the Terraform provider to retrieve, can be 'resources' or 'data-sources'."),
-				mcp.Enum("resources", "data-sources")),
+				mcp.Enum("resources", "data-sources", "functions", "guides")),
 			mcp.WithString("serviceName", mcp.Required(), mcp.Description("The name of the service or resource for read or deployment operations.")),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -94,7 +110,12 @@ func providerResourceDetails(registryClient *http.Client, logger *log.Logger) (t
 				return nil, err
 			}
 
-			content, err := GetProviderResourceDetails(registryClient, providerDetail, serviceName, logger)
+			var content string
+			if isV2ProviderDataType(providerDetail.ProviderDataType) {
+				content, err = GetProviderResourceDetailsV2(registryClient, providerDetail, serviceName, logger)
+			} else {
+				content, err = GetProviderResourceDetails(registryClient, providerDetail, serviceName, logger)
+			}
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/hashicorp/tfregistry/types.go
+++ b/pkg/hashicorp/tfregistry/types.go
@@ -333,20 +333,22 @@ type ProviderResourceDetails struct {
 // ProviderOverview represents the structure of the provider overview (how to use it) response.
 // https://registry.terraform.io/v2/provider-docs?filter[provider-version]=70800&filter[category]=overview&filter[slug]=index
 type ProviderOverview struct {
-	Data []struct {
-		Type       string `json:"type"`
-		ID         string `json:"id"`
-		Attributes struct {
-			Category    string `json:"category"`
-			Language    string `json:"language"`
-			Path        string `json:"path"`
-			Slug        string `json:"slug"`
-			Subcategory any    `json:"subcategory"`
-			Title       string `json:"title"`
-			Truncated   bool   `json:"truncated"`
-		} `json:"attributes"`
-		Links struct {
-			Self string `json:"self"`
-		} `json:"links"`
-	} `json:"data"`
+	Data []ProviderDocData `json:"data"`
+}
+
+type ProviderDocData struct {
+	Type       string `json:"type"`
+	ID         string `json:"id"`
+	Attributes struct {
+		Category    string      `json:"category"`
+		Language    string      `json:"language"`
+		Path        string      `json:"path"`
+		Slug        string      `json:"slug"`
+		Subcategory interface{} `json:"subcategory"`
+		Title       string      `json:"title"`
+		Truncated   bool        `json:"truncated"`
+	} `json:"attributes"`
+	Links struct {
+		Self string `json:"self"`
+	} `json:"links"`
 }

--- a/pkg/hashicorp/tfregistry/utils.go
+++ b/pkg/hashicorp/tfregistry/utils.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -194,6 +195,40 @@ func GetProviderResourceDetails(client *http.Client, providerDetail ProviderDeta
 	return content, nil
 }
 
+// GetProviderResourceDetailsV2 fetches the provider resource details using v2 API with support for pagination using page numbers
+func GetProviderResourceDetailsV2(client *http.Client, providerDetail ProviderDetail, serviceName string, logger *log.Logger) (string, error) {
+	providerVersionID, err := GetProviderVersionID(client, providerDetail.ProviderNamespace, providerDetail.ProviderName, providerDetail.ProviderVersion, logger)
+	if err != nil {
+		return "", logAndReturnError(logger, "getting provider version ID", err)
+	}
+
+	uriPrefix := fmt.Sprintf("provider-docs?filter[provider-version]=%s&filter[category]=%s&filter[slug]=%s&filter[language]=hcl",
+		providerVersionID, providerDetail.ProviderDataType, serviceName)
+
+	docs, err := sendPaginatedRegistryCall[ProviderDocData](client, uriPrefix, logger)
+	if err != nil {
+		return "", err
+	}
+
+	var builder strings.Builder
+	for _, doc := range docs {
+		detailResp, err := sendRegistryCall(client, "GET", fmt.Sprintf("provider-docs/%s", doc.ID), logger, "v2")
+		if err != nil {
+			logger.Errorf("Error fetching provider-docs/%s: %v", doc.ID, err)
+			continue
+		}
+
+		var details ProviderResourceDetails
+		if err := json.Unmarshal(detailResp, &details); err != nil {
+			logger.Errorf("Error unmarshalling provider-docs/%s: %v", doc.ID, err)
+			continue
+		}
+		builder.WriteString(details.Data.Attributes.Content)
+	}
+
+	return builder.String(), nil
+}
+
 // containsSlug checks if the sourceName string contains the slug string anywhere within it.
 // It safely handles potential regex metacharacters in the slug.
 // TODO: include a unit test for this
@@ -227,7 +262,8 @@ func isValidProviderVersionFormat(version string) bool {
 }
 
 func isValidProviderDataType(providerDataType string) bool {
-	return providerDataType == "resources" || providerDataType == "data-sources" || providerDataType == "provider-guides"
+	validTypes := []string{"resources", "data-sources", "functions", "guides", "overview"}
+	return slices.Contains(validTypes, providerDataType)
 }
 
 func resolveProviderDetails(request mcp.CallToolRequest, registryClient *http.Client, defaultErrorGuide string, logger *log.Logger) (ProviderDetail, error) {
@@ -476,10 +512,76 @@ func sendRegistryCall(client *http.Client, method string, uri string, logger *lo
 	return body, nil
 }
 
+func sendPaginatedRegistryCall[T any](client *http.Client, uriPrefix string, logger *log.Logger) ([]T, error) {
+	var results []T
+	page := 1
+
+	for {
+		uri := fmt.Sprintf("%s&page[number]=%d", uriPrefix, page)
+		resp, err := sendRegistryCall(client, "GET", uri, logger, "v2")
+		if err != nil {
+			return nil, logAndReturnError(logger, fmt.Sprintf("calling paginated registry API (page %d)", page), err)
+		}
+
+		var wrapper struct {
+			Data []T `json:"data"`
+		}
+		if err := json.Unmarshal(resp, &wrapper); err != nil {
+			return nil, logAndReturnError(logger, fmt.Sprintf("unmarshalling page %d", page), err)
+		}
+
+		if len(wrapper.Data) == 0 {
+			break
+		}
+
+		results = append(results, wrapper.Data...)
+		page++
+	}
+
+	return results, nil
+}
+
 func logAndReturnError(logger *log.Logger, context string, err error) error {
 	if err == nil {
 		err = fmt.Errorf("%s", context)
 	}
 	logger.Errorf("Error in %s: %v", context, err)
 	return err
+}
+
+// GetProviderDocsV2 retrieves a list of documentation items for a specific provider category using v2 API with support for pagination using page numbers
+func GetProviderDocsV2(client *http.Client, providerDetail ProviderDetail, logger *log.Logger) (string, error) {
+	providerVersionID, err := GetProviderVersionID(client, providerDetail.ProviderNamespace, providerDetail.ProviderName, providerDetail.ProviderVersion, logger)
+	if err != nil {
+		return "", logAndReturnError(logger, "getting provider version ID", err)
+	}
+	category := providerDetail.ProviderDataType
+	if category == "overview" {
+		return GetProviderOverviewDocs(client, providerVersionID, logger)
+	}
+
+	uriPrefix := fmt.Sprintf("provider-docs?filter[provider-version]=%s&filter[category]=%s&filter[language]=hcl",
+		providerVersionID, category)
+
+	docs, err := sendPaginatedRegistryCall[ProviderDocData](client, uriPrefix, logger)
+	if err != nil {
+		return "", err
+	}
+
+	if len(docs) == 0 {
+		return "", fmt.Errorf("no %s documentation found for provider version %s", category, providerVersionID)
+	}
+
+	var builder strings.Builder
+	for _, doc := range docs {
+		builder.WriteString(fmt.Sprintf("## %s\n\n**ID:** %s\n\n**Category:** %s\n\n**Subcategory:** %v\n\n**Path:** %s\n\n",
+			doc.Attributes.Title, doc.ID, doc.Attributes.Category, doc.Attributes.Subcategory, doc.Attributes.Path))
+	}
+
+	return builder.String(), nil
+}
+
+func isV2ProviderDataType(dataType string) bool {
+	v2Categories := []string{"guides", "functions", "overview"}
+	return slices.Contains(v2Categories, dataType)
 }


### PR DESCRIPTION
Issue #25 
* Add v2 API support for ProviderDetails & providerResourceDetails for `providerDataType`: `functions`, `guides` and `overview`
* Reformat utils functions to reduce code duplication
* Add `sendPaginatedRegistryCall` function to make paginated registry calls for v2 API.
* Add test cases to support these changes