### PR TITLE
update base image to scratch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,15 @@ on:
     branches:
       - main
       - release/**
+  pull_request:
+    branches:
+      - main
+      - release/**
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
 
 env:
   PKG_NAME: "terraform-mcp-server"


### PR DESCRIPTION
the CVEs mentioned are currently present in the latest version of alpine images and busybox releases.

updating the image to `scratch` to reduce the vulnerability surface area.

https://security.alpinelinux.org/branch/edge-main (look for busybox related CVEs)

---
main CVE's reported during CI execution

<img width="984" alt="image" src="https://github.com/user-attachments/assets/4bd1327c-23f3-4227-bf32-b3ec9e39063a" />
