### PR TITLE
[release-prep] update base docker image to alpine for supporting 386 and arm (32 bit) arch types

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 name: build
 
 # We now default to running this workflow on every push to every branch.
@@ -118,8 +121,8 @@ jobs:
     strategy:
       matrix:
         include:
-        #   - { arch: "386" }
-        #   - { arch: "arm" }
+          - { arch: "386" }
+          - { arch: "arm" }
           - { arch: "amd64" }
           - { arch: "arm64" }
       fail-fast: false # recommended during development

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 name: E2E Tests
 on:
   push:

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 schema = "2"
 
 project "terraform-mcp-server" {

--- a/.release/oss-release-metadata.hcl
+++ b/.release/oss-release-metadata.hcl
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 url_docker_registry_dockerhub = "https://hub.docker.com/r/hashicorp/terraform-mcp-server"
 url_source_repository         = "https://github/hashicorp/terraform-mcp-server"
 url_license                   = "https://github.com/hashicorp/terraform-mcp-server/blob/main/LICENSE"

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 container {
 	dependencies = true
 	osv          = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 go build -ldfl
 # dev runs the binary from devbuild
 # -----------------------------------
 # Make a stage to run the app
-FROM gcr.io/distroless/base-debian12 AS dev
+FROM docker.mirror.hashicorp.services/alpine:3.21 AS dev
 ARG VERSION="dev"
 # Set the working directory
 WORKDIR /server
@@ -45,7 +45,7 @@ CMD ["./terraform-mcp-server", "stdio"]
 
 # default release image (refereced in .github/workflows/build.yml)
 # -----------------------------------
-FROM gcr.io/distroless/base-debian12 AS release-default
+FROM docker.mirror.hashicorp.services/alpine:3.21 AS release-default
 ARG BIN_NAME
 # Export BIN_NAME for the CMD below, it can't see ARGs directly.
 ENV BIN_NAME=$BIN_NAME

--- a/scripts/crt-build.sh
+++ b/scripts/crt-build.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 
 # The crt-build script is used to detemine build metadata and create terraform-mcp-server builds.
 # We use it in build.yml for building release artifacts with CRT in the Go Build step. 

--- a/version/version.go
+++ b/version/version.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package version
 
 import (


### PR DESCRIPTION
`docker.mirror.hashicorp.services/alpine:3.21` is a common choice for our OSS product images. [example consul](https://github.com/hashicorp/consul/blob/main/Dockerfile#L16C1-L19)

Previous distroless Docker image didn't support 386 and arm platforms.

<img width="539" alt="image" src="https://github.com/user-attachments/assets/5506244d-7f03-4b81-b057-f0c3f04e6475" />

#37 