### PR TITLE
docs: Add Codex CLI configuration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,40 +323,19 @@ claude mcp add --transport http terraform http://localhost:8080/mcp
 
 ### Usage with Codex CLI
 
-[Codex CLI](https://github.com/openai/codex) is OpenAI's official coding agent that runs in your terminal. It supports MCP servers to extend its capabilities with external tools.
+[Codex CLI](https://github.com/openai/codex) is OpenAI's official coding agent that runs in your terminal. It supports MCP servers for extended capabilities.
 
 #### Prerequisites
 
-- [Node.js 18+](https://nodejs.org/) installed
-- [OpenAI API key](https://platform.openai.com/api-keys) configured (`OPENAI_API_KEY` environment variable)
-- Codex CLI installed: `npm install -g @openai/codex`
+- Node.js 18+ installed
+- [Codex CLI](https://github.com/openai/codex) installed: `npm install -g @openai/codex`
+- OpenAI API key configured
 
 #### Configuration
 
-Add the Terraform MCP server to Codex using the `codex mcp add` command:
+Codex CLI uses a JSON configuration file for MCP servers. Add the Terraform MCP server to your Codex config at `~/.codex/config.json`:
 
-- Local (`stdio`) Transport
-
-```sh
-codex mcp add terraform --type local --cmd docker -- run -i --rm hashicorp/terraform-mcp-server
-```
-
-- Remote (`streamable-http`) Transport
-
-```sh
-# Run server (example)
-docker run -p 8080:8080 --rm -e TRANSPORT_MODE=streamable-http -e TRANSPORT_HOST=0.0.0.0 hashicorp/terraform-mcp-server
-
-# Add to Codex
-codex mcp add terraform --type http --url http://localhost:8080/mcp
-```
-
-Alternatively, you can configure MCP servers in Codex's configuration file at `~/.codex/config.json`:
-
-<table>
-<tr><th>Version 0.3.0+ or greater</th><th>Version 0.2.3 or lower</th></tr>
-<tr valign=top>
-<td>
+**Stdio Transport (Recommended)**
 
 ```json
 {
@@ -376,29 +355,28 @@ Alternatively, you can configure MCP servers in Codex's configuration file at `~
 }
 ```
 
-</td>
-<td>
+**HTTP Transport**
 
-```json
-{
-  "mcpServers": {
-    "terraform": {
-      "command": "docker",
-      "args": [
-        "run",
-        "-i",
-        "--rm",
-        "hashicorp/terraform-mcp-server:0.2.3"
-      ]
-    }
-  }
-}
+```bash
+# Run the MCP server in HTTP mode
+docker run -p 8080:8080 --rm -e TRANSPORT_MODE=streamable-http -e TRANSPORT_HOST=0.0.0.0 hashicorp/terraform-mcp-server:0.4.0
+
+# Add to Codex CLI config
+openai config set mcpServers.terraform.url=http://localhost:8080/mcp
 ```
-</td>
-</tr>
-</table>
 
-More about using MCP server tools in Codex CLI [user documentation](https://github.com/openai/codex/blob/main/README.md).
+#### Usage Examples
+
+Once configured, you can use Terraform tools within Codex:
+
+```bash
+codex "Search for AWS providers in the Terraform Registry"
+codex "List my HCP Terraform workspaces"
+codex "Create a new Terraform workspace for the staging environment"
+```
+
+For more details on MCP configuration in Codex, refer to the [Codex CLI documentation](https://github.com/openai/codex/tree/main/codex-cli#mcp-agent-mode).
+
 
 ### Usage with Gemini extensions
 

--- a/README.md
+++ b/README.md
@@ -321,6 +321,85 @@ docker run -p 8080:8080 --rm -e TRANSPORT_MODE=streamable-http -e TRANSPORT_HOST
 claude mcp add --transport http terraform http://localhost:8080/mcp
 ```
 
+### Usage with Codex CLI
+
+[Codex CLI](https://github.com/openai/codex) is OpenAI's official coding agent that runs in your terminal. It supports MCP servers to extend its capabilities with external tools.
+
+#### Prerequisites
+
+- [Node.js 18+](https://nodejs.org/) installed
+- [OpenAI API key](https://platform.openai.com/api-keys) configured (`OPENAI_API_KEY` environment variable)
+- Codex CLI installed: `npm install -g @openai/codex`
+
+#### Configuration
+
+Add the Terraform MCP server to Codex using the `codex mcp add` command:
+
+- Local (`stdio`) Transport
+
+```sh
+codex mcp add terraform --type local --cmd docker -- run -i --rm hashicorp/terraform-mcp-server
+```
+
+- Remote (`streamable-http`) Transport
+
+```sh
+# Run server (example)
+docker run -p 8080:8080 --rm -e TRANSPORT_MODE=streamable-http -e TRANSPORT_HOST=0.0.0.0 hashicorp/terraform-mcp-server
+
+# Add to Codex
+codex mcp add terraform --type http --url http://localhost:8080/mcp
+```
+
+Alternatively, you can configure MCP servers in Codex's configuration file at `~/.codex/config.json`:
+
+<table>
+<tr><th>Version 0.3.0+ or greater</th><th>Version 0.2.3 or lower</th></tr>
+<tr valign=top>
+<td>
+
+```json
+{
+  "mcpServers": {
+    "terraform": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e", "TFE_ADDRESS=<<PASTE_TFE_ADDRESS_HERE>>",
+        "-e", "TFE_TOKEN=<<PASTE_TFE_TOKEN_HERE>>",
+        "hashicorp/terraform-mcp-server:0.4.0"
+      ]
+    }
+  }
+}
+```
+
+</td>
+<td>
+
+```json
+{
+  "mcpServers": {
+    "terraform": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "hashicorp/terraform-mcp-server:0.2.3"
+      ]
+    }
+  }
+}
+```
+</td>
+</tr>
+</table>
+
+More about using MCP server tools in Codex CLI [user documentation](https://github.com/openai/codex/blob/main/README.md).
+
 ### Usage with Gemini extensions
 
 For security, avoid hardcoding your credentials, create or update `~/.gemini/.env` (where ~ is your home or project directory) for storing HCP Terraform or Terraform Enterprise credentials


### PR DESCRIPTION
## Summary

This PR adds documentation for using the Terraform MCP Server with [Codex CLI](https://github.com/openai/codex), OpenAI's official coding agent.

## Changes

Added a new section "Usage with Codex CLI" to the README.md that includes:
- Brief introduction to Codex CLI
- Installation prerequisites (Node.js 18+, OpenAI API key)
- Configuration examples for both stdio and HTTP transport modes
- Example commands showing how to add the MCP server to Codex
- JSON configuration examples consistent with other client sections (VS Code, Cursor, Claude Desktop, etc.)

## Motivation

Codex CLI is gaining popularity as a terminal-based coding agent, and users need clear documentation on how to integrate the Terraform MCP Server with it. This documentation follows the same style and structure as existing sections for other MCP clients.

## Testing

- Verified the markdown renders correctly
- Commands are based on Codex CLI's documented MCP configuration options