### PR TITLE
feat(search_modules): Add pagination limit and filter parameters to reduce API costs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS
 
+* Add `limit`, `provider`, `namespace`, and `verified` parameters to `search_modules` tool for pagination and filtering to reduce API costs [271](https://github.com/hashicorp/terraform-mcp-server/pull/271)
 * Set custom User-Agent header for TFE API requests to enable tracking MCP server usage separately from other go-tfe clients [268](https://github.com/hashicorp/terraform-mcp-server/pull/268)
 
 ## 0.4.0


### PR DESCRIPTION
## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [X] I have documented a clear reason for, and description of, the change I am making.

### Summary

This PR adds pagination and filtering parameters to the `search_modules` tool to reduce API costs and improve search efficiency.

### Problem

Each module search was returning all matching results, leading to expensive API calls due to large response payloads.

### Changes

Added the following parameters to `search_modules`:

| Parameter | Type | Default | Description |
|-----------|------|---------|-------------|
| `limit` | int | 10 (max: 100) | Maximum number of results to return |
| `provider` | string | - | Filter to a specific provider (e.g., `aws`, `google`, `azurerm`) |
| `namespace` | string | - | Filter to a specific namespace |
| `verified` | bool | false | If `true`, only return verified partner modules |

### Impact

- **Reduced API costs**: Default limit of 10 results significantly reduces response payload size
- **Targeted searches**: Filters enable more precise queries, further reducing unnecessary data transfer
- **Pagination support**: Combined with existing `current_offset`, enables efficient paging through large result sets

### API Reference

These parameters are supported by the [Terraform Registry API](https://developer.hashicorp.com/terraform/registry/api-docs#search-modules).