### PR TITLE
Add module examples and submodules tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ IMPROVEMENTS
 FEATURES
 
 * [New Tool] `get_sentinel_mock` Export and download Sentinel mock bundle data for a Terraform plan
+* [New Tool] `get_module_examples` and `get_module_submodules` retrieve Terraform module examples and submodules separately from root module details [344](https://github.com/hashicorp/terraform-mcp-server/pull/344)
 
 IMPROVEMENTS
 

--- a/cmd/terraform-mcp-server/instructions.md
+++ b/cmd/terraform-mcp-server/instructions.md
@@ -20,6 +20,8 @@ The Terraform MCP server provides tools for generating better Terraform code thr
   - `get_provider_capabilities` shows what types of resources, data sources, functions, and guides are available
   
 - **Module Discovery**: `get_latest_module_version` (if unavailable in code) → `search_modules` → `get_module_details`
+  - `get_module_details` returns root module requirements plus lightweight example and submodule indexes
+  - Use `get_module_examples` or `get_module_submodules` with the selected name when you need a specific example or submodule
 
 - **Policy Discovery**: `search_policies` → `get_policy_details`
 
@@ -60,7 +62,8 @@ The Terraform MCP server provides tools for generating better Terraform code thr
 1. `search_modules`/`search_providers` for available resources
 2. `get_latest_provider_version` if no version available in existing code
 3. `get_module_details` for module requirements
-4. Generate code with discovered constraints
+4. `get_module_examples`/`get_module_submodules` when the selected module has a relevant example or submodule
+5. Generate code with discovered constraints
 
 **Run Management**:
 1. `search_workspaces` → select target

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -231,6 +231,47 @@ func runTestSuite(t *testing.T, client mcpClient.MCPClient, transportName string
 		})
 	}
 
+	for _, modulePartTests := range []struct {
+		toolName  string
+		testCases []RegistryTestCase
+	}{
+		{toolName: "get_module_examples", testCases: moduleExamplesTestCases},
+		{toolName: "get_module_submodules", testCases: moduleSubmodulesTestCases},
+	} {
+		for _, testCase := range modulePartTests.testCases {
+			t.Run(fmt.Sprintf("%s_%s/%s", transportName, modulePartTests.toolName, testCase.TestName), func(t *testing.T) {
+				ensureClientInitialized(t, client)
+				t.Logf("TOOL %s %s", modulePartTests.toolName, testCase.TestDescription)
+				t.Logf("Test payload: %v", testCase.TestPayload)
+
+				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				defer cancel()
+
+				request := mcp.CallToolRequest{}
+				request.Params.Name = modulePartTests.toolName
+				request.Params.Arguments = testCase.TestPayload
+
+				response, err := client.CallTool(ctx, request)
+				if testCase.TestShouldFail {
+					require.NoError(t, err)
+					require.True(t, response.IsError, "expected to call %q tool with error", modulePartTests.toolName)
+				} else {
+					require.NoError(t, err, "expected to call %q tool successfully", modulePartTests.toolName)
+					require.False(t, response.IsError, "expected result not to be an error")
+					require.Len(t, response.Content, 1, "expected content to have one item")
+
+					textContent, ok := response.Content[0].(mcp.TextContent)
+					require.True(t, ok, "expected content to be of type TextContent")
+					t.Logf("Content length: %d", len(textContent.Text))
+
+					for _, want := range testCase.ExpectsContent {
+						require.Contains(t, textContent.Text, want, "expected response to contain %q", want)
+					}
+				}
+			})
+		}
+	}
+
 	for _, testCase := range searchPoliciesTestCases {
 		t.Run("CallTool search_policies", func(t *testing.T) {
 			// t.Parallel()

--- a/e2e/payloads.go
+++ b/e2e/payloads.go
@@ -21,6 +21,8 @@ type RegistryTestCase struct {
 	TestDescription string                 `json:"testDescription"`
 	TestContentType ContentType            `json:"testContentType,omitempty"`
 	TestPayload     map[string]interface{} `json:"testPayload,omitempty"`
+	// ExpectsContent lists substrings that must appear in a successful response body.
+	ExpectsContent []string `json:"expectsContent,omitempty"`
 }
 
 var searchProviderTestCases = []RegistryTestCase{
@@ -367,6 +369,78 @@ var moduleDetailsTestCases = []RegistryTestCase{
 		TestDescription: "Testing get_module_details with invalid module_id format",
 		TestPayload: map[string]interface{}{
 			"module_id": "invalid-format",
+		},
+	},
+}
+
+var moduleExamplesTestCases = []RegistryTestCase{
+	{
+		TestName:        "list_examples",
+		TestShouldFail:  false,
+		TestDescription: "Testing get_module_examples with valid module_id",
+		TestPayload: map[string]interface{}{
+			"module_id": "terraform-google-modules/kubernetes-engine/google/44.0.0",
+		},
+	},
+	{
+		TestName:        "specific_example",
+		TestShouldFail:  false,
+		TestDescription: "Testing get_module_examples with valid example_name",
+		TestPayload: map[string]interface{}{
+			"module_id":    "terraform-google-modules/kubernetes-engine/google/44.0.0",
+			"example_name": "simple_zonal_private",
+		},
+		ExpectsContent: []string{"### README"},
+	},
+	{
+		TestName:        "missing_module_id",
+		TestShouldFail:  true,
+		TestDescription: "Testing get_module_examples missing module_id",
+		TestPayload:     map[string]interface{}{},
+	},
+	{
+		TestName:        "invalid_example_name",
+		TestShouldFail:  true,
+		TestDescription: "Testing get_module_examples with invalid example_name",
+		TestPayload: map[string]interface{}{
+			"module_id":    "terraform-google-modules/kubernetes-engine/google/44.0.0",
+			"example_name": "missing-example",
+		},
+	},
+}
+
+var moduleSubmodulesTestCases = []RegistryTestCase{
+	{
+		TestName:        "list_submodules",
+		TestShouldFail:  false,
+		TestDescription: "Testing get_module_submodules with valid module_id",
+		TestPayload: map[string]interface{}{
+			"module_id": "terraform-google-modules/kubernetes-engine/google/44.0.0",
+		},
+	},
+	{
+		TestName:        "specific_submodule",
+		TestShouldFail:  false,
+		TestDescription: "Testing get_module_submodules with valid submodule_name",
+		TestPayload: map[string]interface{}{
+			"module_id":      "terraform-google-modules/kubernetes-engine/google/44.0.0",
+			"submodule_name": "fleet-app-operator-permissions",
+		},
+		ExpectsContent: []string{"### README"},
+	},
+	{
+		TestName:        "missing_module_id",
+		TestShouldFail:  true,
+		TestDescription: "Testing get_module_submodules missing module_id",
+		TestPayload:     map[string]interface{}{},
+	},
+	{
+		TestName:        "invalid_submodule_name",
+		TestShouldFail:  true,
+		TestDescription: "Testing get_module_submodules with invalid submodule_name",
+		TestPayload: map[string]interface{}{
+			"module_id":      "terraform-google-modules/kubernetes-engine/google/44.0.0",
+			"submodule_name": "missing-submodule",
 		},
 	},
 }

--- a/pkg/tools/registry/get_module_details.go
+++ b/pkg/tools/registry/get_module_details.go
@@ -18,15 +18,54 @@ import (
 )
 
 const MODULE_BASE_PATH = "registry://modules"
+const modulePartNameFallback = "(unnamed)"
+
+type modulePartKind struct {
+	CollectionName  string
+	CollectionTitle string
+	SingularName    string
+	SingularTitle   string
+	ToolName        string
+	ToolTitle       string
+	ArgumentName    string
+	Description     string
+	Select          func(client.TerraformModuleVersionDetails) []client.ModulePart
+}
+
+var (
+	moduleExamplesKind = modulePartKind{
+		CollectionName:  "examples",
+		CollectionTitle: "Examples",
+		SingularName:    "example",
+		SingularTitle:   "Example",
+		ToolName:        "get_module_examples",
+		ToolTitle:       "Retrieve Terraform module examples",
+		ArgumentName:    "example_name",
+		Description:     `Fetches examples for a Terraform module independently from root module details. Omit example_name to list available examples, or provide example_name to fetch one specific example's README and metadata. You must call 'search_modules' first to obtain the exact valid and compatible module_id required to use this tool.`,
+		Select:          func(m client.TerraformModuleVersionDetails) []client.ModulePart { return m.Examples },
+	}
+	moduleSubmodulesKind = modulePartKind{
+		CollectionName:  "submodules",
+		CollectionTitle: "Submodules",
+		SingularName:    "submodule",
+		SingularTitle:   "Submodule",
+		ToolName:        "get_module_submodules",
+		ToolTitle:       "Retrieve Terraform module submodules",
+		ArgumentName:    "submodule_name",
+		Description:     `Fetches submodules for a Terraform module independently from root module details. Omit submodule_name to list available submodules, or provide submodule_name to fetch one specific submodule's README, inputs, outputs, resources, and dependencies. You must call 'search_modules' first to obtain the exact valid and compatible module_id required to use this tool.`,
+		Select:          func(m client.TerraformModuleVersionDetails) []client.ModulePart { return m.Submodules },
+	}
+)
 
 func ModuleDetails(logger *log.Logger) server.ServerTool {
 	return server.ServerTool{
 		Tool: mcp.NewTool("get_module_details",
-			mcp.WithDescription(`Fetches up-to-date documentation on how to use a Terraform module. You must call 'search_modules' first to obtain the exact valid and compatible module_id required to use this tool.`),
+			mcp.WithDescription(`Fetches up-to-date documentation on how to use a Terraform module. Returns root module inputs, outputs, provider dependencies, and lightweight indexes of available examples and submodules. Use get_module_examples or get_module_submodules to fetch selected example or submodule details. You must call 'search_modules' first to obtain the exact valid and compatible module_id required to use this tool.`),
 			mcp.WithTitleAnnotation("Retrieve documentation for a specific Terraform module"),
 			mcp.WithOpenWorldHintAnnotation(true),
 			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithDestructiveHintAnnotation(false),
+			mcp.WithIdempotentHintAnnotation(true),
 			mcp.WithString("module_id",
 				mcp.Required(),
 				mcp.Description("Exact valid and compatible module_id retrieved from search_modules (e.g., 'squareops/terraform-kubernetes-mongodb/mongodb/2.1.1', 'GoogleCloudPlatform/vertex-ai/google/0.2.0')"),
@@ -38,41 +77,112 @@ func ModuleDetails(logger *log.Logger) server.ServerTool {
 	}
 }
 
-func getModuleDetailsHandler(ctx context.Context, request mcp.CallToolRequest, logger *log.Logger) (*mcp.CallToolResult, error) {
-	moduleID, err := request.RequireString("module_id")
-	if err != nil {
-		return ToolError(logger, "missing required input: module_id", err)
+func ModuleExamples(logger *log.Logger) server.ServerTool {
+	return modulePartTool(logger, moduleExamplesKind)
+}
+
+func ModuleSubmodules(logger *log.Logger) server.ServerTool {
+	return modulePartTool(logger, moduleSubmodulesKind)
+}
+
+func modulePartTool(logger *log.Logger, kind modulePartKind) server.ServerTool {
+	return server.ServerTool{
+		Tool: mcp.NewTool(kind.ToolName,
+			mcp.WithDescription(kind.Description),
+			mcp.WithTitleAnnotation(kind.ToolTitle),
+			mcp.WithOpenWorldHintAnnotation(true),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithDestructiveHintAnnotation(false),
+			mcp.WithIdempotentHintAnnotation(true),
+			mcp.WithString("module_id",
+				mcp.Required(),
+				mcp.Description("Exact valid and compatible module_id retrieved from search_modules (e.g., 'terraform-aws-modules/vpc/aws/2.1.0')"),
+			),
+			mcp.WithString(kind.ArgumentName,
+				mcp.Description(fmt.Sprintf("Optional %s name from get_module_details. If omitted, returns the available %s names and paths.", kind.SingularName, kind.CollectionName)),
+			),
+		),
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return getModulePartHandler(ctx, request, logger, kind)
+		},
 	}
-	if moduleID == "" {
-		return ToolError(logger, "module_id cannot be empty", nil)
+}
+
+func getModuleDetailsHandler(ctx context.Context, request mcp.CallToolRequest, logger *log.Logger) (*mcp.CallToolResult, error) {
+	moduleID, errResult := parseAndValidateModuleID(request, logger)
+	if errResult != nil {
+		return errResult, nil
 	}
 
-	// Validate module ID format
-	if err := validateModuleID(moduleID); err != nil {
+	terraformModules, errResult := fetchAndParseModuleDetails(ctx, moduleID, logger)
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	return mcp.NewToolResultText(formatTerraformModule(terraformModules)), nil
+}
+
+func getModulePartHandler(ctx context.Context, request mcp.CallToolRequest, logger *log.Logger, kind modulePartKind) (*mcp.CallToolResult, error) {
+	moduleID, errResult := parseAndValidateModuleID(request, logger)
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	partName := strings.TrimSpace(request.GetString(kind.ArgumentName, ""))
+
+	terraformModules, errResult := fetchAndParseModuleDetails(ctx, moduleID, logger)
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	moduleData, err := formatTerraformModulePart(terraformModules, kind, partName)
+	if err != nil {
 		return ToolError(logger, err.Error(), nil)
 	}
 
-	moduleID = strings.ToLower(moduleID)
+	return mcp.NewToolResultText(moduleData), nil
+}
 
+func parseAndValidateModuleID(request mcp.CallToolRequest, logger *log.Logger) (string, *mcp.CallToolResult) {
+	moduleID, err := request.RequireString("module_id")
+	if err != nil {
+		result, _ := ToolError(logger, "missing required input: module_id", err)
+		return "", result
+	}
+	if moduleID == "" {
+		result, _ := ToolError(logger, "module_id cannot be empty", nil)
+		return "", result
+	}
+	if err := validateModuleID(moduleID); err != nil {
+		result, _ := ToolError(logger, err.Error(), nil)
+		return "", result
+	}
+	return strings.ToLower(moduleID), nil
+}
+
+// fetchAndParseModuleDetails splits its three failure modes (client init, registry fetch,
+// JSON parse) so each surfaces a distinct, actionable message rather than a generic
+// "module not found".
+func fetchAndParseModuleDetails(ctx context.Context, moduleID string, logger *log.Logger) (client.TerraformModuleVersionDetails, *mcp.CallToolResult) {
 	httpClient, err := client.GetHttpClientFromContext(ctx, logger)
 	if err != nil {
-		return ToolError(logger, "failed to get http client for public Terraform registry", err)
+		result, _ := ToolError(logger, "failed to get http client for public Terraform registry", err)
+		return client.TerraformModuleVersionDetails{}, result
 	}
 
 	response, err := getModuleDetails(httpClient, moduleID, 0, logger)
 	if err != nil {
-		return ToolErrorf(logger, "module not found: %s - use search_modules first to find valid module IDs", moduleID)
+		result, _ := ToolErrorf(logger, "module not found: %s - use search_modules first to find valid module IDs", moduleID)
+		return client.TerraformModuleVersionDetails{}, result
 	}
 
-	moduleData, err := unmarshalTerraformModule(response)
+	module, err := unmarshalTerraformModuleDetails(response)
 	if err != nil {
-		return ToolError(logger, "failed to parse module details", err)
-	}
-	if moduleData == "" {
-		return ToolErrorf(logger, "no module data returned for %s - try a different module_id", moduleID)
+		result, _ := ToolErrorf(logger, "failed to parse module details for %s: %v", moduleID, err)
+		return client.TerraformModuleVersionDetails{}, result
 	}
 
-	return mcp.NewToolResultText(moduleData), nil
+	return module, nil
 }
 
 func getModuleDetails(httpClient *http.Client, moduleID string, currentOffset int, logger *log.Logger) ([]byte, error) {
@@ -90,83 +200,221 @@ func getModuleDetails(httpClient *http.Client, moduleID string, currentOffset in
 	return response, nil
 }
 
-func unmarshalTerraformModule(response []byte) (string, error) {
+func unmarshalTerraformModuleDetails(response []byte) (client.TerraformModuleVersionDetails, error) {
 	var terraformModules client.TerraformModuleVersionDetails
 	err := json.Unmarshal(response, &terraformModules)
 	if err != nil {
-		return "", fmt.Errorf("unmarshalling module details: %w", err)
+		return client.TerraformModuleVersionDetails{}, fmt.Errorf("unmarshalling module details: %w", err)
+	}
+	return terraformModules, nil
+}
+
+func formatTerraformModule(terraformModules client.TerraformModuleVersionDetails) string {
+	var builder strings.Builder
+	writeModuleHeader(&builder, terraformModules)
+	writeModulePartSchema(&builder, terraformModules.Root, false)
+	writeModulePartIndex(&builder, terraformModules, moduleExamplesKind, terraformModules.Examples)
+	writeModulePartIndex(&builder, terraformModules, moduleSubmodulesKind, terraformModules.Submodules)
+	return builder.String()
+}
+
+func formatTerraformModulePart(terraformModules client.TerraformModuleVersionDetails, kind modulePartKind, partName string) (string, error) {
+	parts := kind.Select(terraformModules)
+	var part client.ModulePart
+	if partName != "" {
+		var found bool
+		part, found = findModulePart(parts, partName)
+		if !found {
+			return "", fmt.Errorf("%s %q not found for module %s. Available %s: %s",
+				kind.SingularName,
+				partName,
+				moduleVersionID(terraformModules),
+				kind.CollectionName,
+				modulePartNames(parts),
+			)
+		}
 	}
 
 	var builder strings.Builder
-	builder.WriteString(fmt.Sprintf("# %s/%s/%s\n\n", MODULE_BASE_PATH, terraformModules.Namespace, terraformModules.Name))
-	builder.WriteString(fmt.Sprintf("**Description:** %s\n\n", terraformModules.Description))
-	builder.WriteString(fmt.Sprintf("**Module Version:** %s\n\n", terraformModules.Version))
-	builder.WriteString(fmt.Sprintf("**Namespace:** %s\n\n", terraformModules.Namespace))
-	builder.WriteString(fmt.Sprintf("**Source:** %s\n\n", terraformModules.Source))
+	writeModuleHeader(&builder, terraformModules)
 
-	// Format Inputs
-	if len(terraformModules.Root.Inputs) > 0 {
+	if partName == "" {
+		writeModulePartIndex(&builder, terraformModules, kind, parts)
+		return builder.String(), nil
+	}
+
+	fmt.Fprintf(&builder, "### %s: %s\n\n", kind.SingularTitle, modulePartDisplayName(part))
+	if part.Path != "" {
+		fmt.Fprintf(&builder, "**Path:** %s\n\n", part.Path)
+	}
+	if part.Readme != "" {
+		builder.WriteString("### README\n\n")
+		builder.WriteString(part.Readme)
+		builder.WriteString("\n\n")
+	}
+	writeModulePartSchema(&builder, part, true)
+	return builder.String(), nil
+}
+
+func writeModuleHeader(builder *strings.Builder, terraformModules client.TerraformModuleVersionDetails) {
+	fmt.Fprintf(builder, "# %s/%s/%s\n\n", MODULE_BASE_PATH, terraformModules.Namespace, terraformModules.Name)
+	fmt.Fprintf(builder, "**Description:** %s\n\n", terraformModules.Description)
+	fmt.Fprintf(builder, "**Module Version:** %s\n\n", terraformModules.Version)
+	fmt.Fprintf(builder, "**Namespace:** %s\n\n", terraformModules.Namespace)
+	fmt.Fprintf(builder, "**Source:** %s\n\n", terraformModules.Source)
+}
+
+func moduleVersionID(terraformModules client.TerraformModuleVersionDetails) string {
+	return fmt.Sprintf("%s/%s/%s/%s", terraformModules.Namespace, terraformModules.Name, terraformModules.Provider, terraformModules.Version)
+}
+
+func writeModulePartSchema(builder *strings.Builder, part client.ModulePart, includeImplementationDetails bool) {
+	if len(part.Inputs) > 0 {
 		builder.WriteString("### Inputs\n\n")
 		builder.WriteString("| Name | Type | Description | Default | Required |\n")
 		builder.WriteString("|---|---|---|---|---|\n")
-		for _, input := range terraformModules.Root.Inputs {
-			builder.WriteString(fmt.Sprintf("| %s | %s | %s | `%v` | %t |\n",
-				input.Name,
-				input.Type,
-				input.Description,
+		for _, input := range part.Inputs {
+			fmt.Fprintf(builder, "| %s | %s | %s | `%v` | %t |\n",
+				escapeMarkdownTableCell(input.Name),
+				escapeMarkdownTableCell(input.Type),
+				escapeMarkdownTableCell(input.Description),
 				input.Default,
 				input.Required,
-			))
+			)
 		}
 		builder.WriteString("\n")
 	}
 
-	// Format Outputs
-	if len(terraformModules.Root.Outputs) > 0 {
+	if len(part.Outputs) > 0 {
 		builder.WriteString("### Outputs\n\n")
 		builder.WriteString("| Name | Description |\n")
 		builder.WriteString("|---|---|\n")
-		for _, output := range terraformModules.Root.Outputs {
-			builder.WriteString(fmt.Sprintf("| %s | %s |\n",
-				output.Name,
-				output.Description,
-			))
+		for _, output := range part.Outputs {
+			fmt.Fprintf(builder, "| %s | %s |\n",
+				escapeMarkdownTableCell(output.Name),
+				escapeMarkdownTableCell(output.Description),
+			)
 		}
 		builder.WriteString("\n")
 	}
 
-	// Format Provider Dependencies
-	if len(terraformModules.Root.ProviderDependencies) > 0 {
+	if includeImplementationDetails && len(part.Dependencies) > 0 {
+		builder.WriteString("### Module Dependencies\n\n")
+		builder.WriteString("| Name | Source | Version |\n")
+		builder.WriteString("|---|---|---|\n")
+		for _, dep := range part.Dependencies {
+			fmt.Fprintf(builder, "| %s | %s | %s |\n",
+				escapeMarkdownTableCell(dep.Name),
+				escapeMarkdownTableCell(dep.Source),
+				escapeMarkdownTableCell(dep.Version),
+			)
+		}
+		builder.WriteString("\n")
+	}
+
+	if len(part.ProviderDependencies) > 0 {
 		builder.WriteString("### Provider Dependencies\n\n")
 		builder.WriteString("| Name | Namespace | Source | Version |\n")
 		builder.WriteString("|---|---|---|---|\n")
-		for _, dep := range terraformModules.Root.ProviderDependencies {
-			builder.WriteString(fmt.Sprintf("| %s | %s | %s | %s |\n",
-				dep.Name,
-				dep.Namespace,
-				dep.Source,
-				dep.Version,
-			))
+		for _, dep := range part.ProviderDependencies {
+			fmt.Fprintf(builder, "| %s | %s | %s | %s |\n",
+				escapeMarkdownTableCell(dep.Name),
+				escapeMarkdownTableCell(dep.Namespace),
+				escapeMarkdownTableCell(dep.Source),
+				escapeMarkdownTableCell(dep.Version),
+			)
 		}
 		builder.WriteString("\n")
 	}
 
-	// Format Examples
-	if len(terraformModules.Examples) > 0 {
-		builder.WriteString("### Examples\n\n")
-		for _, example := range terraformModules.Examples {
-			builder.WriteString(fmt.Sprintf("#### %s\n\n", example.Name))
-			if example.Readme != "" {
-				builder.WriteString("**Readme:**\n\n")
-				builder.WriteString(example.Readme)
-				builder.WriteString("\n\n")
-			}
+	if includeImplementationDetails && len(part.Resources) > 0 {
+		builder.WriteString("### Resources\n\n")
+		builder.WriteString("| Name | Type |\n")
+		builder.WriteString("|---|---|\n")
+		for _, resource := range part.Resources {
+			fmt.Fprintf(builder, "| %s | %s |\n",
+				escapeMarkdownTableCell(resource.Name),
+				escapeMarkdownTableCell(resource.Type),
+			)
 		}
 		builder.WriteString("\n")
 	}
+}
 
-	content := builder.String()
-	return content, nil
+// escapeMarkdownTableCell prevents registry-supplied text from breaking pipe-delimited
+// table rows. Pipes are escaped; CR/LF are collapsed to spaces.
+var markdownTableCellReplacer = strings.NewReplacer("|", `\|`, "\r\n", " ", "\n", " ", "\r", " ")
+
+func escapeMarkdownTableCell(s string) string {
+	return markdownTableCellReplacer.Replace(s)
+}
+
+func writeModulePartIndex(builder *strings.Builder, terraformModules client.TerraformModuleVersionDetails, kind modulePartKind, parts []client.ModulePart) {
+	fmt.Fprintf(builder, "### Available %s\n\n", kind.CollectionTitle)
+	if len(parts) == 0 {
+		fmt.Fprintf(builder, "No %s found for this module.\n\n", kind.CollectionName)
+		return
+	}
+
+	builder.WriteString("| Name | Path |\n")
+	builder.WriteString("|---|---|\n")
+	for _, part := range parts {
+		fmt.Fprintf(builder, "| %s | %s |\n",
+			escapeMarkdownTableCell(modulePartDisplayName(part)),
+			escapeMarkdownTableCell(modulePartDisplayPath(part)),
+		)
+	}
+	builder.WriteString("\n")
+	fmt.Fprintf(builder, "To fetch one %s, call `%s` with `module_id` set to `%s` and `%s` set to one of the names above.\n\n",
+		kind.SingularName,
+		kind.ToolName,
+		moduleVersionID(terraformModules),
+		kind.ArgumentName,
+	)
+}
+
+func findModulePart(parts []client.ModulePart, name string) (client.ModulePart, bool) {
+	// Path is matched case-sensitively because registry paths mirror filesystem paths.
+	for _, part := range parts {
+		if strings.EqualFold(part.Name, name) || part.Path == name {
+			return part, true
+		}
+		if part.Name == "" && strings.EqualFold(modulePartDisplayName(part), name) {
+			return part, true
+		}
+	}
+	return client.ModulePart{}, false
+}
+
+func modulePartDisplayName(part client.ModulePart) string {
+	if part.Name != "" {
+		return part.Name
+	}
+	path := strings.Trim(part.Path, "/")
+	if path == "" {
+		return modulePartNameFallback
+	}
+	segments := strings.Split(path, "/")
+	return segments[len(segments)-1]
+}
+
+func modulePartDisplayPath(part client.ModulePart) string {
+	if part.Path == "" {
+		return "-"
+	}
+	return part.Path
+}
+
+func modulePartNames(parts []client.ModulePart) string {
+	if len(parts) == 0 {
+		return "none"
+	}
+
+	names := make([]string, 0, len(parts))
+	for _, part := range parts {
+		names = append(names, modulePartDisplayName(part))
+	}
+	return strings.Join(names, ", ")
 }
 
 func validateModuleID(moduleID string) error {

--- a/pkg/tools/registry/get_module_details_test.go
+++ b/pkg/tools/registry/get_module_details_test.go
@@ -6,7 +6,17 @@ package tools
 import (
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/terraform-mcp-server/pkg/client"
 )
+
+func unmarshalAndFormatModule(response []byte) (string, error) {
+	module, err := unmarshalTerraformModuleDetails(response)
+	if err != nil {
+		return "", err
+	}
+	return formatTerraformModule(module), nil
+}
 
 // --- UnmarshalModuleSingular ---
 func TestUnmarshalModuleSingular_ValidAllFields(t *testing.T) {
@@ -49,7 +59,7 @@ func TestUnmarshalModuleSingular_ValidAllFields(t *testing.T) {
 		"versions": ["1.0.0"],
 		"deprecation": null
 	}`)
-	out, err := unmarshalTerraformModule(resp)
+	out, err := unmarshalAndFormatModule(resp)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -61,6 +71,55 @@ func TestUnmarshalModuleSingular_ValidAllFields(t *testing.T) {
 	}
 	if !strings.Contains(out, "example1") {
 		t.Errorf("expected output to contain example name, got %q", out)
+	}
+	if strings.Contains(out, "example readme") {
+		t.Errorf("expected output to omit example README details, got %q", out)
+	}
+}
+
+func TestUnmarshalModuleSingular_ListsSubmodules(t *testing.T) {
+	resp := []byte(`{
+		"id": "namespace/name/provider/1.0.0",
+		"owner": "owner",
+		"namespace": "namespace",
+		"name": "name",
+		"version": "1.0.0",
+		"provider": "provider",
+		"provider_logo_url": "",
+		"description": "A test module",
+		"source": "source",
+		"tag": "",
+		"published_at": "2023-01-01T00:00:00Z",
+		"downloads": 1,
+		"verified": true,
+		"root": {
+			"path": "",
+			"name": "root",
+			"readme": "",
+			"empty": false,
+			"inputs": [],
+			"outputs": [],
+			"dependencies": [],
+			"provider_dependencies": [],
+			"resources": []
+		},
+		"submodules": [
+			{"path": "modules/private", "name": "private", "readme": "private readme", "empty": false, "inputs": [], "outputs": [], "dependencies": [], "provider_dependencies": [], "resources": []}
+		],
+		"examples": [],
+		"providers": ["provider"],
+		"versions": ["1.0.0"],
+		"deprecation": null
+	}`)
+	out, err := unmarshalAndFormatModule(resp)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !strings.Contains(out, "private") {
+		t.Errorf("expected output to contain submodule name, got %q", out)
+	}
+	if strings.Contains(out, "private readme") {
+		t.Errorf("expected output to omit submodule README details, got %q", out)
 	}
 }
 
@@ -96,7 +155,7 @@ func TestUnmarshalModuleSingular_EmptySections(t *testing.T) {
 		"versions": ["1.0.0"],
 		"deprecation": null
 	}`)
-	out, err := unmarshalTerraformModule(resp)
+	out, err := unmarshalAndFormatModule(resp)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -107,9 +166,132 @@ func TestUnmarshalModuleSingular_EmptySections(t *testing.T) {
 
 func TestUnmarshalModuleSingular_InvalidJSON(t *testing.T) {
 	resp := []byte(`not a json`)
-	_, err := unmarshalTerraformModule(resp)
+	_, err := unmarshalAndFormatModule(resp)
 	if err == nil || !strings.Contains(err.Error(), "unmarshalling module details") {
 		t.Errorf("expected unmarshalling error, got %v", err)
+	}
+}
+
+func TestFormatTerraformModulePart_ListExamples(t *testing.T) {
+	module := testTerraformModuleDetails()
+
+	out, err := formatTerraformModulePart(module, moduleExamplesKind, "")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !strings.Contains(out, "example1") {
+		t.Errorf("expected output to contain example name, got %q", out)
+	}
+	if strings.Contains(out, "example readme") {
+		t.Errorf("expected output to omit example README details from list view, got %q", out)
+	}
+	if !strings.Contains(out, "get_module_examples") {
+		t.Errorf("expected output to explain how to fetch one example, got %q", out)
+	}
+}
+
+func TestFormatTerraformModulePart_SelectedExample(t *testing.T) {
+	module := testTerraformModuleDetails()
+
+	out, err := formatTerraformModulePart(module, moduleExamplesKind, "example1")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !strings.Contains(out, "example readme") {
+		t.Errorf("expected output to contain selected example README, got %q", out)
+	}
+	if !strings.Contains(out, "example_input") {
+		t.Errorf("expected output to contain selected example inputs, got %q", out)
+	}
+}
+
+func TestFormatTerraformModulePart_SelectedSubmodule(t *testing.T) {
+	module := testTerraformModuleDetails()
+
+	out, err := formatTerraformModulePart(module, moduleSubmodulesKind, "private")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !strings.Contains(out, "private readme") {
+		t.Errorf("expected output to contain selected submodule README, got %q", out)
+	}
+	if !strings.Contains(out, "submodule_input") {
+		t.Errorf("expected output to contain selected submodule inputs, got %q", out)
+	}
+}
+
+func TestFormatTerraformModulePart_PathMatchIsCaseSensitive(t *testing.T) {
+	module := client.TerraformModuleVersionDetails{
+		Namespace: "namespace",
+		Name:      "name",
+		Version:   "1.0.0",
+		Provider:  "provider",
+		Examples: []client.ModulePart{
+			{Path: "examples/Private", Name: "private-upper"},
+			{Path: "examples/private", Name: "private-lower"},
+		},
+	}
+
+	out, err := formatTerraformModulePart(module, moduleExamplesKind, "examples/private")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !strings.Contains(out, "private-lower") {
+		t.Errorf("expected case-sensitive path match to select 'private-lower', got %q", out)
+	}
+	if strings.Contains(out, "private-upper") {
+		t.Errorf("expected case-sensitive path match to NOT select 'private-upper', got %q", out)
+	}
+}
+
+func TestFormatTerraformModulePart_SelectedPartNotFound(t *testing.T) {
+	module := testTerraformModuleDetails()
+
+	_, err := formatTerraformModulePart(module, moduleExamplesKind, "missing")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "Available examples: example1") {
+		t.Errorf("expected error to list available examples, got %q", err.Error())
+	}
+}
+
+func TestFormatTerraformModulePart_ListEmpty(t *testing.T) {
+	module := client.TerraformModuleVersionDetails{
+		Namespace: "namespace",
+		Name:      "name",
+		Version:   "1.0.0",
+		Provider:  "provider",
+		Examples:  nil,
+	}
+
+	out, err := formatTerraformModulePart(module, moduleExamplesKind, "")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !strings.Contains(out, "No examples found for this module.") {
+		t.Errorf("expected empty-list message, got %q", out)
+	}
+	if strings.Contains(out, "To fetch one example") {
+		t.Errorf("expected empty-list output to omit fetch instructions, got %q", out)
+	}
+}
+
+func TestEscapeMarkdownTableCell(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"plain text", "plain text"},
+		{"a|b", `a\|b`},
+		{"line1\nline2", "line1 line2"},
+		{"line1\r\nline2", "line1 line2"},
+		{"a|b\nc", `a\|b c`},
+	}
+	for _, c := range cases {
+		if got := escapeMarkdownTableCell(c.in); got != c.want {
+			t.Errorf("escapeMarkdownTableCell(%q) = %q, want %q", c.in, got, c.want)
+		}
 	}
 }
 
@@ -120,7 +302,7 @@ func TestValidateModuleID_ValidFormat(t *testing.T) {
 		"terraform-aws-modules/vpc/aws/3.14.0",
 		"namespace/name/provider/1.0.0",
 	}
-	
+
 	for _, id := range validIDs {
 		err := validateModuleID(id)
 		if err != nil {
@@ -140,7 +322,7 @@ func TestValidateModuleID_InvalidFormat(t *testing.T) {
 		{"hashicorp/consul/aws", "three parts"},
 		{"hashicorp/consul/aws/1.0.0/extra", "five parts"},
 	}
-	
+
 	for _, tc := range testCases {
 		err := validateModuleID(tc.moduleID)
 		if err == nil {
@@ -152,5 +334,40 @@ func TestValidateModuleID_InvalidFormat(t *testing.T) {
 		if !strings.Contains(err.Error(), "Expected format: namespace/name/provider/version (4 parts)") {
 			t.Errorf("expected error message to contain format hint, got %q", err.Error())
 		}
+	}
+}
+
+func testTerraformModuleDetails() client.TerraformModuleVersionDetails {
+	return client.TerraformModuleVersionDetails{
+		ID:          "namespace/name/provider/1.0.0",
+		Namespace:   "namespace",
+		Name:        "name",
+		Version:     "1.0.0",
+		Provider:    "provider",
+		Description: "A test module",
+		Source:      "source",
+		Root: client.ModulePart{
+			Name: "root",
+		},
+		Examples: []client.ModulePart{
+			{
+				Path:   "examples/example1",
+				Name:   "example1",
+				Readme: "example readme",
+				Inputs: []client.ModuleInput{
+					{Name: "example_input", Type: "string", Description: "desc", Default: "value", Required: false},
+				},
+			},
+		},
+		Submodules: []client.ModulePart{
+			{
+				Path:   "modules/private",
+				Name:   "private",
+				Readme: "private readme",
+				Inputs: []client.ModuleInput{
+					{Name: "submodule_input", Type: "string", Description: "desc", Default: nil, Required: true},
+				},
+			},
+		},
 	}
 }

--- a/pkg/tools/registry/search_modules.go
+++ b/pkg/tools/registry/search_modules.go
@@ -22,8 +22,8 @@ import (
 func SearchModules(logger *log.Logger) server.ServerTool {
 	return server.ServerTool{
 		Tool: mcp.NewTool("search_modules",
-			mcp.WithDescription(`Resolves a Terraform module name to obtain a compatible module_id for the get_module_details tool and returns a list of matching Terraform modules.
-You MUST call this function before 'get_module_details' to obtain a valid and compatible module_id.
+			mcp.WithDescription(`Resolves a Terraform module name to obtain a compatible module_id for get_module_details, get_module_examples, and get_module_submodules, and returns a list of matching Terraform modules.
+You MUST call this function before calling get_module_details, get_module_examples, or get_module_submodules to obtain a valid and compatible module_id.
 When selecting the best match, consider the following:
 	- Name similarity to the query
 	- Description relevance

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -46,6 +46,16 @@ func RegisterTools(hcServer *server.MCPServer, logger *log.Logger, enabledToolse
 		hcServer.AddTool(tool.Tool, tool.Handler)
 	}
 
+	if toolsets.IsToolEnabled("get_module_examples", enabledToolsets) {
+		tool := registryTools.ModuleExamples(logger)
+		hcServer.AddTool(tool.Tool, tool.Handler)
+	}
+
+	if toolsets.IsToolEnabled("get_module_submodules", enabledToolsets) {
+		tool := registryTools.ModuleSubmodules(logger)
+		hcServer.AddTool(tool.Tool, tool.Handler)
+	}
+
 	if toolsets.IsToolEnabled("get_latest_module_version", enabledToolsets) {
 		tool := registryTools.GetLatestModuleVersion(logger)
 		hcServer.AddTool(tool.Tool, tool.Handler)

--- a/pkg/toolsets/mapping.go
+++ b/pkg/toolsets/mapping.go
@@ -13,6 +13,8 @@ var ToolToToolset = map[string]string{
 	"get_provider_capabilities":   Registry,
 	"search_modules":              Registry,
 	"get_module_details":          Registry,
+	"get_module_examples":         Registry,
+	"get_module_submodules":       Registry,
 	"get_latest_module_version":   Registry,
 	"search_policies":             Registry,
 	"get_policy_details":          Registry,

--- a/pkg/toolsets/toolsets_test.go
+++ b/pkg/toolsets/toolsets_test.go
@@ -347,6 +347,8 @@ func TestGetAllValidToolNames(t *testing.T) {
 		"get_provider_details",
 		"search_modules",
 		"get_module_details",
+		"get_module_examples",
+		"get_module_submodules",
 		"search_policies",
 		"get_policy_details",
 		"list_workspaces",


### PR DESCRIPTION
## Summary
- add get_module_examples and get_module_submodules registry tools
- keep get_module_details focused on root module details plus example/submodule indexes
- add unit and Docker e2e coverage for listing and selecting module examples/submodules

Closes #307

## Validation
- go test ./pkg/tools/registry ./pkg/tools ./pkg/toolsets
- go vet ./pkg/tools/registry ./pkg/tools ./pkg/toolsets
- go test ./cmd/terraform-mcp-server ./pkg/client ./pkg/resources ./pkg/tools ./pkg/tools/registry ./pkg/tools/tfe ./pkg/toolsets ./pkg/utils ./version
- go vet ./cmd/terraform-mcp-server ./pkg/client ./pkg/resources ./pkg/tools ./pkg/tools/registry ./pkg/tools/tfe ./pkg/toolsets ./pkg/utils ./version
- make test-e2e