### PR TITLE
Add new metric to capture client type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,15 @@
-IMPROVEMENTS
-
-* Run as a non-root user for Kubernetes compatibility. [356] https://github.com/hashicorp/terraform-mcp-server/pull/356
-
-# 0.5.2
+# 0.5.3
 
 FEATURES
 
 * [New Tool] `get_sentinel_mock` Export and download Sentinel mock bundle data for a Terraform plan
+
+IMPROVEMENTS
+
+* Add a new metric to capture client type and version [355](https://github.com/hashicorp/terraform-mcp-server/pull/355)
+* Run as a non-root user for Kubernetes compatibility. [356] https://github.com/hashicorp/terraform-mcp-server/pull/356
+
+# 0.5.2
 
 IMPROVEMENTS
 

--- a/cmd/terraform-mcp-server/main.go
+++ b/cmd/terraform-mcp-server/main.go
@@ -34,6 +34,7 @@ import (
 
 //go:embed instructions.md
 var instructions string
+var sessionClientInfo sync.Map // map[string]client.ClientInfo
 
 func runHTTPServer(logger *log.Logger, host string, port string, endpointPath string, heartbeatInterval time.Duration, enabledToolsets []string, metricsConfig client.MetricsConfig) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -80,17 +81,49 @@ func attachMetricsHooks(hooks *server.Hooks, metricsConfig client.MetricsConfig,
 	}
 	hooks.AddAfterInitialize(func(ctx context.Context, id any, message *mcp.InitializeRequest, result *mcp.InitializeResult) {
 		if message != nil && message.Params.ClientInfo.Name != "" {
-			clientName := message.Params.ClientInfo.Name
-			clientVersion := message.Params.ClientInfo.Version
-			clientTitle := message.Params.ClientInfo.Title
-			clientDesc := message.Params.ClientInfo.Description
-			client.RecordClientType(ctx, clientName, clientVersion, clientTitle, clientDesc, metricsConfig, logger)
+			session := server.ClientSessionFromContext(ctx)
+			if session == nil {
+				logger.Debug("AddAfterInitialize hook: No session found in context")
+				return
+			}
+			ci := client.ClientInfo{
+				Name:        message.Params.ClientInfo.Name,
+				Version:     message.Params.ClientInfo.Version,
+				Title:       message.Params.ClientInfo.Title,
+				Description: message.Params.ClientInfo.Description,
+			}
+			// Record the client info in the session first so we can reuse it in the BeforeToolCall hook
+			sessionClientInfo.Store(session.SessionID(), ci)
+			// Record the metric
+			client.RecordClientType(ctx, ci, metricsConfig, logger)
 		}
 	})
 
 	var toolStartTimes sync.Map
 	hooks.AddBeforeCallTool(func(ctx context.Context, id any, message *mcp.CallToolRequest) {
 		toolStartTimes.Store(fmt.Sprintf("%v", id), time.Now())
+		session := server.ClientSessionFromContext(ctx)
+		if session == nil {
+			logger.Debug("AddBeforeCallTool hook: No session found in context")
+			return
+		}
+		value, ok := sessionClientInfo.Load(session.SessionID())
+		if !ok {
+			logger.Debugf("AddBeforeCallTool hook: Client info not found for session ID: %s", session.SessionID())
+			return
+		}
+		// Read the client info recorded in the AddAfterInitialize hook
+		info, ok := value.(client.ClientInfo)
+		if !ok || info.Name == "" {
+			logger.Debugf("AddBeforeCallTool hook: Unable to read client info for sessionID %s from sessionClientInfo map", session.SessionID())
+			return
+		}
+		client.RecordClientType(
+			ctx,
+			info,
+			metricsConfig,
+			logger,
+		)
 	})
 	hooks.AddAfterCallTool(func(ctx context.Context, id any, message *mcp.CallToolRequest, result any) {
 		startTime := time.Now()

--- a/cmd/terraform-mcp-server/main.go
+++ b/cmd/terraform-mcp-server/main.go
@@ -78,6 +78,13 @@ func attachMetricsHooks(hooks *server.Hooks, metricsConfig client.MetricsConfig,
 	if !metricsConfig.Enabled {
 		return
 	}
+	hooks.AddAfterInitialize(func(ctx context.Context, id any, message *mcp.InitializeRequest, result *mcp.InitializeResult) {
+		if message != nil && message.Params.ClientInfo.Name != "" {
+			clientName := message.Params.ClientInfo.Name
+			clientVersion := message.Params.ClientInfo.Version
+			client.RecordClientType(ctx, clientName, clientVersion, metricsConfig, logger)
+		}
+	})
 
 	var toolStartTimes sync.Map
 	hooks.AddBeforeCallTool(func(ctx context.Context, id any, message *mcp.CallToolRequest) {
@@ -391,6 +398,12 @@ func initMetrics(ctx context.Context, config *client.MetricsConfig, logger *log.
 		metric.WithUnit("s"))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create latency histogram: %w", err)
+	}
+
+	config.ClientTypeCounter, err = meter.Int64Counter("mcp_client_type_total",
+		metric.WithDescription("Total number of connections by client type"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client type counter: %w", err)
 	}
 
 	return func() {

--- a/cmd/terraform-mcp-server/main.go
+++ b/cmd/terraform-mcp-server/main.go
@@ -46,6 +46,8 @@ func runHTTPServer(logger *log.Logger, host string, port string, endpointPath st
 		client.NewSessionHandler(ctx, session, logger)
 	})
 	hooks.AddOnUnregisterSession(func(ctx context.Context, session server.ClientSession) {
+		// Clean up client info populated in the metrics hooks, for the session
+		sessionClientInfo.Delete(session.SessionID())
 		client.EndSessionHandler(ctx, session, logger)
 	})
 	// When running multiple sessions of the MCP server (load balancing), calling client.NewSessionHandler

--- a/cmd/terraform-mcp-server/main.go
+++ b/cmd/terraform-mcp-server/main.go
@@ -82,7 +82,9 @@ func attachMetricsHooks(hooks *server.Hooks, metricsConfig client.MetricsConfig,
 		if message != nil && message.Params.ClientInfo.Name != "" {
 			clientName := message.Params.ClientInfo.Name
 			clientVersion := message.Params.ClientInfo.Version
-			client.RecordClientType(ctx, clientName, clientVersion, metricsConfig, logger)
+			clientTitle := message.Params.ClientInfo.Title
+			clientDesc := message.Params.ClientInfo.Description
+			client.RecordClientType(ctx, clientName, clientVersion, clientTitle, clientDesc, metricsConfig, logger)
 		}
 	})
 

--- a/pkg/client/metrics.go
+++ b/pkg/client/metrics.go
@@ -27,6 +27,13 @@ type MetricsConfig struct {
 	ClientTypeCounter     metric.Int64Counter      // Client type count (e.g. cli, cpi, vscode, web etc.)
 }
 
+type ClientInfo struct {
+	Name        string
+	Version     string
+	Title       string
+	Description string
+}
+
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
 		Enabled:              false,
@@ -106,17 +113,17 @@ func RecordToolCall(ctx context.Context, startTime time.Time, toolErr bool, id a
 }
 
 // RecordClientType records the type and version of the client making the tool call (e.g., CLI, VSCode, Web, etc.)
-func RecordClientType(ctx context.Context, clientName string, clientVersion string, clientTitle string, clientDesc string, config MetricsConfig, logger *log.Logger) {
-	logger.Infof("Recording client type for client: %s version: %s title: %s description: %s", clientName, clientVersion, clientTitle, clientDesc)
+func RecordClientType(ctx context.Context, ci ClientInfo, config MetricsConfig, logger *log.Logger) {
+	logger.Infof("Recording client type for client: %s version: %s title: %s description: %s", ci.Name, ci.Version, ci.Title, ci.Description)
 	if !config.Enabled || config.ClientTypeCounter == nil {
 		logger.Debugf("Either metrics are not enabled or ClientTypeCounter is NIL! Initialization failed.")
 		return
 	}
 	attrs := metric.WithAttributes(
-		attribute.String("client.name", clientName),
-		attribute.String("client.version", clientVersion),
-		attribute.String("client.title", clientTitle),
-		attribute.String("client.description", clientDesc),
+		attribute.String("client.name", ci.Name),
+		attribute.String("client.version", ci.Version),
+		attribute.String("client.title", ci.Title),
+		attribute.String("client.description", ci.Description),
 		attribute.String("service.name", config.ServiceName),
 		attribute.String("service.version", config.ServiceVersion),
 	)

--- a/pkg/client/metrics.go
+++ b/pkg/client/metrics.go
@@ -24,6 +24,7 @@ type MetricsConfig struct {
 	ToolCounter           metric.Int64Counter      // ToolCounter tracks the total number of tool calls initiated
 	ErrorCounter          metric.Int64Counter      // Error count
 	ToolCallLatencyBucket metric.Float64Histogram  // Latency distribution
+	ClientTypeCounter     metric.Int64Counter      // Client type count (e.g. cli, cpi, vscode, web etc.)
 }
 
 func DefaultMetricsConfig() MetricsConfig {
@@ -102,4 +103,20 @@ func RecordToolCall(ctx context.Context, startTime time.Time, toolErr bool, id a
 		config.ErrorCounter.Add(ctx, 1, attrs)
 		logger.Errorf("Recorded error for tool %s", message.Params.Name)
 	}
+}
+
+// RecordClientType records the type and version of the client making the tool call (e.g., CLI, VSCode, Web, etc.)
+func RecordClientType(ctx context.Context, clientName string, clientVersion string, config MetricsConfig, logger *log.Logger) {
+	logger.Infof("Recording client type for client: %s version: %s", clientName, clientVersion)
+	if !config.Enabled || config.ClientTypeCounter == nil {
+		logger.Errorf("DEBUG: Either metrics are not enabled or ClientTypeCounter is NIL! Initialization failed.")
+		return
+	}
+	attrs := metric.WithAttributes(
+		attribute.String("client.name", clientName),
+		attribute.String("client.version", clientVersion),
+		attribute.String("service.name", config.ServiceName),
+		attribute.String("service.version", config.ServiceVersion),
+	)
+	config.ClientTypeCounter.Add(ctx, 1, attrs)
 }

--- a/pkg/client/metrics.go
+++ b/pkg/client/metrics.go
@@ -83,7 +83,7 @@ func LoadMetricsConfigFromEnv() MetricsConfig {
 func RecordToolCall(ctx context.Context, startTime time.Time, toolErr bool, id any, message *mcp.CallToolRequest, config MetricsConfig, logger *log.Logger) {
 	logger.Infof("Recording tool call for tool: %s id: %v", message.Params.Name, id)
 	if !config.Enabled || config.ToolCounter == nil {
-		logger.Errorf("DEBUG: Either metrics are not enabled or ToolCounter is NIL! Initialization failed.")
+		logger.Debugf("Either metrics are not enabled or ToolCounter is NIL! Initialization failed.")
 		return
 	}
 	// Calculate latency
@@ -106,15 +106,17 @@ func RecordToolCall(ctx context.Context, startTime time.Time, toolErr bool, id a
 }
 
 // RecordClientType records the type and version of the client making the tool call (e.g., CLI, VSCode, Web, etc.)
-func RecordClientType(ctx context.Context, clientName string, clientVersion string, config MetricsConfig, logger *log.Logger) {
-	logger.Infof("Recording client type for client: %s version: %s", clientName, clientVersion)
+func RecordClientType(ctx context.Context, clientName string, clientVersion string, clientTitle string, clientDesc string, config MetricsConfig, logger *log.Logger) {
+	logger.Infof("Recording client type for client: %s version: %s title: %s description: %s", clientName, clientVersion, clientTitle, clientDesc)
 	if !config.Enabled || config.ClientTypeCounter == nil {
-		logger.Errorf("DEBUG: Either metrics are not enabled or ClientTypeCounter is NIL! Initialization failed.")
+		logger.Debugf("Either metrics are not enabled or ClientTypeCounter is NIL! Initialization failed.")
 		return
 	}
 	attrs := metric.WithAttributes(
 		attribute.String("client.name", clientName),
 		attribute.String("client.version", clientVersion),
+		attribute.String("client.title", clientTitle),
+		attribute.String("client.description", clientDesc),
 		attribute.String("service.name", config.ServiceName),
 		attribute.String("service.version", config.ServiceVersion),
 	)

--- a/pkg/client/metrics_test.go
+++ b/pkg/client/metrics_test.go
@@ -15,6 +15,12 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
+func testLogger() *log.Logger {
+	logger := log.New()
+	logger.SetOutput(io.Discard)
+	return logger
+}
+
 func TestLoadMetricsConfigFromEnv(t *testing.T) {
 	t.Run("uses environment overrides", func(t *testing.T) {
 		t.Setenv("OTEL_METRICS_ENDPOINT", "collector.internal:4318")
@@ -75,8 +81,7 @@ func TestRecordToolCallRecordsMetrics(t *testing.T) {
 		ToolCallLatencyBucket: latencyHistogram,
 	}
 
-	logger := log.New()
-	logger.SetOutput(io.Discard)
+	logger := testLogger()
 
 	request := &mcp.CallToolRequest{
 		Params: mcp.CallToolParams{Name: "list_runs"},
@@ -169,4 +174,92 @@ func findFloat64HistogramMetric(t *testing.T, resourceMetrics metricdata.Resourc
 
 	t.Fatalf("metric %s not found", name)
 	return metricdata.Histogram[float64]{}
+}
+
+func newTestMetricsConfig(t *testing.T) (MetricsConfig, *sdkmetric.ManualReader) {
+	t.Helper()
+
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() {
+		require.NoError(t, provider.Shutdown(context.Background()))
+	})
+
+	meter := provider.Meter("test-service")
+	clientTypeCounter, err := meter.Int64Counter("mcp_client_types_total")
+	require.NoError(t, err)
+
+	return MetricsConfig{
+		Enabled:           true,
+		ServiceName:       "terraform-mcp-server",
+		ServiceVersion:    "test-version",
+		MeterProvider:     provider,
+		ClientTypeCounter: clientTypeCounter,
+	}, reader
+}
+
+// Test 1: Records client type with correct attributes
+func TestRecordClientTypeSuccess(t *testing.T) {
+	config, reader := newTestMetricsConfig(t)
+	ctx := context.Background()
+
+	RecordClientType(ctx, "Claude", "1.0.0", config, testLogger())
+
+	var resourceMetrics metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(ctx, &resourceMetrics))
+
+	clientTypes := findInt64SumMetric(t, resourceMetrics, "mcp_client_types_total")
+	require.Len(t, clientTypes.DataPoints, 1)
+	assert.EqualValues(t, 1, clientTypes.DataPoints[0].Value)
+
+	attrs := clientTypes.DataPoints[0].Attributes.ToSlice()
+	assert.Contains(t, attrs, attribute.String("client.name", "Claude"))
+	assert.Contains(t, attrs, attribute.String("client.version", "1.0.0"))
+	assert.Contains(t, attrs, attribute.String("service.name", "terraform-mcp-server"))
+	assert.Contains(t, attrs, attribute.String("service.version", "test-version"))
+}
+
+// Test 2: Aggregates multiple calls from same client
+func TestRecordClientTypeMultipleCalls(t *testing.T) {
+	config, reader := newTestMetricsConfig(t)
+	ctx := context.Background()
+
+	// Record same client multiple times
+	RecordClientType(ctx, "Claude", "1.0.0", config, testLogger())
+	RecordClientType(ctx, "Claude", "1.0.0", config, testLogger())
+	RecordClientType(ctx, "Bedrock", "2.0.0", config, testLogger())
+
+	var resourceMetrics metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(ctx, &resourceMetrics))
+
+	clientTypes := findInt64SumMetric(t, resourceMetrics, "mcp_client_types_total")
+	require.Len(t, clientTypes.DataPoints, 2, "Should have 2 unique client combinations")
+
+	// Verify counts
+	for _, dp := range clientTypes.DataPoints {
+		attrs := dp.Attributes.ToSlice()
+		var clientName string
+		for _, attr := range attrs {
+			if attr.Key == "client.name" {
+				clientName = attr.Value.AsString()
+				break
+			}
+		}
+
+		if clientName == "Claude" {
+			assert.EqualValues(t, 2, dp.Value, "Claude should have 2 connections")
+		} else if clientName == "Bedrock" {
+			assert.EqualValues(t, 1, dp.Value, "Bedrock should have 1 connection")
+		}
+	}
+}
+
+// Test 3: Handles disabled metrics gracefully
+func TestRecordClientTypeMetricsDisabled(t *testing.T) {
+	config := MetricsConfig{Enabled: false}
+	ctx := context.Background()
+
+	assert.NotPanics(t, func() {
+		RecordClientType(ctx, "Claude", "1.0.0", config, testLogger())
+	})
 }

--- a/pkg/client/metrics_test.go
+++ b/pkg/client/metrics_test.go
@@ -202,8 +202,13 @@ func newTestMetricsConfig(t *testing.T) (MetricsConfig, *sdkmetric.ManualReader)
 func TestRecordClientTypeSuccess(t *testing.T) {
 	config, reader := newTestMetricsConfig(t)
 	ctx := context.Background()
-
-	RecordClientType(ctx, "Claude", "1.0.0", "Claude Title", "Claude Description", config, testLogger())
+	ci := ClientInfo{
+		Name:        "Claude",
+		Version:     "1.0.0",
+		Title:       "Claude Title",
+		Description: "Claude Description",
+	}
+	RecordClientType(ctx, ci, config, testLogger())
 
 	var resourceMetrics metricdata.ResourceMetrics
 	require.NoError(t, reader.Collect(ctx, &resourceMetrics))
@@ -227,9 +232,21 @@ func TestRecordClientTypeMultipleCalls(t *testing.T) {
 	ctx := context.Background()
 
 	// Record same client multiple times
-	RecordClientType(ctx, "Claude", "1.0.0", "Claude Title", "Claude Description", config, testLogger())
-	RecordClientType(ctx, "Claude", "1.0.0", "Claude Title", "Claude Description", config, testLogger())
-	RecordClientType(ctx, "Bedrock", "2.0.0", "Bedrock Title", "Bedrock Description", config, testLogger())
+	ciClaude := ClientInfo{
+		Name:        "Claude",
+		Version:     "1.0.0",
+		Title:       "Claude Title",
+		Description: "Claude Description",
+	}
+	ciBedrock := ClientInfo{
+		Name:        "Bedrock",
+		Version:     "2.0.0",
+		Title:       "Bedrock Title",
+		Description: "Bedrock Description",
+	}
+	RecordClientType(ctx, ciClaude, config, testLogger())
+	RecordClientType(ctx, ciClaude, config, testLogger())
+	RecordClientType(ctx, ciBedrock, config, testLogger())
 
 	var resourceMetrics metricdata.ResourceMetrics
 	require.NoError(t, reader.Collect(ctx, &resourceMetrics))
@@ -261,7 +278,14 @@ func TestRecordClientTypeMetricsDisabled(t *testing.T) {
 	config := MetricsConfig{Enabled: false}
 	ctx := context.Background()
 
+	ci := ClientInfo{
+		Name:        "Claude",
+		Version:     "1.0.0",
+		Title:       "Claude Title",
+		Description: "Claude Description",
+	}
+
 	assert.NotPanics(t, func() {
-		RecordClientType(ctx, "Claude", "1.0.0", "Claude Title", "Claude Description", config, testLogger())
+		RecordClientType(ctx, ci, config, testLogger())
 	})
 }

--- a/pkg/client/metrics_test.go
+++ b/pkg/client/metrics_test.go
@@ -228,7 +228,7 @@ func TestRecordClientTypeMultipleCalls(t *testing.T) {
 
 	// Record same client multiple times
 	RecordClientType(ctx, "Claude", "1.0.0", "Claude Title", "Claude Description", config, testLogger())
-	RecordClientType(ctx, "Claude", "1.0.0", "Claude Title 2", "Claude Description 2", config, testLogger())
+	RecordClientType(ctx, "Claude", "1.0.0", "Claude Title", "Claude Description", config, testLogger())
 	RecordClientType(ctx, "Bedrock", "2.0.0", "Bedrock Title", "Bedrock Description", config, testLogger())
 
 	var resourceMetrics metricdata.ResourceMetrics

--- a/pkg/client/metrics_test.go
+++ b/pkg/client/metrics_test.go
@@ -203,7 +203,7 @@ func TestRecordClientTypeSuccess(t *testing.T) {
 	config, reader := newTestMetricsConfig(t)
 	ctx := context.Background()
 
-	RecordClientType(ctx, "Claude", "1.0.0", config, testLogger())
+	RecordClientType(ctx, "Claude", "1.0.0", "Claude Title", "Claude Description", config, testLogger())
 
 	var resourceMetrics metricdata.ResourceMetrics
 	require.NoError(t, reader.Collect(ctx, &resourceMetrics))
@@ -215,6 +215,8 @@ func TestRecordClientTypeSuccess(t *testing.T) {
 	attrs := clientTypes.DataPoints[0].Attributes.ToSlice()
 	assert.Contains(t, attrs, attribute.String("client.name", "Claude"))
 	assert.Contains(t, attrs, attribute.String("client.version", "1.0.0"))
+	assert.Contains(t, attrs, attribute.String("client.title", "Claude Title"))
+	assert.Contains(t, attrs, attribute.String("client.description", "Claude Description"))
 	assert.Contains(t, attrs, attribute.String("service.name", "terraform-mcp-server"))
 	assert.Contains(t, attrs, attribute.String("service.version", "test-version"))
 }
@@ -225,9 +227,9 @@ func TestRecordClientTypeMultipleCalls(t *testing.T) {
 	ctx := context.Background()
 
 	// Record same client multiple times
-	RecordClientType(ctx, "Claude", "1.0.0", config, testLogger())
-	RecordClientType(ctx, "Claude", "1.0.0", config, testLogger())
-	RecordClientType(ctx, "Bedrock", "2.0.0", config, testLogger())
+	RecordClientType(ctx, "Claude", "1.0.0", "Claude Title", "Claude Description", config, testLogger())
+	RecordClientType(ctx, "Claude", "1.0.0", "Claude Title 2", "Claude Description 2", config, testLogger())
+	RecordClientType(ctx, "Bedrock", "2.0.0", "Bedrock Title", "Bedrock Description", config, testLogger())
 
 	var resourceMetrics metricdata.ResourceMetrics
 	require.NoError(t, reader.Collect(ctx, &resourceMetrics))
@@ -260,6 +262,6 @@ func TestRecordClientTypeMetricsDisabled(t *testing.T) {
 	ctx := context.Background()
 
 	assert.NotPanics(t, func() {
-		RecordClientType(ctx, "Claude", "1.0.0", config, testLogger())
+		RecordClientType(ctx, "Claude", "1.0.0", "Claude Title", "Claude Description", config, testLogger())
 	})
 }


### PR DESCRIPTION
As part of better understanding the usage of our mcp server we need to be able to answer:
Where are customers calling our mcp server from? Claude, Bedrock etc..
Add a metric which can capture the client type.
We can do this by creating a hook for the Initialize lifecycle step and grabbing the clientInfo see spec: 
[Lifecycle - Model Context Protocol](https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle#initialization)



## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
