### PR TITLE
add checksum verification for mcp-publisher binary

### DIFF
--- a/.github/workflows/publish-registry.yml
+++ b/.github/workflows/publish-registry.yml
@@ -43,9 +43,25 @@ jobs:
         run: make crt-build
 
       - name: Install MCP Publisher CLI
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          # Determine architecture
+          ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+          
+          # Download the latest release with checksums
+          gh release download --repo modelcontextprotocol/registry \
+            --pattern "*checksums.txt" \
+            --pattern "*linux_${ARCH}*"
+          
+          # Verify checksum before extracting
+          sha256sum --check *checksums.txt --ignore-missing
+          
+          # Extract and make executable
+          tar xzf mcp-publisher_linux_${ARCH}.tar.gz mcp-publisher
           chmod +x mcp-publisher
+          
+          rm -f *checksums.txt *.tar.gz
 
       - name: Authenticate with MCP Registry
         run: ./mcp-publisher login github-oidc

--- a/.github/workflows/publish-registry.yml
+++ b/.github/workflows/publish-registry.yml
@@ -61,7 +61,6 @@ jobs:
           tar xzf mcp-publisher_linux_${ARCH}.tar.gz mcp-publisher
           chmod +x mcp-publisher
           
-          rm -f *checksums.txt *.tar.gz
 
       - name: Authenticate with MCP Registry
         run: ./mcp-publisher login github-oidc


### PR DESCRIPTION
## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

This PR adds SHA256 checksum verification when downloading the `mcp-publisher` binary in the publish workflow.


- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
