### PR TITLE
Fixed Cursor mcp config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Add this to your Cursor config (`~/.cursor/mcp.json`) or via Settings → Cursor
 
 ```json
 {
-  "servers": {
+  "mcpServers": {
     "terraform": {
       "command": "docker",
       "args": [


### PR DESCRIPTION
The cursor msp.json differs from the vscode standard.  As you'll see in [the docs](https://cursor.com/docs/context/mcp#config-interpolation) the root element should be `mcpServers` not `servers`