### PR TITLE
[release] remove pre-promotion and promotion events

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -66,14 +66,6 @@ event "promote-staging" {
     on = "always"
   }
 
-  promotion-events {
-
-    pre-promotion {
-      organization = "hashicorp"
-      repository   = "terraform-mcp-server"
-      workflow     = "enos-run"
-    }
-  }
 }
 
 event "trigger-production" {
@@ -94,8 +86,4 @@ event "promote-production" {
     on = "always"
   }
 
-  promotion-events {
-    bump-version-patch = true
-    update-ironbank    = true
-  }
 }


### PR DESCRIPTION
- enos is a test tool that should be configured if we use it only
- we don't have an iron-bank repo and nor did we need auto-version-bump for release