### PR TITLE
[release-prep] update CMD for CRT docker image as variable expansion didn't work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,8 +56,8 @@ ARG PRODUCT_NAME=$BIN_NAME
 ARG TARGETOS TARGETARCH
 LABEL version=$PRODUCT_VERSION
 LABEL revision=$PRODUCT_REVISION
-COPY dist/$TARGETOS/$TARGETARCH/$BIN_NAME /bin/
-CMD ["/bin/$BIN_NAME", "stdio"]
+COPY dist/$TARGETOS/$TARGETARCH/$BIN_NAME /bin/terraform-mcp-server
+CMD ["/bin/terraform-mcp-server", "stdio"]
 
 # ===================================
 #


### PR DESCRIPTION
CMD is not good with expanding variables when it comes to the executable name itself. So made it static

Tested the fix locally after building the release-default image that CRT uses and it works correctly.
```
[  7:07PM ]  [ ec2-user@ip-172-31-29-203:~/workspace/DevWorkspace/terraform-mcp-server(mukeshjc-release-prep✔) ]
 $ docker build --no-cache --target release-default --build-arg BIN_NAME=terraform-mcp-server --build-arg VERSION=0.1.0-dev -t terraform-mcp-server:dev-crt .
[+] Building 0.9s (7/7) FINISHED                                                                docker:default
 => [internal] load build definition from Dockerfile                                                      0.0s
 => => transferring dockerfile: 2.30kB                                                                    0.0s
 => [internal] load metadata for gcr.io/distroless/base-debian12:latest                                   0.6s
 => [internal] load .dockerignore                                                                         0.0s
 => => transferring context: 2B                                                                           0.0s
 => [internal] load build context                                                                         0.0s
 => => transferring context: 387B                                                                         0.0s
 => CACHED [release-default 1/2] FROM gcr.io/distroless/base-debian12:latest@sha256:27769871031f67460f15  0.0s
 => [release-default 2/2] COPY dist/linux/amd64/terraform-mcp-server /bin/tf-mcp-server                   0.1s
 => exporting to image                                                                                    0.1s
 => => exporting layers                                                                                   0.1s
 => => writing image sha256:eaaa4c9765ea93377ee49c6bf1ac5caa243cef049a06b90cbcdde5a4ae2d77df              0.0s
 => => naming to docker.io/library/terraform-mcp-server:dev-crt                                           0.0s

[  7:07PM ]  [ ec2-user@ip-172-31-29-203:~/workspace/DevWorkspace/terraform-mcp-server(mukeshjc-release-prep✔) ]
 $ docker run --rm -i docker.io/library/terraform-mcp-server:dev-crt
HCP Terraform MCP Server running on stdio
...
......
...
```