### PR TITLE
remove extra Build Step in e2e workflow

### DIFF
--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -32,6 +32,3 @@ jobs:
         env:
           HCP_TFE_TOKEN: ${{ github.input.HCP_TFE_TOKEN }}
         run: make test-e2e
-
-      - name: Build
-        run: make build


### PR DESCRIPTION
we already perform a docker image build as the start of our e2e test so this isn't necessary for us.