### PR TITLE
fix: remove redundant grpc replace directive that breaks `go install`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,5 +62,3 @@ require (
 	golang.org/x/text v0.34.0
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace google.golang.org/grpc => google.golang.org/grpc v1.79.3


### PR DESCRIPTION
This removes the `replace google.golang.org/grpc => google.golang.org/grpc v1.79.3` directive from `go.mod` which was added in #313 when the `require` section listed v1.79.2, then #314 bumped `require` to v1.79.3 but left the now-redundant `replace` in place. The `replace` directive causes `go install ...@latest` to fail since Go tooling rejects modules with `replace` directives when installed externally.

Fixes https://github.com/hashicorp/terraform-mcp-server/issues/331