### PR TITLE
Run runtime images as non-root for Kubernetes compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+IMPROVEMENTS
+
+* Run as a non-root user for Kubernetes compatibility. [356] https://github.com/hashicorp/terraform-mcp-server/pull/356
+
 # 0.5.2
 
 FEATURES

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,8 @@ WORKDIR /server
 # Copy the binary from the build stage
 COPY --from=devbuild /build/terraform-mcp-server .
 COPY --from=certbuild /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+# Run as a non-root user for Kubernetes compatibility.
+USER 65532:65532
 # Command to run the server (mode determined by environment variables or defaults to stdio)
 ENTRYPOINT ["./terraform-mcp-server"]
 
@@ -64,6 +66,8 @@ LABEL revision=$PRODUCT_REVISION
 LABEL io.modelcontextprotocol.server.name="io.github.hashicorp/terraform-mcp-server"
 COPY dist/$TARGETOS/$TARGETARCH/$BIN_NAME /bin/terraform-mcp-server
 COPY --from=certbuild /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+# Run as a non-root user for Kubernetes compatibility.
+USER 65532:65532
 # Command to run the server (mode determined by environment variables or defaults to stdio)
 ENTRYPOINT ["/bin/terraform-mcp-server"]
 


### PR DESCRIPTION
The runtime container images were running as root by default (scratch image + no explicit user). In Kubernetes clusters with restricted Pod Security settings, this can fail admission or violate security policy when runAsNonRoot is required.

**Changes Made**
Added an explicit non-root runtime user to the dev image stage:
- Added the same explicit non-root runtime user to the release image stage:
- Chosen user/group is numeric 65532:65532, which works in scratch-based images without requiring passwd/group files.

This change ensures containers do not run as UID 0 by default. It improves compatibility with Kubernetes securityContext settings such as `runAsNonRoot: true`. Keeps runtime behaviour unchanged aside from process identity (entrypoints and binaries are unchanged).

**Scope/Impact:**
- Runtime security hardening only.
- No API, protocol, or functional behaviour changes.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
