### PR TITLE
fix: function name update, claude desktop usage link

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,10 @@ Optionally, you can add a similar example (i.e. without the mcp key) to a file c
 }
 ```
 
-More about using MCP server tools in Claude Desktop [user documentation](https://code.visualstudio.com/docs/copilot/chat/mcp-servers).
 
 ### Usage with Claude Desktop
+
+More about using MCP server tools in Claude Desktop [user documentation](https://modelcontextprotocol.io/quickstart/user).
 
 ```json
 {

--- a/pkg/hashicorp/tfregistry/utils.go
+++ b/pkg/hashicorp/tfregistry/utils.go
@@ -79,7 +79,7 @@ func GetProviderOverviewDocs(registryClient *http.Client, providerVersionID stri
 
 	resourceContent := ""
 	for _, providerOverviewPage := range providerOverview.Data {
-		resourceContentNew, err := GetProviderResouceDocs(registryClient, providerOverviewPage.ID, logger)
+		resourceContentNew, err := GetProviderResourceDocs(registryClient, providerOverviewPage.ID, logger)
 		resourceContent += resourceContentNew
 		if err != nil {
 			return "", logAndReturnError(logger, "getting provider resource docs looping", err)
@@ -89,7 +89,7 @@ func GetProviderOverviewDocs(registryClient *http.Client, providerVersionID stri
 	return resourceContent, nil
 }
 
-func GetProviderResouceDocs(registryClient *http.Client, providerDocsID string, logger *log.Logger) (string, error) {
+func GetProviderResourceDocs(registryClient *http.Client, providerDocsID string, logger *log.Logger) (string, error) {
 	// https://registry.terraform.io/v2/provider-docs/8862001
 	uri := fmt.Sprintf("provider-docs/%s", providerDocsID)
 	response, err := sendRegistryCall(registryClient, "GET", uri, logger, "v2")
@@ -477,10 +477,10 @@ func sendPaginatedRegistryCall[T any](client *http.Client, uriPrefix string, log
 }
 
 func logAndReturnError(logger *log.Logger, context string, err error) error {
-    err = fmt.Errorf("%s, %w", context, err)
-    if logger != nil {
-        logger.Errorf("Error in %s, %v", context, err)
-    }
+	err = fmt.Errorf("%s, %w", context, err)
+	if logger != nil {
+		logger.Errorf("Error in %s, %v", context, err)
+	}
 	return err
 }
 


### PR DESCRIPTION
# Description

- Updated `GetProviderResouceDocs` to `GetProviderResourceDocs` 
- Updated README to use Claude Desktop reference than VSCode.


### Successful build
```
make build
CGO_ENABLED=0 GOARCH=arm64 GOOS=darwin go build -ldflags="-s -w -X terraform-mcp-server/version.GitCommit=8b72466783f4405551eff1a95b0d269f2fe7323e -X terraform-mcp-server/version.BuildDate=2025-06-09T20:10:17Z" -o terraform-mcp-server ./cmd/terraform-mcp-server
go: downloading github.com/spf13/cobra v1.9.1
go: downloading github.com/sirupsen/logrus v1.9.3
go: downloading github.com/spf13/viper v1.20.1
go: downloading github.com/mark3labs/mcp-go v0.27.0
go: downloading golang.org/x/sys v0.33.0
go: downloading github.com/yosida95/uritemplate/v3 v3.0.2
go: downloading github.com/spf13/cast v1.8.0
go: downloading github.com/google/uuid v1.6.0
go: downloading github.com/go-viper/mapstructure/v2 v2.2.1
go: downloading github.com/fsnotify/fsnotify v1.9.0
go: downloading github.com/pelletier/go-toml/v2 v2.2.4
go: downloading github.com/spf13/afero v1.14.0
go: downloading github.com/spf13/pflag v1.0.6
go: downloading gopkg.in/yaml.v3 v3.0.1
go: downloading github.com/sagikazarmark/locafero v0.9.0
go: downloading github.com/subosito/gotenv v1.6.0
go: downloading golang.org/x/text v0.25.0
go: downloading github.com/sourcegraph/conc v0.3.0

```




