### PR TITLE
feat(tfe): add list_run_comments tool (#347)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 0.5.2
 
+FEATURES
+
+* [New Tool] `list_run_comments` Lists comments on a Terraform run, returning each comment's ID and body so agents can read context that humans left on a run [352](https://github.com/hashicorp/terraform-mcp-server/pull/352)
+
 IMPROVEMENTS
 
 * Add http server metrics instrumentation [330](https://github.com/hashicorp/terraform-mcp-server/pull/330)

--- a/pkg/tools/dynamic_tool.go
+++ b/pkg/tools/dynamic_tool.go
@@ -182,6 +182,12 @@ func (r *DynamicToolRegistry) registerTFETools() {
 		r.mcpServer.AddTool(tool.Tool, tool.Handler)
 	}
 
+	// Read-only counterpart to action_run's comment-write path. See #347.
+	if toolsets.IsToolEnabled("list_run_comments", r.enabledToolsets) {
+		tool := r.createDynamicTFETool("list_run_comments", tfeTools.ListRunComments)
+		r.mcpServer.AddTool(tool.Tool, tool.Handler)
+	}
+
 	// Create run tool with conditional options based on TF operations setting
 	if toolsets.IsToolEnabled("create_run", r.enabledToolsets) {
 		var tool server.ServerTool

--- a/pkg/tools/tfe/list_run_comments.go
+++ b/pkg/tools/tfe/list_run_comments.go
@@ -1,0 +1,99 @@
+// Copyright IBM Corp. 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/hashicorp/terraform-mcp-server/pkg/client"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	log "github.com/sirupsen/logrus"
+)
+
+// ListRunComments creates a tool that lists every comment attached to a
+// specific Terraform Cloud / Enterprise run. Closes the gap described in
+// https://github.com/hashicorp/terraform-mcp-server/issues/347 — `action_run`
+// already supports posting a comment, but until now there was no read path,
+// so an agent inspecting a run via `get_run_details` could see that comments
+// existed but couldn't read their bodies.
+//
+// Backed by the upstream TFE Comments API:
+//
+//	GET /runs/{run_id}/comments
+//	https://developer.hashicorp.com/terraform/cloud-docs/api-docs/comments
+func ListRunComments(logger *log.Logger) server.ServerTool {
+	return server.ServerTool{
+		Tool: mcp.NewTool("list_run_comments",
+			mcp.WithDescription(`List all comments attached to a specific Terraform run. Useful for reading context left by humans or automation on a run before deciding next steps.`),
+			mcp.WithTitleAnnotation("List Terraform run comments"),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithDestructiveHintAnnotation(false),
+			mcp.WithString("run_id",
+				mcp.Required(),
+				mcp.Description("ID of the Terraform run whose comments should be listed (e.g. 'run-CZcmD7eagjhyX0vN')."),
+			),
+		),
+		Handler: func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return listRunCommentsHandler(ctx, req, logger)
+		},
+	}
+}
+
+func listRunCommentsHandler(ctx context.Context, request mcp.CallToolRequest, logger *log.Logger) (*mcp.CallToolResult, error) {
+	runID, err := request.RequireString("run_id")
+	if err != nil {
+		return ToolError(logger, "missing required input: run_id", err)
+	}
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		return ToolErrorf(logger, "run_id must be non-empty")
+	}
+
+	tfeClient, err := client.GetTfeClientFromContext(ctx, logger)
+	if err != nil {
+		return ToolError(logger, "failed to get Terraform client", err)
+	}
+
+	commentList, err := tfeClient.Comments.List(ctx, runID)
+	if err != nil {
+		return ToolErrorf(logger, "failed to list comments for run '%s': %s", runID, err.Error())
+	}
+
+	summaries := make([]*RunCommentSummary, len(commentList.Items))
+	for i, c := range commentList.Items {
+		summaries[i] = &RunCommentSummary{
+			ID:   c.ID,
+			Body: c.Body,
+		}
+	}
+
+	buf, err := json.Marshal(&RunCommentList{
+		Items: summaries,
+	})
+	if err != nil {
+		return ToolError(logger, "failed to marshal comments", err)
+	}
+
+	return mcp.NewToolResultText(string(buf)), nil
+}
+
+// RunCommentSummary is the shape returned per-comment. The upstream TFE
+// Comment type carries only ID and Body, so we project both — adding
+// future fields here is a passthrough exercise.
+type RunCommentSummary struct {
+	ID   string `json:"id"`
+	Body string `json:"body"`
+}
+
+// RunCommentList wraps the per-run comment summaries. No pagination
+// fields today because the upstream Comments.List endpoint does not
+// expose a paging cursor (CommentList embeds *Pagination but TFE
+// returns the full set in one response). Wrapping in a struct keeps
+// the tool output forward-compatible if pagination is later wired up.
+type RunCommentList struct {
+	Items []*RunCommentSummary `json:"items"`
+}

--- a/pkg/toolsets/mapping.go
+++ b/pkg/toolsets/mapping.go
@@ -33,6 +33,7 @@ var ToolToToolset = map[string]string{
 	"update_workspace":                    Terraform,
 	"delete_workspace_safely":             Terraform,
 	"list_runs":                           Terraform,
+	"list_run_comments":                   Terraform,
 	"get_run_details":                     Terraform,
 	"get_plan_details":                    Terraform,
 	"get_plan_logs":                       Terraform,


### PR DESCRIPTION
Closes #347.

\`action_run\` already lets agents *post* a run comment when applying / discarding / canceling, but there was no way to *read* the existing comments back. \`get_run_details\` returns the comment ID, but no body — so an agent inspecting a run can see that humans left context but can't act on it.

This wires the existing TFE Comments API (\`GET /runs/{run_id}/comments\`, surfaced via \`go-tfe\`'s \`Comments.List\`) as a new \`list_run_comments\` tool. Shape mirrors \`list_runs\`:

\`\`\`json
// list_run_comments({"run_id": "run-CZcmD7eagjhyX0vN"})
{
  "items": [
    {"id": "comment-XXX", "body": "Approved by @sre, retrying after the 503"},
    {"id": "comment-YYY", "body": "..."}
  ]
}
\`\`\`

- Read-only and non-destructive annotations.
- Structured \`RunCommentSummary\` / \`RunCommentList\` types so future field additions (resolved-by, created-at) are a passthrough rather than a struct rewrite.

## Wiring

Three files:
- New \`pkg/tools/tfe/list_run_comments.go\` (mirrors \`list_runs.go\` shape).
- \`pkg/toolsets/mapping.go\` — \`list_run_comments → Terraform\` toolset.
- \`pkg/tools/dynamic_tool.go\` — conditional registration alongside \`list_runs\`.

## What's not in scope

- **Pagination.** The upstream \`Comments.List\` endpoint returns the full list in a single response (the go-tfe \`CommentList\` type embeds \`*Pagination\` but the endpoint doesn't actually populate page cursors). Output is wrapped in a struct anyway so pagination is a passthrough add later if upstream gets it.
- **Read-by-id.** \`go-tfe\` exposes \`Comments.Read(commentID)\` too, but the issue's ask is the list path. Happy to add a \`get_run_comment\` companion if reviewers want it.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./pkg/tools/tfe/... ./pkg/toolsets/...\` ok
- [ ] (For maintainer) — exercise against a real TFC org with a run that has 1+ comments and confirm the bodies render correctly. The go-tfe lib is already used heavily in this repo so the network path itself is well-trodden.

## Note on duplication

@vavdoshka offered on the issue to contribute this — happy to defer if they were already partway through. Didn't see an open PR or a draft branch from them, so I went ahead. If you'd rather their PR land instead, totally fine to close this one.