### PR TITLE
support dev releases from feature branches to ensure builds pass even before merges to main/release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,12 @@ on:
     branches:
       - main
       - release/**
+      - feature/**
   pull_request:
     branches:
       - main
       - release/**
+      - feature/**
     types:
       - opened
       - synchronize


### PR DESCRIPTION
official resources are still only supported from `main` and `release/**` branches only.

https://github.com/hashicorp/terraform-mcp-server/blob/main/.release/ci.hcl#L17