### PR TITLE
add ECR release support and update 'latest' tag of dev images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,6 +171,7 @@ jobs:
           arch: ${{ matrix.arch }}
           tags: |
             docker.io/hashicorp/${{ env.repo }}:${{ env.product_version }}
+            public.ecr.aws/hashicorp/${{ env.repo }}:${{ env.product_version }}
           # dev_tags are tags that get automatically pushed whenever successful
           # builds make it to the stable channel. The intention is for these tags
           # to be used for early testing of new code prior to official releases
@@ -191,5 +192,6 @@ jobs:
           # will fail to any other DockerHub org or registry. You can optionally
           # prepend docker.io
           dev_tags: |
+            docker.io/hashicorppreview/${{ env.repo }}:latest
             docker.io/hashicorppreview/${{ env.repo }}:${{ env.product_version }}-dev
             docker.io/hashicorppreview/${{ env.repo }}:${{ env.product_version }}-${{ github.sha }}

--- a/.release/oss-release-metadata.hcl
+++ b/.release/oss-release-metadata.hcl
@@ -2,5 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 url_docker_registry_dockerhub = "https://hub.docker.com/r/hashicorp/terraform-mcp-server"
+url_docker_registry_ecr       = "https://gallery.ecr.aws/hashicorp/terraform-mcp-server"
 url_source_repository         = "https://github/hashicorp/terraform-mcp-server"
 url_license                   = "https://github.com/hashicorp/terraform-mcp-server/blob/main/LICENSE"


### PR DESCRIPTION
ECR release support. 

Backporting this change to `release/0.1.0` is tricky, because that would be a new hash and we would have to re-upload all artifacts for 0.1.0 including to Dockerhub as well. Choosing not to do that for 0.1.0 and we start with 0.2.0 on ECR. It's not clean but folks should ideally be using just the `:latest` tag mostly when pulling the image.