### PR TITLE
Improve documentation on Dev docs for running on binary + details for TLS inspection on local network config

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -66,14 +66,6 @@ event "promote-staging" {
     on = "always"
   }
 
-  promotion-events {
-
-    pre-promotion {
-      organization = "hashicorp"
-      repository   = "terraform-mcp-server"
-      workflow     = "enos-run"
-    }
-  }
 }
 
 event "trigger-production" {
@@ -94,8 +86,4 @@ event "promote-production" {
     on = "always"
   }
 
-  promotion-events {
-    bump-version-patch = true
-    update-ironbank    = true
-  }
 }

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -6,8 +6,9 @@ schema = "2"
 project "terraform-mcp-server" {
   team = "team-proj-mcp-servers"
 
+  # slack channel : feed-terraform-mcp-server-releases
   slack {
-    notification_channel = "C08QFU5CWG1"
+    notification_channel = "C08TEJWRXDX"
   }
 
   github {


### PR DESCRIPTION
It appears that the instructions for running directly from the binary are in the [MCP Server GitHub ReadMe](https://github.com/hashicorp/terraform-mcp-server?tab=readme-ov-file#install-from-source), but please add this into HashiCorp's official [MCP Server dev docs](https://developer.hashicorp.com/terraform/docs/tools/mcp-server) so the information is all in one centralized, easy to locate place. 

The documentation for how to implement MCP server also needs to be improved for use cases where customers perform TLS inspection through their own networks, outbound proxies, or another network inspection system. The dev docs point out Docker as the only option (and include prerequisites to have Docker installed), but they should include details for this scenario since the docs are written in a way that implies this should work for anyone and non-container users are likely to try this and fail if their company uses TLS inspection.

