### PR TITLE
feat: add organization allowlist gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ IMPROVEMENTS
 * Run as a non-root user for Kubernetes compatibility. [356] https://github.com/hashicorp/terraform-mcp-server/pull/356
 * Bump go version to 1.26.4 [383](https://github.com/hashicorp/terraform-mcp-server/pull/383)
 * Add support for X-Forwarded-For header [367](https://github.com/hashicorp/terraform-mcp-server/pull/367)
+* Add an organization allowlist gate for StreamableHTTP deployments [386](https://github.com/hashicorp/terraform-mcp-server/pull/386)
 
 FIXES
 

--- a/README.md
+++ b/README.md
@@ -577,7 +577,7 @@ export MCP_SESSION_MODE=stateless
 
 When running the MCP server centrally (StreamableHTTP mode) for multiple users, each user can pass their own Terraform token via HTTP headers for RBAC enforcement. This allows a single server instance to serve multiple users with different permissions.
 
-When `MCP_ORGANIZATION_ALLOWLIST` or `--organization-allowlist` is configured, the allowlist must be a CSV list of HCP Terraform organization names. The server requires `Authorization: Bearer <token>` and rejects requests unless that token can access at least one organization in the CSV allowlist. Organization name matching is case-insensitive.
+When `MCP_ORGANIZATION_ALLOWLIST` or `--organization-allowlist` is configured, the allowlist must be a CSV list of HCP Terraform organization names. The server requires `Authorization: Bearer <token>` and rejects requests unless that token can access at least one organization in the CSV allowlist. Organization name matching is case-insensitive. If the configured CSV value parses to zero organization names, the server exits with a malformed organization allowlist error.
 
 ### Supported Headers
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ automation and interaction capabilities for Infrastructure as Code (IaC) develop
 | `MCP_TLS_KEY_FILE` |  Path to TLS key file, required for non-localhost deployment (e.g. `/path/to/key.pem`)| `""` (empty) |
 | `MCP_RATE_LIMIT_GLOBAL` | Global rate limit (format: `rps:burst`) | `10:20` |
 | `MCP_RATE_LIMIT_SESSION` | Per-session rate limit (format: `rps:burst`) | `5:10` |
+| `MCP_ORGANIZATION_ALLOWLIST` | CSV list of HCP Terraform organization names allowed to access the HTTP server | `""` (empty) |
 | `ENABLE_TF_OPERATIONS` | Enable tools that require explicit approval | `false` |
 | `OTEL_METRICS_ENABLED` | Enable tools and server metrics using otel | `false` |
 | `OTEL_METRICS_SERVICE_VERSION` | Version of the terraform-mcp-server sending metrics, which is used to set metric attributes. It also helps track metrics across different deployments | `latest` |
@@ -60,7 +61,7 @@ automation and interaction capabilities for Infrastructure as Code (IaC) develop
 terraform-mcp-server stdio [--log-file /path/to/log] [--log-level info] [--log-format text] [--toolsets <toolsets>] [--tools <tools>]
 
 # StreamableHTTP mode
-terraform-mcp-server streamable-http [--transport-port 8080] [--transport-host 127.0.0.1] [--mcp-endpoint /mcp] [--log-file /path/to/log] [--log-level info] [--log-format text] [--toolsets <toolsets>] [--tools <tools>]
+terraform-mcp-server streamable-http [--transport-port 8080] [--transport-host 127.0.0.1] [--mcp-endpoint /mcp] [--organization-allowlist <orgs-csv>] [--log-file /path/to/log] [--log-level info] [--log-format text] [--toolsets <toolsets>] [--tools <tools>]
 ```
 
 ## Instructions
@@ -558,6 +559,7 @@ Modern HTTP-based transport supporting both direct HTTP requests and Server-Sent
 - **Endpoint**: `http://{hostname}:8080/mcp`
 - **Health Check**: `http://{hostname}:8080/health`
 - **Environment Configuration**: Set `TRANSPORT_MODE=http` or `TRANSPORT_PORT=8080` to enable
+- **Organization Allowlist**: Set `MCP_ORGANIZATION_ALLOWLIST` or `--organization-allowlist` to a CSV list of allowed HCP Terraform organization names
 
 ## Session Modes
 
@@ -574,6 +576,8 @@ export MCP_SESSION_MODE=stateless
 ## Token Passthrough for Centralized Deployments
 
 When running the MCP server centrally (StreamableHTTP mode) for multiple users, each user can pass their own Terraform token via HTTP headers for RBAC enforcement. This allows a single server instance to serve multiple users with different permissions.
+
+When `MCP_ORGANIZATION_ALLOWLIST` or `--organization-allowlist` is configured, the allowlist must be a CSV list of HCP Terraform organization names. The server requires `Authorization: Bearer <token>` and rejects requests unless that token can access at least one organization in the CSV allowlist. Organization name matching is case-insensitive.
 
 ### Supported Headers
 
@@ -618,6 +622,7 @@ docker run -p 8080:8080 \
   -e MCP_TLS_CERT_FILE=/certs/server.pem \
   -e MCP_TLS_KEY_FILE=/certs/server-key.pem \
   -e MCP_ALLOWED_ORIGINS=https://ide.company.com \
+  -e MCP_ORGANIZATION_ALLOWLIST=team-alpha,team-beta \
   -v /path/to/certs:/certs \
   hashicorp/terraform-mcp-server:1.0.0
 ```

--- a/cmd/terraform-mcp-server/config_test.go
+++ b/cmd/terraform-mcp-server/config_test.go
@@ -182,6 +182,57 @@ func TestGetHeartbeatInterval(t *testing.T) {
 	assert.Equal(t, time.Duration(0), heartbeat, "Heartbeat interval should be 0 when MCP_HEARTBEAT_INTERVAL is set to an invalid value")
 }
 
+func TestGetOrganizationAllowlist(t *testing.T) {
+	origAllowlist := os.Getenv("MCP_ORGANIZATION_ALLOWLIST")
+	defer func() {
+		os.Setenv("MCP_ORGANIZATION_ALLOWLIST", origAllowlist)
+	}()
+
+	tests := []struct {
+		name      string
+		envValue  string
+		flagValue string
+		expected  []string
+	}{
+		{
+			name:      "env var takes precedence over flag",
+			envValue:  "env-alpha, env-beta",
+			flagValue: "flag-alpha",
+			expected:  []string{"env-alpha", "env-beta"},
+		},
+		{
+			name:      "flag used when env not set",
+			flagValue: "flag-alpha, flag-beta",
+			expected:  []string{"flag-alpha", "flag-beta"},
+		},
+		{
+			name:     "empty when neither set",
+			expected: nil,
+		},
+		{
+			name:      "blank CSV fields disable allowlist",
+			flagValue: " , ,, ",
+			expected:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue != "" {
+				os.Setenv("MCP_ORGANIZATION_ALLOWLIST", tt.envValue)
+			} else {
+				os.Unsetenv("MCP_ORGANIZATION_ALLOWLIST")
+			}
+
+			cmd := &cobra.Command{}
+			cmd.Flags().String("organization-allowlist", tt.flagValue, "test flag")
+
+			result := getOrganizationAllowlist(cmd)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func TestGetLogLevel(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/cmd/terraform-mcp-server/config_test.go
+++ b/cmd/terraform-mcp-server/config_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/terraform-mcp-server/pkg/client"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -183,25 +184,35 @@ func TestGetHeartbeatInterval(t *testing.T) {
 }
 
 func TestGetOrganizationAllowlist(t *testing.T) {
-	origAllowlist := os.Getenv("MCP_ORGANIZATION_ALLOWLIST")
+	origAllowlist, hadOrigAllowlist := os.LookupEnv("MCP_ORGANIZATION_ALLOWLIST")
 	defer func() {
-		os.Setenv("MCP_ORGANIZATION_ALLOWLIST", origAllowlist)
+		if hadOrigAllowlist {
+			os.Setenv("MCP_ORGANIZATION_ALLOWLIST", origAllowlist)
+		} else {
+			os.Unsetenv("MCP_ORGANIZATION_ALLOWLIST")
+		}
 	}()
 
 	tests := []struct {
-		name      string
-		envValue  string
-		flagValue string
-		expected  []string
+		name        string
+		envSet      bool
+		envValue    string
+		flagSet     bool
+		flagValue   string
+		expected    []string
+		expectedErr error
 	}{
 		{
 			name:      "env var takes precedence over flag",
+			envSet:    true,
 			envValue:  "env-alpha, env-beta",
+			flagSet:   true,
 			flagValue: "flag-alpha",
 			expected:  []string{"env-alpha", "env-beta"},
 		},
 		{
 			name:      "flag used when env not set",
+			flagSet:   true,
 			flagValue: "flag-alpha, flag-beta",
 			expected:  []string{"flag-alpha", "flag-beta"},
 		},
@@ -210,25 +221,54 @@ func TestGetOrganizationAllowlist(t *testing.T) {
 			expected: nil,
 		},
 		{
-			name:      "blank CSV fields disable allowlist",
-			flagValue: " , ,, ",
-			expected:  nil,
+			name:        "blank CSV flag is malformed",
+			flagSet:     true,
+			flagValue:   " , ,, ",
+			expectedErr: client.ErrMalformedOrganizationAllowlist,
+		},
+		{
+			name:        "empty CSV flag is malformed",
+			flagSet:     true,
+			flagValue:   "",
+			expectedErr: client.ErrMalformedOrganizationAllowlist,
+		},
+		{
+			name:        "blank CSV env var is malformed",
+			envSet:      true,
+			envValue:    " , ,, ",
+			flagSet:     true,
+			flagValue:   "flag-alpha",
+			expectedErr: client.ErrMalformedOrganizationAllowlist,
+		},
+		{
+			name:        "empty CSV env var is malformed",
+			envSet:      true,
+			envValue:    "",
+			expectedErr: client.ErrMalformedOrganizationAllowlist,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.envValue != "" {
+			if tt.envSet {
 				os.Setenv("MCP_ORGANIZATION_ALLOWLIST", tt.envValue)
 			} else {
 				os.Unsetenv("MCP_ORGANIZATION_ALLOWLIST")
 			}
 
 			cmd := &cobra.Command{}
-			cmd.Flags().String("organization-allowlist", tt.flagValue, "test flag")
+			cmd.Flags().String("organization-allowlist", "", "test flag")
+			if tt.flagSet {
+				assert.NoError(t, cmd.Flags().Set("organization-allowlist", tt.flagValue))
+			}
 
-			result := getOrganizationAllowlist(cmd)
+			result, err := getOrganizationAllowlist(cmd)
 			assert.Equal(t, tt.expected, result)
+			if tt.expectedErr != nil {
+				assert.ErrorIs(t, err, tt.expectedErr)
+			} else {
+				assert.NoError(t, err)
+			}
 		})
 	}
 }

--- a/cmd/terraform-mcp-server/init.go
+++ b/cmd/terraform-mcp-server/init.go
@@ -95,7 +95,10 @@ var (
 			}
 
 			enabledToolsets := getToolsetsFromCmd(cmd.Root(), logger)
-			organizationAllowlist := getOrganizationAllowlist(cmd)
+			organizationAllowlist, err := getOrganizationAllowlist(cmd)
+			if err != nil {
+				stdlog.Fatal(err)
+			}
 			stdlog.Printf("Starting StreamableHTTP server with host: %s, port: %s, endpoint: %s, heartbeatInterval: %v, enabledToolsets: %v, organizationAllowlistConfigured: %t, organizationAllowlistCount: %d", host, port, endpointPath, heartbeatInterval, enabledToolsets, len(organizationAllowlist) > 0, len(organizationAllowlist))
 			metricsConfig, shutdownMetrics := setupMetrics(logger)
 			defer shutdownMetrics()

--- a/cmd/terraform-mcp-server/init.go
+++ b/cmd/terraform-mcp-server/init.go
@@ -95,11 +95,12 @@ var (
 			}
 
 			enabledToolsets := getToolsetsFromCmd(cmd.Root(), logger)
-			stdlog.Printf("Starting StreamableHTTP server with host: %s, port: %s, endpoint: %s, heartbeatInterval: %v, enabledToolsets: %v", host, port, endpointPath, heartbeatInterval, enabledToolsets)
+			organizationAllowlist := getOrganizationAllowlist(cmd)
+			stdlog.Printf("Starting StreamableHTTP server with host: %s, port: %s, endpoint: %s, heartbeatInterval: %v, enabledToolsets: %v, organizationAllowlistConfigured: %t, organizationAllowlistCount: %d", host, port, endpointPath, heartbeatInterval, enabledToolsets, len(organizationAllowlist) > 0, len(organizationAllowlist))
 			metricsConfig, shutdownMetrics := setupMetrics(logger)
 			defer shutdownMetrics()
 
-			if err := runHTTPServer(logger, host, port, endpointPath, heartbeatInterval, enabledToolsets, metricsConfig); err != nil {
+			if err := runHTTPServer(logger, host, port, endpointPath, heartbeatInterval, enabledToolsets, metricsConfig, organizationAllowlist); err != nil {
 				stdlog.Fatal("failed to run streamableHTTP server:", err)
 			}
 		},
@@ -132,12 +133,14 @@ func init() {
 	streamableHTTPCmd.Flags().StringP("transport-port", "p", "8080", "Port to listen on")
 	streamableHTTPCmd.Flags().Duration("heartbeat-interval", 0, "Heartbeat interval for HTTP connections (e.g., 30s). 0 to disable")
 	streamableHTTPCmd.Flags().String("mcp-endpoint", "/mcp", "Path for streamable HTTP endpoint")
+	streamableHTTPCmd.Flags().String("organization-allowlist", "", "Comma-separated list of HCP Terraform organization names allowed to access the HTTP server")
 
 	// Add the same flags to the alias command for backward compatibility
 	httpCmdAlias.Flags().String("transport-host", "127.0.0.1", "Host to bind to")
 	httpCmdAlias.Flags().StringP("transport-port", "p", "8080", "Port to listen on")
 	httpCmdAlias.Flags().String("mcp-endpoint", "/mcp", "Path for streamable HTTP endpoint")
 	httpCmdAlias.Flags().Duration("heartbeat-interval", 0, "Heartbeat interval for HTTP connections (e.g., 30s). 0 to disable")
+	httpCmdAlias.Flags().String("organization-allowlist", "", "Comma-separated list of HCP Terraform organization names allowed to access the HTTP server")
 
 	rootCmd.AddCommand(stdioCmd)
 	rootCmd.AddCommand(streamableHTTPCmd)
@@ -264,7 +267,7 @@ func serverInit(ctx context.Context, hcServer *server.MCPServer, logger *log.Log
 	return nil
 }
 
-func streamableHTTPServerInit(ctx context.Context, hcServer *server.MCPServer, logger *log.Logger, host string, port string, endpointPath string, heartbeatInterval time.Duration) error {
+func streamableHTTPServerInit(ctx context.Context, hcServer *server.MCPServer, logger *log.Logger, host string, port string, endpointPath string, heartbeatInterval time.Duration, organizationAllowlist []string) error {
 	// Ensure endpoint path starts with /
 	endpointPath = path.Join("/", endpointPath)
 	var handler http.Handler
@@ -315,13 +318,12 @@ func streamableHTTPServerInit(ctx context.Context, hcServer *server.MCPServer, l
 		logger.Warnf("CORS validation is disabled. This is not recommended for production.")
 	}
 
-	// Create a security wrapper around the streamable server
-	streamableServer := client.NewSecurityHandler(baseStreamableServer, corsConfig.AllowedOrigins, corsConfig.Mode, logger)
-
 	mux := http.NewServeMux()
 
 	// Apply middleware
+	streamableServer := client.OrganizationAllowlistMiddleware(organizationAllowlist, logger)(baseStreamableServer)
 	streamableServer = client.TerraformContextMiddleware(logger)(streamableServer)
+	streamableServer = client.NewSecurityHandler(streamableServer, corsConfig.AllowedOrigins, corsConfig.Mode, logger)
 
 	// Handle the /mcp endpoint with the streamable server (with security wrapper)
 	mux.Handle(endpointPath, streamableServer)

--- a/cmd/terraform-mcp-server/main.go
+++ b/cmd/terraform-mcp-server/main.go
@@ -294,7 +294,10 @@ func main() {
 		endpointPath := getEndpointPath(nil)
 		enabledToolsets := getToolsetsFromCmd(rootCmd, logger)
 		heartbeatInterval := getHeartbeatInterval()
-		organizationAllowlist := getOrganizationAllowlist(rootCmd)
+		organizationAllowlist, err := getOrganizationAllowlist(rootCmd)
+		if err != nil {
+			stdlog.Fatal(err)
+		}
 		if err := runHTTPServer(logger, host, port, endpointPath, heartbeatInterval, enabledToolsets, metricsConfig, organizationAllowlist); err != nil {
 			stdlog.Fatal("failed to run StreamableHTTP server:", err)
 		}
@@ -374,18 +377,22 @@ func getHeartbeatInterval() time.Duration {
 	return 0
 }
 
-func getOrganizationAllowlist(cmd *cobra.Command) []string {
-	if envAllowlist := os.Getenv(client.OrganizationAllowlistEnv); envAllowlist != "" {
+func getOrganizationAllowlist(cmd *cobra.Command) ([]string, error) {
+	if envAllowlist, ok := os.LookupEnv(client.OrganizationAllowlistEnv); ok {
 		return client.ParseOrganizationAllowlistCSV(envAllowlist)
 	}
 
 	if cmd != nil {
-		if allowlist, err := cmd.Flags().GetString("organization-allowlist"); err == nil && allowlist != "" {
+		if cmd.Flags().Changed("organization-allowlist") {
+			allowlist, err := cmd.Flags().GetString("organization-allowlist")
+			if err != nil {
+				return nil, err
+			}
 			return client.ParseOrganizationAllowlistCSV(allowlist)
 		}
 	}
 
-	return nil
+	return nil, nil
 }
 
 func setupMetrics(logger *log.Logger) (client.MetricsConfig, func()) {

--- a/cmd/terraform-mcp-server/main.go
+++ b/cmd/terraform-mcp-server/main.go
@@ -36,7 +36,7 @@ import (
 var instructions string
 var sessionClientInfo sync.Map // map[string]client.ClientInfo
 
-func runHTTPServer(logger *log.Logger, host string, port string, endpointPath string, heartbeatInterval time.Duration, enabledToolsets []string, metricsConfig client.MetricsConfig) error {
+func runHTTPServer(logger *log.Logger, host string, port string, endpointPath string, heartbeatInterval time.Duration, enabledToolsets []string, metricsConfig client.MetricsConfig, organizationAllowlist []string) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
@@ -74,7 +74,7 @@ func runHTTPServer(logger *log.Logger, host string, port string, endpointPath st
 	hcServer := NewServer(version.Version, logger, enabledToolsets, opts...)
 	registerToolsAndResources(hcServer, logger, enabledToolsets)
 
-	return streamableHTTPServerInit(ctx, hcServer, logger, host, port, endpointPath, heartbeatInterval)
+	return streamableHTTPServerInit(ctx, hcServer, logger, host, port, endpointPath, heartbeatInterval, organizationAllowlist)
 }
 
 func attachMetricsHooks(hooks *server.Hooks, metricsConfig client.MetricsConfig, logger *log.Logger) {
@@ -294,7 +294,8 @@ func main() {
 		endpointPath := getEndpointPath(nil)
 		enabledToolsets := getToolsetsFromCmd(rootCmd, logger)
 		heartbeatInterval := getHeartbeatInterval()
-		if err := runHTTPServer(logger, host, port, endpointPath, heartbeatInterval, enabledToolsets, metricsConfig); err != nil {
+		organizationAllowlist := getOrganizationAllowlist(rootCmd)
+		if err := runHTTPServer(logger, host, port, endpointPath, heartbeatInterval, enabledToolsets, metricsConfig, organizationAllowlist); err != nil {
 			stdlog.Fatal("failed to run StreamableHTTP server:", err)
 		}
 		return
@@ -371,6 +372,20 @@ func getHeartbeatInterval() time.Duration {
 		}
 	}
 	return 0
+}
+
+func getOrganizationAllowlist(cmd *cobra.Command) []string {
+	if envAllowlist := os.Getenv(client.OrganizationAllowlistEnv); envAllowlist != "" {
+		return client.ParseOrganizationAllowlistCSV(envAllowlist)
+	}
+
+	if cmd != nil {
+		if allowlist, err := cmd.Flags().GetString("organization-allowlist"); err == nil && allowlist != "" {
+			return client.ParseOrganizationAllowlistCSV(allowlist)
+		}
+	}
+
+	return nil
 }
 
 func setupMetrics(logger *log.Logger) (client.MetricsConfig, func()) {

--- a/pkg/client/middleware.go
+++ b/pkg/client/middleware.go
@@ -191,13 +191,13 @@ func OrganizationAllowlistMiddleware(allowlist []string, logger *log.Logger) fun
 					http.Error(w, "Terraform token is unauthorized", http.StatusUnauthorized)
 					return
 				}
-				logger.WithError(err).Error("Failed to list Terraform organizations for allowlist validation")
-				http.Error(w, "Failed to validate organization allowlist", http.StatusBadGateway)
+				logger.WithError(err).Error("Failed to validate organization membership for supplied authorization token")
+				http.Error(w, "Failed to validate organization membership for supplied authorization token", http.StatusBadGateway)
 				return
 			}
 			if !allowed {
-				logger.Warn("Rejecting request: Terraform token cannot access an allowlisted organization")
-				http.Error(w, "Terraform token cannot access an allowlisted organization", http.StatusForbidden)
+				logger.Warn("Rejecting request: Supplied authorization token does not have access to any organizations allowed by this server")
+				http.Error(w, "Supplied authorization token does not have access to any organizations allowed by this server", http.StatusForbidden)
 				return
 			}
 

--- a/pkg/client/middleware.go
+++ b/pkg/client/middleware.go
@@ -164,6 +164,12 @@ func OrganizationAllowlistMiddleware(allowlist []string, logger *log.Logger) fun
 				return
 			}
 
+			if r.Header.Get(TerraformAddress) != "" || r.URL.Query().Get(TerraformAddress) != "" {
+				logger.Warn("Rejecting request: Terraform address override is not allowed when organization allowlist is configured")
+				http.Error(w, "Cannot specify Terraform address when organization allowlist is configured", http.StatusForbidden)
+				return
+			}
+
 			token := strings.TrimSpace(getTokenFromAuthHeader(r))
 			if token == "" {
 				logger.Warn("Rejecting request: organization allowlist requires Authorization bearer token")
@@ -201,11 +207,7 @@ func OrganizationAllowlistMiddleware(allowlist []string, logger *log.Logger) fun
 }
 
 func organizationListerForRequest(ctx context.Context, token string, logger *log.Logger) (organizationLister, error) {
-	terraformAddress, ok := ctx.Value(contextKey(TerraformAddress)).(string)
-	if !ok || terraformAddress == "" {
-		terraformAddress = utils.GetEnv(TerraformAddress, DefaultTerraformAddress)
-	}
-
+	terraformAddress := utils.GetEnv(TerraformAddress, DefaultTerraformAddress)
 	clientIP, _ := ctx.Value(contextKey(ClientIPKey)).(string)
 	tfeClient, err := NewTfeClientForToken(terraformAddress, parseTerraformSkipTLSVerify(ctx), token, clientIP, logger)
 	if err != nil {

--- a/pkg/client/middleware.go
+++ b/pkg/client/middleware.go
@@ -5,19 +5,38 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
 	"strings"
 
+	"github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-mcp-server/pkg/utils"
 	log "github.com/sirupsen/logrus"
 )
+
+const OrganizationAllowlistEnv = "MCP_ORGANIZATION_ALLOWLIST"
 
 // CORSConfig holds CORS configuration
 type CORSConfig struct {
 	AllowedOrigins []string
 	Mode           string // "strict", "development", "disabled"
+}
+
+// ParseOrganizationAllowlistCSV parses a CSV list of HCP Terraform organization names.
+func ParseOrganizationAllowlistCSV(allowlistCSV string) []string {
+	var allowlist []string
+	for _, organizationName := range strings.Split(allowlistCSV, ",") {
+		organizationName = strings.TrimSpace(organizationName)
+		if organizationName != "" {
+			allowlist = append(allowlist, strings.ToLower(organizationName))
+		}
+	}
+	if len(allowlist) == 0 {
+		return nil
+	}
+	return allowlist
 }
 
 // LoadCORSConfigFromEnv loads CORS configuration from environment variables
@@ -121,6 +140,109 @@ func NewSecurityHandler(handler http.Handler, allowedOrigins []string, corsMode 
 		allowedOrigins: allowedOrigins,
 		corsMode:       corsMode,
 		logger:         logger,
+	}
+}
+
+type organizationLister interface {
+	List(ctx context.Context, options *tfe.OrganizationListOptions) (*tfe.OrganizationList, error)
+}
+
+// OrganizationAllowlistMiddleware rejects HTTP requests whose bearer token cannot access an allowlisted organization.
+func OrganizationAllowlistMiddleware(allowlist []string, logger *log.Logger) func(http.Handler) http.Handler {
+	allowedOrganizations := make(map[string]struct{}, len(allowlist))
+	for _, organizationName := range allowlist {
+		organizationName = strings.TrimSpace(strings.ToLower(organizationName))
+		if organizationName != "" {
+			allowedOrganizations[organizationName] = struct{}{}
+		}
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if len(allowedOrganizations) == 0 {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			token := strings.TrimSpace(getTokenFromAuthHeader(r))
+			if token == "" {
+				logger.Warn("Rejecting request: organization allowlist requires Authorization bearer token")
+				http.Error(w, "Authorization bearer token is required", http.StatusUnauthorized)
+				return
+			}
+
+			lister, err := organizationListerForRequest(r.Context(), token, logger)
+			if err != nil {
+				logger.WithError(err).Error("Failed to initialize organization allowlist client")
+				http.Error(w, "Failed to validate organization allowlist", http.StatusBadGateway)
+				return
+			}
+
+			allowed, err := tokenHasAllowedOrganization(r.Context(), lister, allowedOrganizations)
+			if err != nil {
+				if errors.Is(err, tfe.ErrUnauthorized) {
+					logger.Warn("Rejecting request: Terraform token is unauthorized")
+					http.Error(w, "Terraform token is unauthorized", http.StatusUnauthorized)
+					return
+				}
+				logger.WithError(err).Error("Failed to list Terraform organizations for allowlist validation")
+				http.Error(w, "Failed to validate organization allowlist", http.StatusBadGateway)
+				return
+			}
+			if !allowed {
+				logger.Warn("Rejecting request: Terraform token cannot access an allowlisted organization")
+				http.Error(w, "Terraform token cannot access an allowlisted organization", http.StatusForbidden)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func organizationListerForRequest(ctx context.Context, token string, logger *log.Logger) (organizationLister, error) {
+	terraformAddress, ok := ctx.Value(contextKey(TerraformAddress)).(string)
+	if !ok || terraformAddress == "" {
+		terraformAddress = utils.GetEnv(TerraformAddress, DefaultTerraformAddress)
+	}
+
+	clientIP, _ := ctx.Value(contextKey(ClientIPKey)).(string)
+	tfeClient, err := NewTfeClientForToken(terraformAddress, parseTerraformSkipTLSVerify(ctx), token, clientIP, logger)
+	if err != nil {
+		return nil, err
+	}
+	return tfeClient.Organizations, nil
+}
+
+func tokenHasAllowedOrganization(ctx context.Context, lister organizationLister, allowedOrganizations map[string]struct{}) (bool, error) {
+	pageNumber := 1
+	for {
+		orgs, err := lister.List(ctx, &tfe.OrganizationListOptions{
+			ListOptions: tfe.ListOptions{
+				PageNumber: pageNumber,
+				PageSize:   100,
+			},
+		})
+		if err != nil {
+			return false, err
+		}
+		if orgs == nil {
+			return false, nil
+		}
+
+		for _, org := range orgs.Items {
+			if org == nil {
+				continue
+			}
+			if _, ok := allowedOrganizations[strings.ToLower(org.Name)]; ok {
+				return true, nil
+			}
+		}
+
+		if orgs.Pagination == nil || orgs.NextPage == 0 {
+			return false, nil
+		}
+		pageNumber = orgs.NextPage
 	}
 }
 

--- a/pkg/client/middleware.go
+++ b/pkg/client/middleware.go
@@ -18,6 +18,8 @@ import (
 
 const OrganizationAllowlistEnv = "MCP_ORGANIZATION_ALLOWLIST"
 
+var ErrMalformedOrganizationAllowlist = errors.New("malformed organization allowlist")
+
 // CORSConfig holds CORS configuration
 type CORSConfig struct {
 	AllowedOrigins []string
@@ -25,7 +27,7 @@ type CORSConfig struct {
 }
 
 // ParseOrganizationAllowlistCSV parses a CSV list of HCP Terraform organization names.
-func ParseOrganizationAllowlistCSV(allowlistCSV string) []string {
+func ParseOrganizationAllowlistCSV(allowlistCSV string) ([]string, error) {
 	var allowlist []string
 	for _, organizationName := range strings.Split(allowlistCSV, ",") {
 		organizationName = strings.TrimSpace(organizationName)
@@ -34,9 +36,9 @@ func ParseOrganizationAllowlistCSV(allowlistCSV string) []string {
 		}
 	}
 	if len(allowlist) == 0 {
-		return nil
+		return nil, ErrMalformedOrganizationAllowlist
 	}
-	return allowlist
+	return allowlist, nil
 }
 
 // LoadCORSConfigFromEnv loads CORS configuration from environment variables

--- a/pkg/client/middleware_test.go
+++ b/pkg/client/middleware_test.go
@@ -387,6 +387,9 @@ func TestOrganizationAllowlistMiddleware(t *testing.T) {
 		allowlist        []string
 		authHeader       string
 		tfeTokenHeader   string
+		headerValues     map[string]string
+		queryValues      map[string]string
+		envValues        map[string]string
 		contextValues    map[string]string
 		expectedStatus   int
 		expectedNextCall bool
@@ -415,10 +418,28 @@ func TestOrganizationAllowlistMiddleware(t *testing.T) {
 			expectedStatus: http.StatusUnauthorized,
 		},
 		{
+			name:       "TFE_ADDRESS header rejected when allowlist configured",
+			allowlist:  []string{"alpha"},
+			authHeader: "Bearer user-token",
+			headerValues: map[string]string{
+				TerraformAddress: "https://attacker.example.com",
+			},
+			expectedStatus: http.StatusForbidden,
+		},
+		{
+			name:       "TFE_ADDRESS query parameter rejected when allowlist configured",
+			allowlist:  []string{"alpha"},
+			authHeader: "Bearer user-token",
+			queryValues: map[string]string{
+				TerraformAddress: "https://attacker.example.com",
+			},
+			expectedStatus: http.StatusForbidden,
+		},
+		{
 			name:       "client initialization error rejected as bad gateway",
 			allowlist:  []string{"alpha"},
 			authHeader: "Bearer user-token",
-			contextValues: map[string]string{
+			envValues: map[string]string{
 				TerraformAddress: "://bad-address",
 			},
 			expectedStatus: http.StatusBadGateway,
@@ -427,6 +448,9 @@ func TestOrganizationAllowlistMiddleware(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			for key, value := range tt.envValues {
+				t.Setenv(key, value)
+			}
 			nextCalled := false
 			mockHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				nextCalled = true
@@ -447,6 +471,14 @@ func TestOrganizationAllowlistMiddleware(t *testing.T) {
 			if tt.tfeTokenHeader != "" {
 				req.Header.Set(TerraformToken, tt.tfeTokenHeader)
 			}
+			for key, value := range tt.headerValues {
+				req.Header.Set(key, value)
+			}
+			q := req.URL.Query()
+			for key, value := range tt.queryValues {
+				q.Set(key, value)
+			}
+			req.URL.RawQuery = q.Encode()
 
 			rr := httptest.NewRecorder()
 			handler.ServeHTTP(rr, req)
@@ -536,6 +568,18 @@ func TestTokenHasAllowedOrganization(t *testing.T) {
 			assert.Equal(t, tt.expectedPages, tt.lister.pageNumbers)
 		})
 	}
+}
+
+func TestOrganizationListerForRequestIgnoresContextAddress(t *testing.T) {
+	logger := log.New()
+	logger.SetLevel(log.ErrorLevel)
+
+	ctx := context.WithValue(context.Background(), contextKey(TerraformAddress), "://bad-address")
+
+	lister, err := organizationListerForRequest(ctx, "user-token", logger)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, lister)
 }
 
 // TestGetTokenFromAuthHeader tests the helper function that extracts token from Authorization Bearer header

--- a/pkg/client/middleware_test.go
+++ b/pkg/client/middleware_test.go
@@ -4,6 +4,8 @@
 package client
 
 import (
+	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/go-tfe"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
@@ -138,6 +141,42 @@ func TestLoadCORSConfigFromEnv(t *testing.T) {
 	config = LoadCORSConfigFromEnv()
 	assert.Equal(t, "development", config.Mode)
 	assert.Equal(t, []string{"https://example.com", "https://test.com"}, config.AllowedOrigins)
+}
+
+func TestParseOrganizationAllowlistCSV(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "empty CSV disables allowlist",
+			input:    "",
+			expected: nil,
+		},
+		{
+			name:     "trims spaces and ignores empty fields",
+			input:    " alpha, beta ,, gamma ",
+			expected: []string{"alpha", "beta", "gamma"},
+		},
+		{
+			name:     "normalizes case",
+			input:    "Alpha,alpha,ALPHA",
+			expected: []string{"alpha", "alpha", "alpha"},
+		},
+		{
+			name:     "blank fields only disable allowlist",
+			input:    " , ,, ",
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseOrganizationAllowlistCSV(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
 }
 
 // TestSecurityHandler tests the HTTP handler that applies CORS validation logic
@@ -314,6 +353,189 @@ func TestOptionsRequest(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 	assert.Equal(t, "https://example.com", rr.Header().Get("Access-Control-Allow-Origin"))
 	assert.NotEmpty(t, rr.Header().Get("Access-Control-Allow-Methods"))
+}
+
+type fakeOrganizationLister struct {
+	pages       []*tfe.OrganizationList
+	err         error
+	pageNumbers []int
+}
+
+func (l *fakeOrganizationLister) List(_ context.Context, options *tfe.OrganizationListOptions) (*tfe.OrganizationList, error) {
+	if options != nil {
+		l.pageNumbers = append(l.pageNumbers, options.PageNumber)
+	}
+	if l.err != nil {
+		return nil, l.err
+	}
+	if len(l.pages) == 0 {
+		return &tfe.OrganizationList{}, nil
+	}
+	page := len(l.pageNumbers) - 1
+	if page >= len(l.pages) {
+		return l.pages[len(l.pages)-1], nil
+	}
+	return l.pages[page], nil
+}
+
+func TestOrganizationAllowlistMiddleware(t *testing.T) {
+	logger := log.New()
+	logger.SetLevel(log.ErrorLevel)
+
+	tests := []struct {
+		name             string
+		allowlist        []string
+		authHeader       string
+		tfeTokenHeader   string
+		contextValues    map[string]string
+		expectedStatus   int
+		expectedNextCall bool
+	}{
+		{
+			name:             "empty allowlist disables gate",
+			allowlist:        nil,
+			expectedStatus:   http.StatusOK,
+			expectedNextCall: true,
+		},
+		{
+			name:           "missing Authorization rejected when allowlist configured",
+			allowlist:      []string{"alpha"},
+			expectedStatus: http.StatusUnauthorized,
+		},
+		{
+			name:           "blank bearer token rejected",
+			allowlist:      []string{"alpha"},
+			authHeader:     "Bearer   ",
+			expectedStatus: http.StatusUnauthorized,
+		},
+		{
+			name:           "TFE_TOKEN header does not satisfy allowlist gate",
+			allowlist:      []string{"alpha"},
+			tfeTokenHeader: "header-token",
+			expectedStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "client initialization error rejected as bad gateway",
+			allowlist:  []string{"alpha"},
+			authHeader: "Bearer user-token",
+			contextValues: map[string]string{
+				TerraformAddress: "://bad-address",
+			},
+			expectedStatus: http.StatusBadGateway,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nextCalled := false
+			mockHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				nextCalled = true
+				w.WriteHeader(http.StatusOK)
+			})
+
+			handler := OrganizationAllowlistMiddleware(tt.allowlist, logger)(mockHandler)
+
+			req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+			ctx := req.Context()
+			for key, value := range tt.contextValues {
+				ctx = context.WithValue(ctx, contextKey(key), value)
+			}
+			req = req.WithContext(ctx)
+			if tt.authHeader != "" {
+				req.Header.Set("Authorization", tt.authHeader)
+			}
+			if tt.tfeTokenHeader != "" {
+				req.Header.Set(TerraformToken, tt.tfeTokenHeader)
+			}
+
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			assert.Equal(t, tt.expectedStatus, rr.Code)
+			assert.Equal(t, tt.expectedNextCall, nextCalled)
+		})
+	}
+}
+
+func TestTokenHasAllowedOrganization(t *testing.T) {
+	tests := []struct {
+		name          string
+		allowed       map[string]struct{}
+		lister        *fakeOrganizationLister
+		expected      bool
+		expectedErr   error
+		expectedPages []int
+	}{
+		{
+			name:    "matching organization allowed case insensitively",
+			allowed: map[string]struct{}{"beta": {}},
+			lister: &fakeOrganizationLister{
+				pages: []*tfe.OrganizationList{{
+					Items: []*tfe.Organization{{Name: "alpha"}, {Name: "Beta"}},
+				}},
+			},
+			expected:      true,
+			expectedPages: []int{1},
+		},
+		{
+			name:    "non matching organization rejected",
+			allowed: map[string]struct{}{"beta": {}},
+			lister: &fakeOrganizationLister{
+				pages: []*tfe.OrganizationList{{
+					Items: []*tfe.Organization{{Name: "alpha"}},
+				}},
+			},
+			expected:      false,
+			expectedPages: []int{1},
+		},
+		{
+			name:    "checks paginated organizations",
+			allowed: map[string]struct{}{"gamma": {}},
+			lister: &fakeOrganizationLister{
+				pages: []*tfe.OrganizationList{
+					{
+						Items:      []*tfe.Organization{{Name: "alpha"}},
+						Pagination: &tfe.Pagination{CurrentPage: 1, NextPage: 2, TotalPages: 2},
+					},
+					{
+						Items:      []*tfe.Organization{{Name: "gamma"}},
+						Pagination: &tfe.Pagination{CurrentPage: 2, TotalPages: 2},
+					},
+				},
+			},
+			expected:      true,
+			expectedPages: []int{1, 2},
+		},
+		{
+			name:          "unauthorized organization list returns unauthorized error",
+			allowed:       map[string]struct{}{"alpha": {}},
+			lister:        &fakeOrganizationLister{err: tfe.ErrUnauthorized},
+			expectedErr:   tfe.ErrUnauthorized,
+			expectedPages: []int{1},
+		},
+		{
+			name:          "upstream organization list error is returned",
+			allowed:       map[string]struct{}{"alpha": {}},
+			lister:        &fakeOrganizationLister{err: errors.New("upstream unavailable")},
+			expectedErr:   errors.New("upstream unavailable"),
+			expectedPages: []int{1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			allowed, err := tokenHasAllowedOrganization(context.Background(), tt.lister, tt.allowed)
+
+			assert.Equal(t, tt.expected, allowed)
+			if tt.expectedErr != nil {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErr.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.expectedPages, tt.lister.pageNumbers)
+		})
+	}
 }
 
 // TestGetTokenFromAuthHeader tests the helper function that extracts token from Authorization Bearer header

--- a/pkg/client/middleware_test.go
+++ b/pkg/client/middleware_test.go
@@ -145,14 +145,15 @@ func TestLoadCORSConfigFromEnv(t *testing.T) {
 
 func TestParseOrganizationAllowlistCSV(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    string
-		expected []string
+		name        string
+		input       string
+		expected    []string
+		expectedErr error
 	}{
 		{
-			name:     "empty CSV disables allowlist",
-			input:    "",
-			expected: nil,
+			name:        "empty CSV is malformed",
+			input:       "",
+			expectedErr: ErrMalformedOrganizationAllowlist,
 		},
 		{
 			name:     "trims spaces and ignores empty fields",
@@ -165,16 +166,21 @@ func TestParseOrganizationAllowlistCSV(t *testing.T) {
 			expected: []string{"alpha", "alpha", "alpha"},
 		},
 		{
-			name:     "blank fields only disable allowlist",
-			input:    " , ,, ",
-			expected: nil,
+			name:        "blank fields only are malformed",
+			input:       " , ,, ",
+			expectedErr: ErrMalformedOrganizationAllowlist,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := ParseOrganizationAllowlistCSV(tt.input)
+			result, err := ParseOrganizationAllowlistCSV(tt.input)
 			assert.Equal(t, tt.expected, result)
+			if tt.expectedErr != nil {
+				assert.ErrorIs(t, err, tt.expectedErr)
+			} else {
+				assert.NoError(t, err)
+			}
 		})
 	}
 }

--- a/pkg/client/tfe_client.go
+++ b/pkg/client/tfe_client.go
@@ -29,6 +29,22 @@ var activeTfeClients sync.Map
 
 // NewTfeClient creates a new TFE client for the given session
 func NewTfeClient(sessionId string, terraformAddress string, terraformSkipTLSVerify bool, terraformToken string, clientIP string, logger *log.Logger) (*tfe.Client, error) {
+	client, err := newTfeClient(terraformAddress, terraformSkipTLSVerify, terraformToken, clientIP, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	activeTfeClients.Store(sessionId, client)
+	logger.WithField("session_id", sessionId).Info("Created TFE client")
+	return client, nil
+}
+
+// NewTfeClientForToken creates a TFE client without storing it in session state.
+func NewTfeClientForToken(terraformAddress string, terraformSkipTLSVerify bool, terraformToken string, clientIP string, logger *log.Logger) (*tfe.Client, error) {
+	return newTfeClient(terraformAddress, terraformSkipTLSVerify, terraformToken, clientIP, logger)
+}
+
+func newTfeClient(terraformAddress string, terraformSkipTLSVerify bool, terraformToken string, clientIP string, logger *log.Logger) (*tfe.Client, error) {
 	if terraformToken == "" {
 		logger.Warn("No Terraform token provided, TFE client will not be available")
 		return nil, utils.LogAndReturnError(logger, "required input: no Terraform token provided", nil)
@@ -53,8 +69,6 @@ func NewTfeClient(sessionId string, terraformAddress string, terraformSkipTLSVer
 		return nil, utils.LogAndReturnError(logger, "creating TFE client", err)
 	}
 
-	activeTfeClients.Store(sessionId, client)
-	logger.WithField("session_id", sessionId).Info("Created TFE client")
 	return client, nil
 }
 
@@ -107,7 +121,6 @@ func CreateTfeClientForSession(ctx context.Context, session server.ClientSession
 		}
 		logger.Info("Read TFE_TOKEN from credentials.tfrc.json")
 	}
-
 
 	// Get client IP from context for X-Forwarded-For header
 	clientIP, _ := ctx.Value(contextKey(ClientIPKey)).(string)


### PR DESCRIPTION
## summary
- add an HTTP-only organization allowlist gate configured by `--organization-allowlist` or `MCP_ORGANIZATION_ALLOWLIST`
- require `Authorization: Bearer <token>` when the comma-separated allowlist is configured
- validate bearer-token organization access through paginated TFE organization listing without storing the validation client in session state
- document the new comma-separated allowlist configuration and add table-driven coverage

## validation
- `go test ./pkg/client ./cmd/terraform-mcp-server`
- `go test ./...`