### PR TITLE
Fix: --tools alone falsely flagged as conflicting with --toolsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ IMPROVEMENTS
 * Run as a non-root user for Kubernetes compatibility. [356] https://github.com/hashicorp/terraform-mcp-server/pull/356
 * Bump go version to 1.26.3 [366] https://github.com/hashicorp/terraform-mcp-server/pull/366
 
+FIXES
+
+* Fix `--tools` alone being falsely flagged as conflicting with `--toolsets` [380](https://github.com/hashicorp/terraform-mcp-server/pull/380)
+
 # 0.5.2
 
 IMPROVEMENTS

--- a/cmd/terraform-mcp-server/main.go
+++ b/cmd/terraform-mcp-server/main.go
@@ -230,12 +230,15 @@ func getToolsetsFromCmd(cmd *cobra.Command, logger *log.Logger) []string {
 	}
 
 	if err == nil && toolsFlag != "" {
-		// Ensure --toolsets is not also set
-		toolsetsFlag, _ := cmd.Flags().GetString("toolsets")
-		if toolsetsFlag == "" {
-			toolsetsFlag, _ = cmd.Root().PersistentFlags().GetString("toolsets")
+		// Ensure --toolsets is not also explicitly set. The flag is declared with
+		// a non-empty default ("all"), so a value-based check would always fire
+		// when only --tools is passed; pflag's Changed field is the precise
+		// "was this flag set on the command line?" signal.
+		toolsetsFlagDef := cmd.Flags().Lookup("toolsets")
+		if toolsetsFlagDef == nil {
+			toolsetsFlagDef = cmd.Root().PersistentFlags().Lookup("toolsets")
 		}
-		if toolsetsFlag != "" && toolsetsFlag != "default" {
+		if toolsetsFlagDef != nil && toolsetsFlagDef.Changed {
 			logger.Fatal("Cannot use both --tools and --toolsets flags together")
 		}
 		return parseIndividualTools(toolsFlag, logger)

--- a/cmd/terraform-mcp-server/toolsets_conflict_test.go
+++ b/cmd/terraform-mcp-server/toolsets_conflict_test.go
@@ -1,0 +1,120 @@
+// Copyright IBM Corp. 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fatalRecordingLogger returns a logrus logger whose Fatal calls flip the
+// returned bool instead of terminating the process, letting tests assert on
+// Fatal behavior without exiting the test binary.
+func fatalRecordingLogger() (*log.Logger, *bool) {
+	logger := log.New()
+	logger.SetOutput(io.Discard)
+	fatalCalled := false
+	logger.ExitFunc = func(_ int) { fatalCalled = true }
+	return logger, &fatalCalled
+}
+
+// restoreToolsAndToolsetsFlags returns rootCmd's --tools / --toolsets persistent
+// flags to their declared defaults and clears Changed so they do not leak into
+// other tests in the package.
+func restoreToolsAndToolsetsFlags(t *testing.T) {
+	t.Helper()
+	for _, spec := range []struct{ name, def string }{
+		{"tools", ""},
+		{"toolsets", "all"},
+	} {
+		f := rootCmd.PersistentFlags().Lookup(spec.name)
+		if f == nil {
+			continue
+		}
+		if err := rootCmd.PersistentFlags().Set(spec.name, spec.def); err != nil {
+			t.Fatalf("failed to reset persistent flag %q: %v", spec.name, err)
+		}
+		f.Changed = false
+	}
+}
+
+// TestToolsFlagAloneDoesNotConflictWithDefaultToolsets verifies that passing
+// only --tools (without --toolsets) does not trigger the conflict Fatal in
+// getToolsetsFromCmd.
+//
+// The conflict check at cmd/terraform-mcp-server/main.go reads the --toolsets
+// value with GetString and treats anything non-empty / non-"default" as
+// "explicitly set". Because --toolsets is declared with default "all", that
+// check fires even when the operator did not pass --toolsets at all, and
+// `./terraform-mcp-server --tools=X` exits with
+//
+//	Cannot use both --tools and --toolsets flags together
+//
+// The correct check is "did the user pass --toolsets?", which pflag exposes
+// directly via flag.Changed.
+func TestToolsFlagAloneDoesNotConflictWithDefaultToolsets(t *testing.T) {
+	origRun := rootCmd.Run
+	origArgs := os.Args
+	t.Cleanup(func() {
+		rootCmd.Run = origRun
+		os.Args = origArgs
+		restoreToolsAndToolsetsFlags(t)
+	})
+
+	os.Args = []string{
+		"terraform-mcp-server",
+		"--tools=search_providers,get_provider_details",
+	}
+
+	logger, fatalCalled := fatalRecordingLogger()
+	var captured []string
+	rootCmd.Run = func(cmd *cobra.Command, _ []string) {
+		captured = getToolsetsFromCmd(cmd, logger)
+	}
+
+	require.NoError(t, rootCmd.Execute())
+
+	assert.False(t, *fatalCalled,
+		"passing only --tools (with --toolsets at its declared 'all' default) must not "+
+			"trigger the --tools/--toolsets conflict Fatal")
+	assert.Contains(t, captured, "search_providers")
+	assert.Contains(t, captured, "get_provider_details")
+}
+
+// TestToolsAndToolsetsTogetherTriggersFatal locks the negative behavior down:
+// when the operator explicitly passes both --tools and --toolsets, the
+// conflict Fatal must still fire. This is the behavior the original check
+// intended; the fix narrows the trigger to "user explicitly set --toolsets"
+// without removing it.
+func TestToolsAndToolsetsTogetherTriggersFatal(t *testing.T) {
+	origRun := rootCmd.Run
+	origArgs := os.Args
+	t.Cleanup(func() {
+		rootCmd.Run = origRun
+		os.Args = origArgs
+		restoreToolsAndToolsetsFlags(t)
+	})
+
+	os.Args = []string{
+		"terraform-mcp-server",
+		"--tools=search_providers",
+		"--toolsets=registry",
+	}
+
+	logger, fatalCalled := fatalRecordingLogger()
+	rootCmd.Run = func(cmd *cobra.Command, _ []string) {
+		_ = getToolsetsFromCmd(cmd, logger)
+	}
+
+	require.NoError(t, rootCmd.Execute())
+
+	assert.True(t, *fatalCalled,
+		"passing both --tools and --toolsets explicitly must still trigger the conflict Fatal")
+}


### PR DESCRIPTION
Fixes #379.

## Summary

`getToolsetsFromCmd` guards against passing both `--tools` and `--toolsets` at the same time. It does so by reading the `--toolsets` value with `GetString` and rejecting any value that is non-empty and not `"default"`:

```go
toolsetsFlag, _ := cmd.Flags().GetString("toolsets")
if toolsetsFlag == "" {
    toolsetsFlag, _ = cmd.Root().PersistentFlags().GetString("toolsets")
}
if toolsetsFlag != "" && toolsetsFlag != "default" {
    logger.Fatal("Cannot use both --tools and --toolsets flags together")
}
```

`--toolsets` is declared with default `"all"` in `init.go`. `GetString` returns the default when the operator has not passed the flag, so the check fires every time someone passes only `--tools`:

```
$ ./terraform-mcp-server --tools=search_providers
time="..." level=fatal msg="Cannot use both --tools and --toolsets flags together"
```

## Change

Replace the value-based check with a `pflag.Flag.Changed` check. `Changed` is `true` only when the operator set the flag on the command line, which is precisely the condition the original check was reaching for. The intent (forbid passing both flags) is preserved; the false positive on the declared default goes away.

Diff is +8 / -5 in `main.go` and a new test file.

## Verification

```bash
$ go build -o ./terraform-mcp-server ./cmd/terraform-mcp-server/

# Before
$ ./terraform-mcp-server stdio --tools=search_providers
level=fatal msg="Cannot use both --tools and --toolsets flags together"
# exit 1

# After
$ ./terraform-mcp-server stdio --tools=search_providers,get_provider_details
level=info msg="Enabled individual tools: [search_providers get_provider_details]"
Terraform MCP Server running on stdio
```

`go test ./...` passes (578/578).

## Test plan

* [x] `TestToolsFlagAloneDoesNotConflictWithDefaultToolsets` — passes only `--tools`, asserts the Fatal is not triggered (uses a logrus `ExitFunc` override so a Fatal call would be observable without exiting the test binary).
* [x] `TestToolsAndToolsetsTogetherTriggersFatal` — locks the negative behavior down: passing both flags explicitly must still Fatal.
* [x] `go test ./...` — 578 pass.
* [x] Manual repro: `./terraform-mcp-server stdio --tools=search_providers` now starts cleanly.