### PR TITLE
Fix run-http cmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,11 +53,11 @@ docker-build:
 
 # Run HTTP server locally
 run-http:
-	./$(BINARY_NAME) http --transport-port 8080 --transport-host 0.0.0.0
+	bin/$(BINARY_NAME) http --transport-port 8080 --transport-host 0.0.0.0
 
 # Run HTTP server with security settings
 run-http-secure:
-	MCP_ALLOWED_ORIGINS="http://localhost:3000,https://example.com" MCP_CORS_MODE="development" ./$(BINARY_NAME) http --transport-port 8080 --transport-host 0.0.0.0
+	MCP_ALLOWED_ORIGINS="http://localhost:3000,https://example.com" MCP_CORS_MODE="development" bin/$(BINARY_NAME) http --transport-port 8080 --transport-host 0.0.0.0
 
 # Run HTTP server in Docker
 docker-run-http:


### PR DESCRIPTION
make build builds the binary to bin/ path. Configuring run-http paths to pick the right binary path.
```
[12/08/25 2:59:01] *[main][~/work/mcp/terraform-mcp-server]$ make run-http 
bin/terraform-mcp-server http --transport-port 8080 --transport-host 0.0.0.0
Command "http" is deprecated, Use 'streamable-http' instead
INFO[0000] Using endpoint path: /mcp                    
INFO[0000] Running in stateful mode (default)           
INFO[0000] CORS Mode: strict                            
WARN[0000] No allowed origins configured in strict mode. All cross-origin requests will be rejected. 
INFO[0000] Starting StreamableHTTP server on 0.0.0.0:8080/mcp 
^CINFO[0001] Shutting down StreamableHTTP server... 
```

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
