### PR TITLE
fix: use absolute URIs with terraform:// scheme for resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## UNRELEASED
 
+FIXES
+
+* Use absolute URIs with `terraform://` scheme for resource identifiers to comply with MCP specification [#274](https://github.com/hashicorp/terraform-mcp-server/pull/274)
+
 IMPROVEMENTS
 
 * Set custom User-Agent header for TFE API requests to enable tracking MCP server usage separately from other go-tfe clients [268](https://github.com/hashicorp/terraform-mcp-server/pull/268)

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"path"
 
 	"github.com/hashicorp/terraform-mcp-server/pkg/client"
 	"github.com/hashicorp/terraform-mcp-server/pkg/utils"
@@ -28,7 +27,7 @@ func RegisterResources(hcServer *server.MCPServer, logger *log.Logger) {
 
 // TerraformStyleGuideResource returns the resource and handler for the style guide
 func TerraformStyleGuideResource(logger *log.Logger) (mcp.Resource, server.ResourceHandlerFunc) {
-	resourceURI := "/terraform/style-guide"
+	resourceURI := "terraform://guides/style-guide"
 	description := "Terraform Style Guide"
 
 	return mcp.NewResource(
@@ -69,7 +68,7 @@ func TerraformStyleGuideResource(logger *log.Logger) (mcp.Resource, server.Resou
 
 // TerraformModuleDevGuideResource returns a resource and handler for the Terraform Module Development Guide markdown files
 func TerraformModuleDevGuideResource(logger *log.Logger) (mcp.Resource, server.ResourceHandlerFunc) {
-	resourceURI := "/terraform/module-development"
+	resourceURI := "terraform://guides/module-development"
 	description := "Terraform Module Development Guide"
 
 	var urls = []struct {
@@ -114,7 +113,7 @@ func TerraformModuleDevGuideResource(logger *log.Logger) (mcp.Resource, server.R
 				}
 				contents = append(contents, mcp.TextResourceContents{
 					MIMEType: "text/markdown",
-					URI:      path.Join(resourceURI, u.Name),
+					URI:      resourceURI + "/" + u.Name,
 					Text:     string(body),
 				})
 			}


### PR DESCRIPTION
Resource URIs were using relative paths like `/terraform/style-guide` which don't comply with the [MCP specification](https://modelcontextprotocol.io/specification/2025-11-25/server/resources), which requires resource URIs to be valid URIs per RFC 3986 (i.e., must include a scheme).

This changes the resource URIs to use the `terraform://` scheme:
- `/terraform/style-guide` → `terraform://guides/style-guide`
- `/terraform/module-development` → `terraform://guides/module-development`

Also fixed the sub-resource URI construction for `module-development` which was using `path.Join()` that would incorrectly handle the `://` in the URI scheme.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
