### PR TITLE
[release-prep] alaways build a statically linked binary so it can run without extra dependencies.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,11 @@ all: build
 # Build the binary
 # Get local ARCH; on Intel Mac, 'uname -m' returns x86_64 which we turn into amd64.
 # Not using 'go env GOOS/GOARCH' here so 'make docker' will work without local Go install.
+# Always use CGO_ENABLED=0 to ensure a statically linked binary is built
 ARCH     = $(shell A=$$(uname -m); [ $$A = x86_64 ] && A=amd64; echo $$A)
 OS       = $(shell uname | tr [[:upper:]] [[:lower:]])
 build:
-	GOARCH=$(ARCH) GOOS=$(OS) $(GO) build $(LDFLAGS) -o $(BINARY_NAME) ./cmd/terraform-mcp-server
+	CGO_ENABLED=0 GOARCH=$(ARCH) GOOS=$(OS) $(GO) build $(LDFLAGS) -o $(BINARY_NAME) ./cmd/terraform-mcp-server
 
 crt-build:
 	@mkdir -p $(TARGET_DIR)

--- a/scripts/crt-build.sh
+++ b/scripts/crt-build.sh
@@ -77,8 +77,9 @@ function build() {
   fi
 
   # Build terraform-mcp-server
+  # Always use CGO_ENABLED=0 to ensure a statically linked binary is built
   echo "$msg"
-  go build -o "$BIN_PATH" -tags "$GO_TAGS" -ldflags "$ldflags" -trimpath -buildvcs=false ./cmd/terraform-mcp-server
+  CGO_ENABLED=0 go build -o "$BIN_PATH" -tags "$GO_TAGS" -ldflags "$ldflags" -trimpath -buildvcs=false ./cmd/terraform-mcp-server
 }
 
 # Run the CRT Builder


### PR DESCRIPTION
after switching to alpine images, the golang binary wouldn't run, this was due to missing dependencies.

Adding a flag to build process to ensure that a statically linked binary is built without needing extra dependencies during execution. (you can buld your dockers from `scratch` image)

tried the image locally on my linux machine and this image works fine

```
[  1:08PM ]  [ ec2-user@ip-172-31-29-203:~/workspace/DevWorkspace/terraform-mcp-server(mukeshjc-release-prep✗) ]
 $ docker run -i --rm hashicorppreview/terraform-mcp-server:0.1.0-858e5250176036944543109dd90f5c8ea408453d
HCP Terraform MCP Server running on stdio

{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"Parse error"}}

{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"Parse error"}}

{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"Parse error"}}

{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"Parse error"}}

```

#37 