### PR TITLE
add CRT fixes made for 0.1.0 release into `main` for future releases

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -66,14 +66,6 @@ event "promote-staging" {
     on = "always"
   }
 
-  promotion-events {
-
-    pre-promotion {
-      organization = "hashicorp"
-      repository   = "terraform-mcp-server"
-      workflow     = "enos-run"
-    }
-  }
 }
 
 event "trigger-production" {
@@ -94,8 +86,4 @@ event "promote-production" {
     on = "always"
   }
 
-  promotion-events {
-    bump-version-patch = true
-    update-ironbank    = true
-  }
 }

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -6,8 +6,9 @@ schema = "2"
 project "terraform-mcp-server" {
   team = "team-proj-mcp-servers"
 
+  # slack channel : feed-terraform-mcp-server-releases
   slack {
-    notification_channel = "C08QFU5CWG1"
+    notification_channel = "C08TEJWRXDX"
   }
 
   github {


### PR DESCRIPTION
These fixes were made as part of 0.1.0 release and have to be added back to `main` so future releases are smoother