### PR TITLE
Use configurable container runtime in e2e tests instead of hardcoded Docker commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+
+* Use the configured container runtime for e2e tests instead of hardcoded Docker commands, enabling Podman-based test runs [358](https://github.com/hashicorp/terraform-mcp-server/pull/358)
+
 # 0.5.2
 
 FEATURES

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,8 @@ WORKDIR /server
 # Copy the binary from the build stage
 COPY --from=devbuild /build/terraform-mcp-server .
 COPY --from=certbuild /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+# Run as a non-root user for Kubernetes compatibility.
+USER 65532:65532
 # Command to run the server (mode determined by environment variables or defaults to stdio)
 ENTRYPOINT ["./terraform-mcp-server"]
 
@@ -64,6 +66,8 @@ LABEL revision=$PRODUCT_REVISION
 LABEL io.modelcontextprotocol.server.name="io.github.hashicorp/terraform-mcp-server"
 COPY dist/$TARGETOS/$TARGETARCH/$BIN_NAME /bin/terraform-mcp-server
 COPY --from=certbuild /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+# Run as a non-root user for Kubernetes compatibility.
+USER 65532:65532
 # Command to run the server (mode determined by environment variables or defaults to stdio)
 ENTRYPOINT ["/bin/terraform-mcp-server"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,6 @@ WORKDIR /server
 # Copy the binary from the build stage
 COPY --from=devbuild /build/terraform-mcp-server .
 COPY --from=certbuild /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-# Run as a non-root user for Kubernetes compatibility.
-USER 65532:65532
 # Command to run the server (mode determined by environment variables or defaults to stdio)
 ENTRYPOINT ["./terraform-mcp-server"]
 
@@ -66,8 +64,6 @@ LABEL revision=$PRODUCT_REVISION
 LABEL io.modelcontextprotocol.server.name="io.github.hashicorp/terraform-mcp-server"
 COPY dist/$TARGETOS/$TARGETARCH/$BIN_NAME /bin/terraform-mcp-server
 COPY --from=certbuild /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-# Run as a non-root user for Kubernetes compatibility.
-USER 65532:65532
 # Command to run the server (mode determined by environment variables or defaults to stdio)
 ENTRYPOINT ["/bin/terraform-mcp-server"]
 

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ test:
 
 # Run e2e tests
 test-e2e:
-	@trap '$(MAKE) cleanup-test-containers' EXIT; $(GO) test -v --tags e2e ./e2e
+	@trap '$(MAKE) cleanup-test-containers' EXIT; DOCKER=$(DOCKER) $(GO) test -v --tags e2e ./e2e
 
 # Clean build artifacts
 clean:

--- a/e2e/cors_e2e_test.go
+++ b/e2e/cors_e2e_test.go
@@ -74,7 +74,7 @@ func TestCORSE2E(t *testing.T) {
 
 			containerID := startHTTPContainerWithCORS(t, config.port, config.mode, config.origins)
 			defer func() {
-				stopCmd := exec.Command("docker", "stop", containerID)
+				stopCmd := exec.Command(containerRuntime(), "stop", containerID)
 				stopCmd.Run()
 			}()
 
@@ -90,7 +90,7 @@ func TestCORSE2E(t *testing.T) {
 func startHTTPContainerWithCORS(t *testing.T, port, mode, origins string) string {
 	portMapping := fmt.Sprintf("%s:8080", port)
 	cmd := exec.Command(
-		"docker", "run", "-d", "--rm",
+		containerRuntime(), "run", "-d", "--rm",
 		"-e", "TRANSPORT_MODE=streamable-http",
 		"-e", "TRANSPORT_HOST=0.0.0.0",
 		"-e", "MCP_SESSION_MODE=stateful",

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -374,7 +374,7 @@ func runTestSuite(t *testing.T, client mcpClient.MCPClient, transportName string
 // createStdioClient creates a stdio-based MCP client
 func createStdioClient(t *testing.T) (mcpClient.MCPClient, func()) {
 	args := []string{
-		"docker",
+		containerRuntime(),
 		"run",
 		"-i",
 		"--rm",
@@ -430,7 +430,7 @@ func createHTTPClient(t *testing.T) (mcpClient.MCPClient, func()) {
 func startHTTPContainer(t *testing.T, port string) string {
 	portMapping := fmt.Sprintf("%s:8080", port)
 	cmd := exec.Command(
-		"docker", "run", "-d", "--rm",
+		containerRuntime(), "run", "-d", "--rm",
 		"-e", "TRANSPORT_MODE=streamable-http",
 		"-e", "TRANSPORT_HOST=0.0.0.0",
 		"-e", "MCP_SESSION_MODE=stateful",
@@ -472,11 +472,11 @@ func stopContainer(t *testing.T, containerID string) {
 	}
 
 	t.Logf("Stopping container: %s", containerID)
-	cmd := exec.Command("docker", "stop", containerID)
+	cmd := exec.Command(containerRuntime(), "stop", containerID)
 	if err := cmd.Run(); err != nil {
 		t.Logf("Warning: failed to stop container %s: %v", containerID, err)
 		// Try force kill if stop fails
-		killCmd := exec.Command("docker", "kill", containerID)
+		killCmd := exec.Command(containerRuntime(), "kill", containerID)
 		if killErr := killCmd.Run(); killErr != nil {
 			t.Logf("Warning: failed to kill container %s: %v", containerID, killErr)
 		}
@@ -490,7 +490,7 @@ func cleanupAllTestContainers(t *testing.T) {
 	t.Log("Cleaning up all test containers...")
 
 	// Find all containers with our test image
-	cmd := exec.Command("docker", "ps", "-q", "--filter", "ancestor=terraform-mcp-server:test-e2e")
+	cmd := exec.Command(containerRuntime(), "ps", "-q", "--filter", "ancestor=terraform-mcp-server:test-e2e")
 	output, err := cmd.Output()
 	if err != nil {
 		t.Logf("Warning: failed to list test containers: %v", err)
@@ -504,7 +504,7 @@ func cleanupAllTestContainers(t *testing.T) {
 	}
 
 	// Stop all found containers
-	stopCmd := exec.Command("docker", "stop")
+	stopCmd := exec.Command(containerRuntime(), "stop")
 	stopCmd.Stdin = strings.NewReader(containerIDs)
 	if err := stopCmd.Run(); err != nil {
 		t.Logf("Warning: failed to stop some test containers: %v", err)
@@ -519,6 +519,15 @@ func getTestPort() string {
 		return port
 	}
 	return "8080"
+}
+
+// containerRuntime returns the container runtime binary to use.
+// It reads the DOCKER environment variable, falling back to "docker".
+func containerRuntime() string {
+	if rt := os.Getenv("DOCKER"); rt != "" {
+		return rt
+	}
+	return "docker"
 }
 
 func buildDockerImage(t *testing.T) {


### PR DESCRIPTION
The e2e test flow hardcoded `docker` in test helper commands, even though the Makefile already supports a configurable container runtime via `DOCKER` variable.

That caused `make test-e2e` to fail in environments using Podman or another Docker-compatible runtime, because the Go tests ignored the configured runtime and invoked `docker` directly.

## Changes Made
- Added a shared helper in the e2e test package to resolve the container runtime from the DOCKER environment variable.
- Kept a docker fallback so existing Docker-based workflows continue to work unchanged.
- Replaced hardcoded docker invocations in e2e test helpers with the resolved runtime.
- Updated the test-e2e Makefile target to export DOCKER=$(DOCKER) into the Go test process so the tests use the same runtime as the Makefile.

## Why This Fix
- Aligns the Go e2e tests with the existing Makefile configuration.
- Allows make test-e2e to work with Podman without requiring local aliases or manual edits.
- Preserves backward compatibility for Docker users.

## Scope
Test infrastructure only.
No changes to server runtime behaviour or production container images.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
