### PR TITLE
fix: bugfix to remove fields in 2nd package definition that the upstream registry does not expect for `oci` packages

### DIFF
--- a/server.json
+++ b/server.json
@@ -381,9 +381,7 @@
     },
     {
       "registryType": "oci",
-      "registryBaseUrl": "https://docker.io",
       "identifier": "docker.io/hashicorp/terraform-mcp-server:0.3.2",
-      "version": "0.3.2",
       "transport": {
         "type": "streamable-http",
         "url": "http://127.0.0.1:8080/mcp"


### PR DESCRIPTION
Updates Package definition 1 (2nd package definition) to remove fields that the MCP Registry refuses for OCI Package Types.

Reason: Move `server.json` into spec

Revert: Revert the commit this PR introduces

Security Controls Changes: None. No changes to the underlying MCP Server this repository describes.

- [✅] I have documented a clear reason for, and description of, the change I am making.

- [✅] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [✅] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
