### PR TITLE
Add --disable-streaming cli flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ IMPROVEMENTS
 * Add `--heartbeat-interval` CLI flag and `MCP_HEARTBEAT_INTERVAL` env var for HTTP heartbeat in load-balanced environments
 * Set custom User-Agent header for TFE API requests to enable tracking MCP server usage separately from other go-tfe clients [268](https://github.com/hashicorp/terraform-mcp-server/pull/268)
 * Adding a new cli flags `--log-level` to set the desired log level for the server logs and `--log-format` for the logs formatting [286](https://github.com/hashicorp/terraform-mcp-server/pull/286)
-* Adding a new cli flags `disable-streaming` to disable Server-Sent Events (SSE) streaming and use direct HTTP response only [286](https://github.com/hashicorp/terraform-mcp-server/pull/286)
+* Adding a new cli flags `disable-streaming` to disable Server-Sent Events (SSE) streaming and use direct HTTP response only [294]](https://github.com/hashicorp/terraform-mcp-server/pull/294)
 
 FIXES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ IMPROVEMENTS
 * Add `--heartbeat-interval` CLI flag and `MCP_HEARTBEAT_INTERVAL` env var for HTTP heartbeat in load-balanced environments
 * Set custom User-Agent header for TFE API requests to enable tracking MCP server usage separately from other go-tfe clients [268](https://github.com/hashicorp/terraform-mcp-server/pull/268)
 * Adding a new cli flags `--log-level` to set the desired log level for the server logs and `--log-format` for the logs formatting [286](https://github.com/hashicorp/terraform-mcp-server/pull/286)
+* Adding a new cli flags `disable-streaming` to disable Server-Sent Events (SSE) streaming and use direct HTTP response only [286](https://github.com/hashicorp/terraform-mcp-server/pull/286)
 
 FIXES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ IMPROVEMENTS
 
 * Add `--heartbeat-interval` CLI flag and `MCP_HEARTBEAT_INTERVAL` env var for HTTP heartbeat in load-balanced environments
 * Set custom User-Agent header for TFE API requests to enable tracking MCP server usage separately from other go-tfe clients [268](https://github.com/hashicorp/terraform-mcp-server/pull/268)
-* Adding a new cli flags `--log-level` to set the desired log level for the server logs and `--log-format` for the logs formatting [286](https://github.com/hashicorp/terraform-mcp-server/pull/286)
-* Adding a new cli flags `disable-streaming` to disable Server-Sent Events (SSE) streaming and use direct HTTP response only [294]](https://github.com/hashicorp/terraform-mcp-server/pull/294)
+* Adding cli flags `--log-level` to set the desired log level for the server logs and `--log-format` for the logs formatting and corresponding env vars `LOG_LEVEL` and `LOG_FORMAT` [286](https://github.com/hashicorp/terraform-mcp-server/pull/286)
+* Adding cli flag `--disable-streaming` and env var `MCP_DISABLE_STREAMING` to disable Server-Sent Events (SSE) streaming and use direct HTTP response only [294]](https://github.com/hashicorp/terraform-mcp-server/pull/294)
 
 FIXES
 

--- a/README.md
+++ b/README.md
@@ -48,13 +48,14 @@ automation and interaction capabilities for Infrastructure as Code (IaC) develop
 | `MCP_RATE_LIMIT_GLOBAL` | Global rate limit (format: `rps:burst`) | `10:20` |
 | `MCP_RATE_LIMIT_SESSION` | Per-session rate limit (format: `rps:burst`) | `5:10` |
 | `ENABLE_TF_OPERATIONS` | Enable tools that require explicit approval | `false` |
+| `MCP_DISABLE_STREAMING` | Disables Server-Sent Events (SSE) streaming and uses direct HTTP request/response only | `false` |
 
 ```bash
 # Stdio mode
 terraform-mcp-server stdio [--log-file /path/to/log] [--log-level info] [--log-format text] [--toolsets <toolsets>] [--tools <tools>]
 
 # StreamableHTTP mode
-terraform-mcp-server streamable-http [--transport-port 8080] [--transport-host 127.0.0.1] [--mcp-endpoint /mcp] [--log-file /path/to/log] [--log-level info] [--log-format text] [--toolsets <toolsets>] [--tools <tools>]
+terraform-mcp-server streamable-http [--transport-port 8080] [--transport-host 127.0.0.1] [--mcp-endpoint /mcp] [--log-file /path/to/log] [--log-level info] [--log-format text] [--disable-streaming ] [--toolsets <toolsets>] [--tools <tools>]
 ```
 
 ## Instructions

--- a/cmd/terraform-mcp-server/config_test.go
+++ b/cmd/terraform-mcp-server/config_test.go
@@ -525,3 +525,65 @@ func TestGetLogFormatWithNilCommand(t *testing.T) {
 		t.Errorf("expected default text format with invalid env var and nil command, got %q", format)
 	}
 }
+
+func TestShouldDisableStreaming(t *testing.T) {
+	// Save original env var to restore later
+	origDisableStreaming := os.Getenv("MCP_DISABLE_STREAMING")
+	defer func() {
+		if origDisableStreaming != "" {
+			os.Setenv("MCP_DISABLE_STREAMING", origDisableStreaming)
+		} else {
+			os.Unsetenv("MCP_DISABLE_STREAMING")
+		}
+	}()
+
+	// Test case: When MCP_DISABLE_STREAMING is not set, streaming should be enabled (default)
+	os.Unsetenv("MCP_DISABLE_STREAMING")
+	assert.False(t, shouldDisableStreaming(nil), "Streaming should be enabled when MCP_DISABLE_STREAMING is not set")
+
+	// Test case: When MCP_DISABLE_STREAMING is set to "true", streaming should be disabled
+	os.Setenv("MCP_DISABLE_STREAMING", "true")
+	assert.True(t, shouldDisableStreaming(nil), "Streaming should be disabled when MCP_DISABLE_STREAMING is set to 'true'")
+
+	// Test case: When MCP_DISABLE_STREAMING is set to "1", streaming should be disabled
+	os.Setenv("MCP_DISABLE_STREAMING", "1")
+	assert.True(t, shouldDisableStreaming(nil), "Streaming should be disabled when MCP_DISABLE_STREAMING is set to '1'")
+
+	// Test case: Case insensitivity - uppercase TRUE
+	os.Setenv("MCP_DISABLE_STREAMING", "TRUE")
+	assert.True(t, shouldDisableStreaming(nil), "Streaming should be disabled when MCP_DISABLE_STREAMING is set to 'TRUE' (uppercase)")
+
+	// Test case: Case insensitivity - mixed case
+	os.Setenv("MCP_DISABLE_STREAMING", "TrUe")
+	assert.True(t, shouldDisableStreaming(nil), "Streaming should be disabled when MCP_DISABLE_STREAMING is set to 'TrUe' (mixed case)")
+
+	// Test case: Whitespace handling
+	os.Setenv("MCP_DISABLE_STREAMING", "  true  ")
+	assert.True(t, shouldDisableStreaming(nil), "Streaming should be disabled when MCP_DISABLE_STREAMING is set to '  true  ' (with whitespace)")
+
+	// Test case: When MCP_DISABLE_STREAMING is set to "false", streaming should be enabled
+	os.Setenv("MCP_DISABLE_STREAMING", "false")
+	assert.False(t, shouldDisableStreaming(nil), "Streaming should be enabled when MCP_DISABLE_STREAMING is set to 'false'")
+
+	// Test case: Invalid value should default to enabled
+	os.Setenv("MCP_DISABLE_STREAMING", "0")
+	assert.False(t, shouldDisableStreaming(nil), "Streaming should be enabled when MCP_DISABLE_STREAMING is set to '0'")
+
+	// Test case: Empty string should default to enabled
+	os.Setenv("MCP_DISABLE_STREAMING", "")
+	assert.False(t, shouldDisableStreaming(nil), "Streaming should be enabled when MCP_DISABLE_STREAMING is set to empty string")
+
+	// Test case: CLI flag takes effect when env var not set
+	os.Unsetenv("MCP_DISABLE_STREAMING")
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("disable-streaming", false, "test flag")
+	cmd.Flags().Set("disable-streaming", "true")
+	assert.True(t, shouldDisableStreaming(cmd), "Streaming should be disabled when --disable-streaming flag is set")
+
+	// Test case: Env var takes precedence over CLI flag
+	os.Setenv("MCP_DISABLE_STREAMING", "false")
+	cmd2 := &cobra.Command{}
+	cmd2.Flags().Bool("disable-streaming", false, "test flag")
+	cmd2.Flags().Set("disable-streaming", "true")
+	assert.False(t, shouldDisableStreaming(cmd2), "Env var should take precedence - false value means enabled")
+}

--- a/cmd/terraform-mcp-server/init.go
+++ b/cmd/terraform-mcp-server/init.go
@@ -95,7 +95,7 @@ var (
 
 			enabledToolsets := getToolsetsFromCmd(cmd.Root(), logger)
 
-			if err := runHTTPServer(logger, host, port, endpointPath, heartbeatInterval, enabledToolsets); err != nil {
+			if err := runHTTPServer(logger, host, port, endpointPath, heartbeatInterval, enabledToolsets, cmd); err != nil {
 				stdlog.Fatal("failed to run streamableHTTP server:", err)
 			}
 		},
@@ -128,12 +128,14 @@ func init() {
 	streamableHTTPCmd.Flags().StringP("transport-port", "p", "8080", "Port to listen on")
 	streamableHTTPCmd.Flags().Duration("heartbeat-interval", 0, "Heartbeat interval for HTTP connections (e.g., 30s). 0 to disable")
 	streamableHTTPCmd.Flags().String("mcp-endpoint", "/mcp", "Path for streamable HTTP endpoint")
+	streamableHTTPCmd.Flags().Bool("disable-streaming", false, "Disable SSE streaming and use direct HTTP responses only")
 
 	// Add the same flags to the alias command for backward compatibility
 	httpCmdAlias.Flags().String("transport-host", "127.0.0.1", "Host to bind to")
 	httpCmdAlias.Flags().StringP("transport-port", "p", "8080", "Port to listen on")
 	httpCmdAlias.Flags().String("mcp-endpoint", "/mcp", "Path for streamable HTTP endpoint")
 	httpCmdAlias.Flags().Duration("heartbeat-interval", 0, "Heartbeat interval for HTTP connections (e.g., 30s). 0 to disable")
+	httpCmdAlias.Flags().Bool("disable-streaming", false, "Disable SSE streaming and use direct HTTP responses only")
 
 	rootCmd.AddCommand(stdioCmd)
 	rootCmd.AddCommand(streamableHTTPCmd)
@@ -260,7 +262,7 @@ func serverInit(ctx context.Context, hcServer *server.MCPServer, logger *log.Log
 	return nil
 }
 
-func streamableHTTPServerInit(ctx context.Context, hcServer *server.MCPServer, logger *log.Logger, host string, port string, endpointPath string, heartbeatInterval time.Duration) error {
+func streamableHTTPServerInit(ctx context.Context, hcServer *server.MCPServer, logger *log.Logger, host string, port string, endpointPath string, heartbeatInterval time.Duration, cmd *cobra.Command) error {
 	// Ensure endpoint path starts with /
 	endpointPath = path.Join("/", endpointPath)
 	// Create StreamableHTTP server which implements the new streamable-http transport
@@ -291,6 +293,14 @@ func streamableHTTPServerInit(ctx context.Context, hcServer *server.MCPServer, l
 	if heartbeatInterval > 0 {
 		opts = append(opts, server.WithHeartbeatInterval(heartbeatInterval))
 		logger.Infof("HTTP heartbeat enabled with interval: %v", heartbeatInterval)
+	}
+	// Check if SSE streaming should be disabled
+	disableStreaming := shouldDisableStreaming(cmd)
+	if disableStreaming {
+		opts = append(opts, server.WithDisableStreaming(true))
+		logger.Info("SSE streaming is disabled - using direct HTTP responses only")
+	} else {
+		logger.Info("SSE streaming is enabled (default)")
 	}
 
 	baseStreamableServer := server.NewStreamableHTTPServer(hcServer, opts...)

--- a/cmd/terraform-mcp-server/main.go
+++ b/cmd/terraform-mcp-server/main.go
@@ -271,13 +271,15 @@ func getHeartbeatInterval() time.Duration {
 // Returns true if MCP_DISABLE_STREAMING environment variable is set to "true" or "1"
 // or if --disable-streaming CLI flag is set
 func shouldDisableStreaming(cmd *cobra.Command) bool {
-	// Check environment variable first (takes precedence)
-	value := strings.ToLower(strings.TrimSpace(os.Getenv("MCP_DISABLE_STREAMING")))
-	if value == "true" || value == "1" {
-		return true
+	// Check if environment variable is set (takes precedence)
+	envValue := os.Getenv("MCP_DISABLE_STREAMING")
+	if envValue != "" {
+		// Environment variable is set, use its value
+		value := strings.ToLower(strings.TrimSpace(envValue))
+		return value == "true" || value == "1"
 	}
 
-	// Check CLI flag if command is provided and flag is set
+	// Environment variable not set, check CLI flag
 	if cmd != nil && cmd.Flags().Changed("disable-streaming") {
 		disabled, _ := cmd.Flags().GetBool("disable-streaming")
 		return disabled

--- a/cmd/terraform-mcp-server/main.go
+++ b/cmd/terraform-mcp-server/main.go
@@ -26,14 +26,14 @@ import (
 //go:embed instructions.md
 var instructions string
 
-func runHTTPServer(logger *log.Logger, host string, port string, endpointPath string, heartbeatInterval time.Duration, enabledToolsets []string) error {
+func runHTTPServer(logger *log.Logger, host string, port string, endpointPath string, heartbeatInterval time.Duration, enabledToolsets []string, cmd *cobra.Command) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
 	hcServer := NewServer(version.Version, logger, enabledToolsets)
 	registerToolsAndResources(hcServer, logger, enabledToolsets)
 
-	return streamableHTTPServerInit(ctx, hcServer, logger, host, port, endpointPath, heartbeatInterval)
+	return streamableHTTPServerInit(ctx, hcServer, logger, host, port, endpointPath, heartbeatInterval, cmd)
 }
 
 func runStdioServer(logger *log.Logger, enabledToolsets []string) error {
@@ -188,7 +188,7 @@ func main() {
 		enabledToolsets := getToolsetsFromCmd(rootCmd, logger)
 
 		heartbeatInterval := getHeartbeatInterval()
-		if err := runHTTPServer(logger, host, port, endpointPath, heartbeatInterval, enabledToolsets); err != nil {
+		if err := runHTTPServer(logger, host, port, endpointPath, heartbeatInterval, enabledToolsets, nil); err != nil {
 			stdlog.Fatal("failed to run StreamableHTTP server:", err)
 		}
 		return
@@ -265,4 +265,23 @@ func getHeartbeatInterval() time.Duration {
 		}
 	}
 	return 0
+}
+
+// shouldDisableStreaming checks if SSE streaming should be disabled
+// Returns true if MCP_DISABLE_STREAMING environment variable is set to "true" or "1"
+// or if --disable-streaming CLI flag is set
+func shouldDisableStreaming(cmd *cobra.Command) bool {
+	// Check environment variable first (takes precedence)
+	value := strings.ToLower(strings.TrimSpace(os.Getenv("MCP_DISABLE_STREAMING")))
+	if value == "true" || value == "1" {
+		return true
+	}
+
+	// Check CLI flag if command is provided and flag is set
+	if cmd != nil && cmd.Flags().Changed("disable-streaming") {
+		disabled, _ := cmd.Flags().GetBool("disable-streaming")
+		return disabled
+	}
+
+	return false
 }


### PR DESCRIPTION
Adding a new flag and env variable to disable SSE streaming responses. Disabling will help return http responses.
Usage:
To disable streaming
`./terraform-mcp-server streamable-http --log-level debug --disable-streaming`
The default value is false.
Env var takes precedence over cli flag.

`The IBM Bob AI assistant was used for help with coding this PR`

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

