### PR TITLE
Add support for configuring TFE token via credentials.tfrc.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 IMPROVEMENTS
 
 * Add http server metrics instrumentation [330](https://github.com/hashicorp/terraform-mcp-server/pull/330)
+* Add support for configuring TFE token via credentials.tfrc.json [333](https://github.com/hashicorp/terraform-mcp-server/pull/333)
 
 # 0.5.1
 

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -6,7 +6,7 @@ type config interface {
 	configDir(*log.Logger) (string, error)
 }
 
-// NewConfig is a factory function that returns the implementation
+// newConfig is a factory function that returns the implementation
 // based on the OS. The compiler will choose which implementation
 // is available at build time.
 func newConfig() config {

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -1,0 +1,14 @@
+package client
+
+import log "github.com/sirupsen/logrus"
+
+type config interface {
+	configDir(*log.Logger) (string, error)
+}
+
+// NewConfig is a factory function that returns the implementation
+// based on the OS. The compiler will choose which implementation
+// is available at build time.
+func newConfig() config {
+	return &platformConfig{}
+}

--- a/pkg/client/config_unix.go
+++ b/pkg/client/config_unix.go
@@ -16,7 +16,7 @@ import (
 type platformConfig struct{}
 
 func (*platformConfig) configDir(logger *log.Logger) (string, error) {
-	logger.Info("OS type is UNIX")
+	logger.Debug("OS type is UNIX")
 	dir, err := os.UserHomeDir()
 	if err != nil {
 		return "", err

--- a/pkg/client/config_unix.go
+++ b/pkg/client/config_unix.go
@@ -1,0 +1,20 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build !windows
+// +build !windows
+
+package client
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func configDir() (string, error) {
+	dir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, ".terraform.d"), nil
+}

--- a/pkg/client/config_unix.go
+++ b/pkg/client/config_unix.go
@@ -9,9 +9,14 @@ package client
 import (
 	"os"
 	"path/filepath"
+
+	log "github.com/sirupsen/logrus"
 )
 
-func configDir() (string, error) {
+type platformConfig struct{}
+
+func (*platformConfig) configDir(logger *log.Logger) (string, error) {
+	logger.Info("OS type is UNIX")
 	dir, err := os.UserHomeDir()
 	if err != nil {
 		return "", err

--- a/pkg/client/config_windows.go
+++ b/pkg/client/config_windows.go
@@ -17,7 +17,7 @@ type platformConfig struct{}
 
 func (*platformConfig) configDir(logger *log.Logger) (string, error) {
 	// On Windows, Terraform uses %APPDATA%/terraform.d (no leading dot)
-	logger.Info("OS type is WINDOWS")
+	logger.Debug("OS type is WINDOWS")
 	appData := os.Getenv("APPDATA")
 	if appData == "" {
 		// Fallback to UserHomeDir if APPDATA not set

--- a/pkg/client/config_windows.go
+++ b/pkg/client/config_windows.go
@@ -1,0 +1,26 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build windows
+// +build windows
+
+package client
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func configDir() (string, error) {
+	// On Windows, Terraform uses %APPDATA%/terraform.d (no leading dot)
+	appData := os.Getenv("APPDATA")
+	if appData == "" {
+		// Fallback to UserHomeDir if APPDATA not set
+		dir, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(dir, "terraform.d"), nil
+	}
+	return filepath.Join(appData, "terraform.d"), nil
+}

--- a/pkg/client/config_windows.go
+++ b/pkg/client/config_windows.go
@@ -9,10 +9,15 @@ package client
 import (
 	"os"
 	"path/filepath"
+
+	log "github.com/sirupsen/logrus"
 )
 
-func configDir() (string, error) {
+type platformConfig struct{}
+
+func (*platformConfig) configDir(logger *log.Logger) (string, error) {
 	// On Windows, Terraform uses %APPDATA%/terraform.d (no leading dot)
+	logger.Info("OS type is WINDOWS")
 	appData := os.Getenv("APPDATA")
 	if appData == "" {
 		// Fallback to UserHomeDir if APPDATA not set

--- a/pkg/client/credentials.go
+++ b/pkg/client/credentials.go
@@ -1,0 +1,65 @@
+// Copyright IBM Corp. 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package client
+
+import (
+	"encoding/json"
+	"net/url"
+	"os"
+	"path/filepath"
+)
+
+// credentialsFile represents the structure of ~/.terraform.d/credentials.tfrc.json
+type credentialsFile struct {
+	Credentials map[string]credentialEntry `json:"credentials"`
+}
+
+type credentialEntry struct {
+	Token string `json:"token"`
+}
+
+// ReadCredentialsFile reads the Terraform CLI credentials file and returns
+// the token for the specified hostname. Returns empty string if not found.
+func ReadCredentialsFile(hostname string) string {
+	if hostname == "" {
+		return ""
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+
+	credPath := filepath.Join(homeDir, ".terraform.d", "credentials.tfrc.json")
+	data, err := os.ReadFile(credPath)
+	if err != nil {
+		return ""
+	}
+
+	var creds credentialsFile
+	if err := json.Unmarshal(data, &creds); err != nil {
+		return ""
+	}
+
+	if entry, ok := creds.Credentials[hostname]; ok {
+		return entry.Token
+	}
+
+	return ""
+}
+
+// extractHostname extracts the hostname from a Terraform address URL.
+// e.g., "https://app.terraform.io" -> "app.terraform.io"
+func extractHostname(address string) string {
+	if address == "" {
+		return ""
+	}
+
+	parsed, err := url.Parse(address)
+	if err != nil {
+		return ""
+	}
+
+	return parsed.Hostname()
+}

--- a/pkg/client/credentials.go
+++ b/pkg/client/credentials.go
@@ -5,6 +5,8 @@ package client
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -23,16 +25,16 @@ type credentialEntry struct {
 
 // ReadCredentialsFile reads the Terraform CLI credentials file and returns
 // the token for the specified hostname. Returns empty string if not found.
-func ReadCredentialsFile(hostname string, logger *log.Logger) string {
+func ReadCredentialsFile(hostname string, logger *log.Logger) (string, error) {
 	if hostname == "" {
-		return ""
+		return "", errors.New("ReadCredentialsFile: hostname is empty")
 	}
 
 	cfg := newConfig()
 	dir, err := cfg.configDir(logger)
 	if err != nil {
-		logger.Warnf("Failed to get config directory for credentials file lookup: %v", err)
-		return ""
+		logger.Errorf("Failed to get config directory for credentials file lookup: %v", err)
+		return "", err
 	}
 
 	credPath := filepath.Join(dir, "credentials.tfrc.json")
@@ -46,21 +48,21 @@ func ReadCredentialsFile(hostname string, logger *log.Logger) string {
 		} else {
 			logger.Warnf("Failed to read credentials file at %s: %v", credPath, err)
 		}
-		return ""
+		return "", err
 	}
 
 	var creds credentialsFile
 	if err := json.Unmarshal(data, &creds); err != nil {
 		logger.Warnf("Failed to parse credentials file at %s: %v", credPath, err)
-		return ""
+		return "", err
 	}
 
 	if entry, ok := creds.Credentials[hostname]; ok {
-		return entry.Token
+		return entry.Token, nil
 	}
 
 	logger.Debugf("No credentials found for hostname %q in credentials file", hostname)
-	return ""
+	return "", errors.New(fmt.Sprintf("No credentials found for hostname %q in credentials file", hostname))
 }
 
 // extractHostname extracts the hostname from a Terraform address URL.

--- a/pkg/client/credentials.go
+++ b/pkg/client/credentials.go
@@ -8,6 +8,8 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+
+	log "github.com/sirupsen/logrus"
 )
 
 // credentialsFile represents the structure of ~/.terraform.d/credentials.tfrc.json
@@ -21,24 +23,33 @@ type credentialEntry struct {
 
 // ReadCredentialsFile reads the Terraform CLI credentials file and returns
 // the token for the specified hostname. Returns empty string if not found.
-func ReadCredentialsFile(hostname string) string {
+func ReadCredentialsFile(hostname string, logger *log.Logger) string {
 	if hostname == "" {
 		return ""
 	}
 
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
+		logger.Warnf("Failed to get home directory for credentials file lookup: %v", err)
 		return ""
 	}
 
 	credPath := filepath.Join(homeDir, ".terraform.d", "credentials.tfrc.json")
 	data, err := os.ReadFile(credPath)
 	if err != nil {
+		if os.IsNotExist(err) {
+			logger.Debugf("No credentials file found at %s", credPath)
+		} else if os.IsPermission(err) {
+			logger.Warnf("Permission denied reading credentials file at %s", credPath)
+		} else {
+			logger.Warnf("Failed to read credentials file at %s: %v", credPath, err)
+		}
 		return ""
 	}
 
 	var creds credentialsFile
 	if err := json.Unmarshal(data, &creds); err != nil {
+		logger.Warnf("Failed to parse credentials file at %s: %v", credPath, err)
 		return ""
 	}
 
@@ -46,6 +57,7 @@ func ReadCredentialsFile(hostname string) string {
 		return entry.Token
 	}
 
+	logger.Debugf("No credentials found for hostname %q in credentials file", hostname)
 	return ""
 }
 

--- a/pkg/client/credentials.go
+++ b/pkg/client/credentials.go
@@ -28,7 +28,8 @@ func ReadCredentialsFile(hostname string, logger *log.Logger) string {
 		return ""
 	}
 
-	dir, err := configDir()
+	cfg := newConfig()
+	dir, err := cfg.configDir(logger)
 	if err != nil {
 		logger.Warnf("Failed to get config directory for credentials file lookup: %v", err)
 		return ""

--- a/pkg/client/credentials.go
+++ b/pkg/client/credentials.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2025
+// Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
 package client
@@ -12,7 +12,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// credentialsFile represents the structure of ~/.terraform.d/credentials.tfrc.json
+// credentialsFile represents the structure of credentials.tfrc.json
 type credentialsFile struct {
 	Credentials map[string]credentialEntry `json:"credentials"`
 }
@@ -28,13 +28,14 @@ func ReadCredentialsFile(hostname string, logger *log.Logger) string {
 		return ""
 	}
 
-	homeDir, err := os.UserHomeDir()
+	dir, err := configDir()
 	if err != nil {
-		logger.Warnf("Failed to get home directory for credentials file lookup: %v", err)
+		logger.Warnf("Failed to get config directory for credentials file lookup: %v", err)
 		return ""
 	}
 
-	credPath := filepath.Join(homeDir, ".terraform.d", "credentials.tfrc.json")
+	credPath := filepath.Join(dir, "credentials.tfrc.json")
+
 	data, err := os.ReadFile(credPath)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/pkg/client/credentials.go
+++ b/pkg/client/credentials.go
@@ -24,7 +24,7 @@ type credentialEntry struct {
 }
 
 // ReadCredentialsFile reads the Terraform CLI credentials file and returns
-// the token for the specified hostname. Returns empty string if not found.
+// the token for the specified hostname
 func ReadCredentialsFile(hostname string, logger *log.Logger) (string, error) {
 	if hostname == "" {
 		return "", errors.New("ReadCredentialsFile: hostname is empty")
@@ -62,7 +62,7 @@ func ReadCredentialsFile(hostname string, logger *log.Logger) (string, error) {
 	}
 
 	logger.Debugf("No credentials found for hostname %q in credentials file", hostname)
-	return "", errors.New(fmt.Sprintf("No credentials found for hostname %q in credentials file", hostname))
+	return "", fmt.Errorf("No credentials found for hostname %q in credentials file", hostname)
 }
 
 // extractHostname extracts the hostname from a Terraform address URL.

--- a/pkg/client/credentials_test.go
+++ b/pkg/client/credentials_test.go
@@ -1,0 +1,108 @@
+// Copyright IBM Corp. 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package client
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractHostname(t *testing.T) {
+	tests := []struct {
+		name     string
+		address  string
+		expected string
+	}{
+		{"standard https", "https://app.terraform.io", "app.terraform.io"},
+		{"with port", "https://tfe.example.com:8443", "tfe.example.com"},
+		{"with path", "https://app.terraform.io/api/v2", "app.terraform.io"},
+		{"http scheme", "http://localhost:8080", "localhost"},
+		{"empty string", "", ""},
+		{"invalid url", "not-a-url", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractHostname(tt.address)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestReadCredentialsFile(t *testing.T) {
+	t.Run("empty hostname", func(t *testing.T) {
+		result := ReadCredentialsFile("")
+		require.Empty(t, result)
+	})
+
+	t.Run("file not found", func(t *testing.T) {
+		result := ReadCredentialsFile("nonexistent.example.com")
+		require.Empty(t, result)
+	})
+
+	t.Run("valid credentials file", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp("", "terraform-test")
+		require.NoError(t, err)
+		defer os.RemoveAll(tmpDir)
+
+		terraformDir := filepath.Join(tmpDir, ".terraform.d")
+		err = os.MkdirAll(terraformDir, 0755)
+		require.NoError(t, err)
+
+		credContent := `{
+  "credentials": {
+    "app.terraform.io": {
+      "token": "test-token-123"
+    },
+    "tfe.example.com": {
+      "token": "enterprise-token-456"
+    }
+  }
+}`
+		credPath := filepath.Join(terraformDir, "credentials.tfrc.json")
+		err = os.WriteFile(credPath, []byte(credContent), 0600)
+		require.NoError(t, err)
+
+		// Override HOME for this test
+		originalHome := os.Getenv("HOME")
+		os.Setenv("HOME", tmpDir)
+		defer os.Setenv("HOME", originalHome)
+
+		// Test finding a token
+		token := ReadCredentialsFile("app.terraform.io")
+		require.Equal(t, "test-token-123", token)
+
+		// Test finding another token
+		token = ReadCredentialsFile("tfe.example.com")
+		require.Equal(t, "enterprise-token-456", token)
+
+		// Test hostname not in file
+		token = ReadCredentialsFile("other.terraform.io")
+		require.Empty(t, token)
+	})
+
+	t.Run("malformed json", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp("", "terraform-test")
+		require.NoError(t, err)
+		defer os.RemoveAll(tmpDir)
+
+		terraformDir := filepath.Join(tmpDir, ".terraform.d")
+		err = os.MkdirAll(terraformDir, 0755)
+		require.NoError(t, err)
+
+		credPath := filepath.Join(terraformDir, "credentials.tfrc.json")
+		err = os.WriteFile(credPath, []byte("not valid json"), 0600)
+		require.NoError(t, err)
+
+		originalHome := os.Getenv("HOME")
+		os.Setenv("HOME", tmpDir)
+		defer os.Setenv("HOME", originalHome)
+
+		token := ReadCredentialsFile("app.terraform.io")
+		require.Empty(t, token)
+	})
+}

--- a/pkg/client/credentials_test.go
+++ b/pkg/client/credentials_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,10 +18,6 @@ func TestExtractHostname(t *testing.T) {
 		address  string
 		expected string
 	}{
-		{"standard https", "https://app.terraform.io", "app.terraform.io"},
-		{"with port", "https://tfe.example.com:8443", "tfe.example.com"},
-		{"with path", "https://app.terraform.io/api/v2", "app.terraform.io"},
-		{"http scheme", "http://localhost:8080", "localhost"},
 		{"empty string", "", ""},
 		{"invalid url", "not-a-url", ""},
 	}
@@ -34,13 +31,16 @@ func TestExtractHostname(t *testing.T) {
 }
 
 func TestReadCredentialsFile(t *testing.T) {
+	logger := logrus.New()
+	logger.SetOutput(os.Stderr)
+
 	t.Run("empty hostname", func(t *testing.T) {
-		result := ReadCredentialsFile("")
+		result := ReadCredentialsFile("", logger)
 		require.Empty(t, result)
 	})
 
 	t.Run("file not found", func(t *testing.T) {
-		result := ReadCredentialsFile("nonexistent.example.com")
+		result := ReadCredentialsFile("nonexistent.example.com", logger)
 		require.Empty(t, result)
 	})
 
@@ -73,15 +73,15 @@ func TestReadCredentialsFile(t *testing.T) {
 		defer os.Setenv("HOME", originalHome)
 
 		// Test finding a token
-		token := ReadCredentialsFile("app.terraform.io")
+		token := ReadCredentialsFile("app.terraform.io", logger)
 		require.Equal(t, "test-token-123", token)
 
 		// Test finding another token
-		token = ReadCredentialsFile("tfe.example.com")
+		token = ReadCredentialsFile("tfe.example.com", logger)
 		require.Equal(t, "enterprise-token-456", token)
 
 		// Test hostname not in file
-		token = ReadCredentialsFile("other.terraform.io")
+		token = ReadCredentialsFile("other.terraform.io", logger)
 		require.Empty(t, token)
 	})
 
@@ -102,7 +102,7 @@ func TestReadCredentialsFile(t *testing.T) {
 		os.Setenv("HOME", tmpDir)
 		defer os.Setenv("HOME", originalHome)
 
-		token := ReadCredentialsFile("app.terraform.io")
+		token := ReadCredentialsFile("app.terraform.io", logger)
 		require.Empty(t, token)
 	})
 }

--- a/pkg/client/credentials_test.go
+++ b/pkg/client/credentials_test.go
@@ -4,6 +4,7 @@
 package client
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -35,13 +36,15 @@ func TestReadCredentialsFile(t *testing.T) {
 	logger.SetOutput(os.Stderr)
 
 	t.Run("empty hostname", func(t *testing.T) {
-		result := ReadCredentialsFile("", logger)
+		result, err := ReadCredentialsFile("", logger)
 		require.Empty(t, result)
+		require.Error(t, err)
 	})
 
 	t.Run("file not found", func(t *testing.T) {
-		result := ReadCredentialsFile("nonexistent.example.com", logger)
+		result, err := ReadCredentialsFile("nonexistent.example.com", logger)
 		require.Empty(t, result)
+		require.Error(t, err)
 	})
 
 	t.Run("valid credentials file", func(t *testing.T) {
@@ -73,16 +76,19 @@ func TestReadCredentialsFile(t *testing.T) {
 		defer os.Setenv("HOME", originalHome)
 
 		// Test finding a token
-		token := ReadCredentialsFile("app.terraform.io", logger)
+		token, err := ReadCredentialsFile("app.terraform.io", logger)
 		require.Equal(t, "test-token-123", token)
+		require.Empty(t, err)
 
 		// Test finding another token
-		token = ReadCredentialsFile("tfe.example.com", logger)
+		token, err = ReadCredentialsFile("tfe.example.com", logger)
 		require.Equal(t, "enterprise-token-456", token)
+		require.Empty(t, err)
 
 		// Test hostname not in file
-		token = ReadCredentialsFile("other.terraform.io", logger)
+		token, err = ReadCredentialsFile("other.terraform.io", logger)
 		require.Empty(t, token)
+		require.Error(t, errors.New("No credentials found for hostname \"other.terraform.io\" in credentials file"))
 	})
 
 	t.Run("malformed json", func(t *testing.T) {
@@ -102,7 +108,8 @@ func TestReadCredentialsFile(t *testing.T) {
 		os.Setenv("HOME", tmpDir)
 		defer os.Setenv("HOME", originalHome)
 
-		token := ReadCredentialsFile("app.terraform.io", logger)
+		token, err := ReadCredentialsFile("app.terraform.io", logger)
 		require.Empty(t, token)
+		require.Error(t, err)
 	})
 }

--- a/pkg/client/credentials_test.go
+++ b/pkg/client/credentials_test.go
@@ -4,7 +4,6 @@
 package client
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -71,9 +70,7 @@ func TestReadCredentialsFile(t *testing.T) {
 		require.NoError(t, err)
 
 		// Override HOME for this test
-		originalHome := os.Getenv("HOME")
-		os.Setenv("HOME", tmpDir)
-		defer os.Setenv("HOME", originalHome)
+		t.Setenv("HOME", tmpDir)
 
 		// Test finding a token
 		token, err := ReadCredentialsFile("app.terraform.io", logger)
@@ -83,12 +80,12 @@ func TestReadCredentialsFile(t *testing.T) {
 		// Test finding another token
 		token, err = ReadCredentialsFile("tfe.example.com", logger)
 		require.Equal(t, "enterprise-token-456", token)
-		require.Empty(t, err)
+		require.NoError(t, err)
 
 		// Test hostname not in file
 		token, err = ReadCredentialsFile("other.terraform.io", logger)
 		require.Empty(t, token)
-		require.Error(t, errors.New("No credentials found for hostname \"other.terraform.io\" in credentials file"))
+		require.EqualError(t, err, "No credentials found for hostname \"other.terraform.io\" in credentials file")
 	})
 
 	t.Run("malformed json", func(t *testing.T) {
@@ -104,9 +101,7 @@ func TestReadCredentialsFile(t *testing.T) {
 		err = os.WriteFile(credPath, []byte("not valid json"), 0600)
 		require.NoError(t, err)
 
-		originalHome := os.Getenv("HOME")
-		os.Setenv("HOME", tmpDir)
-		defer os.Setenv("HOME", originalHome)
+		t.Setenv("HOME", tmpDir)
 
 		token, err := ReadCredentialsFile("app.terraform.io", logger)
 		require.Empty(t, token)

--- a/pkg/client/tfe_client.go
+++ b/pkg/client/tfe_client.go
@@ -94,6 +94,9 @@ func CreateTfeClientForSession(ctx context.Context, session server.ClientSession
 	if !ok || terraformToken == "" {
 		terraformToken = utils.GetEnv(TerraformToken, "")
 	}
+	if terraformToken == "" {
+		terraformToken = ReadCredentialsFile(extractHostname(terraformAddress))
+	}
 
 	client, err := NewTfeClient(session.SessionID(), terraformAddress, parseTerraformSkipTLSVerify(ctx), terraformToken, logger)
 	return client, err

--- a/pkg/client/tfe_client.go
+++ b/pkg/client/tfe_client.go
@@ -100,6 +100,7 @@ func CreateTfeClientForSession(ctx context.Context, session server.ClientSession
 		if err != nil {
 			return nil, err
 		}
+		logger.Infof("Read TFE_TOKEN from credentials.tfrc.son")
 	}
 
 	client, err := NewTfeClient(session.SessionID(), terraformAddress, parseTerraformSkipTLSVerify(ctx), terraformToken, logger)

--- a/pkg/client/tfe_client.go
+++ b/pkg/client/tfe_client.go
@@ -97,7 +97,9 @@ func CreateTfeClientForSession(ctx context.Context, session server.ClientSession
 	}
 	if terraformToken == "" {
 		terraformToken, err = ReadCredentialsFile(extractHostname(terraformAddress), logger)
-		return nil, err
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	client, err := NewTfeClient(session.SessionID(), terraformAddress, parseTerraformSkipTLSVerify(ctx), terraformToken, logger)

--- a/pkg/client/tfe_client.go
+++ b/pkg/client/tfe_client.go
@@ -100,7 +100,7 @@ func CreateTfeClientForSession(ctx context.Context, session server.ClientSession
 		if err != nil {
 			return nil, err
 		}
-		logger.Infof("Read TFE_TOKEN from credentials.tfrc.son")
+		logger.Infof("Read TFE_TOKEN from credentials.tfrc.json")
 	}
 
 	client, err := NewTfeClient(session.SessionID(), terraformAddress, parseTerraformSkipTLSVerify(ctx), terraformToken, logger)

--- a/pkg/client/tfe_client.go
+++ b/pkg/client/tfe_client.go
@@ -85,6 +85,7 @@ func GetTfeClientFromContext(ctx context.Context, logger *log.Logger) (*tfe.Clie
 
 // CreateTfeClientForSession creates only a TFE client for the session
 func CreateTfeClientForSession(ctx context.Context, session server.ClientSession, logger *log.Logger) (*tfe.Client, error) {
+	var err error
 	terraformAddress, ok := ctx.Value(contextKey(TerraformAddress)).(string)
 	if !ok || terraformAddress == "" {
 		terraformAddress = utils.GetEnv(TerraformAddress, DefaultTerraformAddress)
@@ -95,7 +96,8 @@ func CreateTfeClientForSession(ctx context.Context, session server.ClientSession
 		terraformToken = utils.GetEnv(TerraformToken, "")
 	}
 	if terraformToken == "" {
-		terraformToken = ReadCredentialsFile(extractHostname(terraformAddress), logger)
+		terraformToken, err = ReadCredentialsFile(extractHostname(terraformAddress), logger)
+		return nil, err
 	}
 
 	client, err := NewTfeClient(session.SessionID(), terraformAddress, parseTerraformSkipTLSVerify(ctx), terraformToken, logger)

--- a/pkg/client/tfe_client.go
+++ b/pkg/client/tfe_client.go
@@ -95,7 +95,7 @@ func CreateTfeClientForSession(ctx context.Context, session server.ClientSession
 		terraformToken = utils.GetEnv(TerraformToken, "")
 	}
 	if terraformToken == "" {
-		terraformToken = ReadCredentialsFile(extractHostname(terraformAddress))
+		terraformToken = ReadCredentialsFile(extractHostname(terraformAddress), logger)
 	}
 
 	client, err := NewTfeClient(session.SessionID(), terraformAddress, parseTerraformSkipTLSVerify(ctx), terraformToken, logger)

--- a/pkg/client/tfe_client.go
+++ b/pkg/client/tfe_client.go
@@ -100,7 +100,7 @@ func CreateTfeClientForSession(ctx context.Context, session server.ClientSession
 		if err != nil {
 			return nil, err
 		}
-		logger.Infof("Read TFE_TOKEN from credentials.tfrc.json")
+		logger.Info("Read TFE_TOKEN from credentials.tfrc.json")
 	}
 
 	client, err := NewTfeClient(session.SessionID(), terraformAddress, parseTerraformSkipTLSVerify(ctx), terraformToken, logger)


### PR DESCRIPTION
Fixes #228

 - Adds support for reading TFE tokens from `~/.terraform.d/credentials.tfrc.json`                        
  - Users who have run `terraform login` can now use the MCP server without setting `TFE_TOKEN` environment
   variable                                                                                                
  - Maintains backward compatibility - env var still takes precedence when set                             
                                                                                                           
  **New credential resolution chain:**                                                                     
  HTTP Header → Environment Variable → credentials.tfrc.json → Error                                       
                                                                                                           
  ## Changes                                                                                               
                                                                                                           
  | File | Description |                                                                                   
  |------|-------------|                                                                                   
  | `pkg/client/credentials.go` | New file - reads and parses credentials.tfrc.json |                      
  | `pkg/client/credentials_test.go` | Unit tests for credential reading |                                 
  | `pkg/client/tfe_client.go` | Added fallback to credentials file (3 lines) |                    



## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
