### PR TITLE
ci(release-checks): declare contents: read

### DIFF
--- a/.github/workflows/release-checks.yml
+++ b/.github/workflows/release-checks.yml
@@ -2,11 +2,14 @@ name: Version Consistency Check
 
 on:
   push:
-    branches: 
+    branches:
       - 'release/*'
   pull_request:
-    branches: 
+    branches:
       - 'release/*'
+
+permissions:
+  contents: read
 
 jobs:
   version-check:


### PR DESCRIPTION
The version-consistency workflow currently inherits the default `GITHUB_TOKEN` scope. It only runs `scripts/compare-versions.sh` against a checkout, so `contents: read` is the correct minimum.

Matches the top-level pattern already in `unit_test.yml`, `changelog.yml`, `publish-registry.yml`, `e2e_test.yml`. YAML validated locally.