### PR TITLE
Make X-Forwarded-For client IP logic configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 FIXES
 
 * Disable client-supplied `TFE_ADDRESS` in streamable-http mode. Previously a client could override the Terraform address via HTTP header or query parameter, redirecting the server's requests and Authorization bearer token to an arbitrary endpoint. The address must now be configured server-side via the `TFE_ADDRESS` env var. This is a breaking change: clients supplying the address via header or query parameter now receive a 403. [389](https://github.com/hashicorp/terraform-mcp-server/pull/389)
-* Fix http server not serving TLS when configured [391](https://github.com/hashicorp/terraform-mcp-server/pull/391)  
+* Fix http server not serving TLS when configured [391](https://github.com/hashicorp/terraform-mcp-server/pull/391)
+* Make client IP sourcing configurable and fix insecure X-Forwarded-For handling. The server previously trusted the leftmost `X-Forwarded-For` value,had no IPv6 support, and did not validate IPs. Sourcing is now configurable via `MCP_REMOTE_IP_METHOD` (`RemoteAddr`, `X-Real-IP`, `X-Forwarded-For`) and `MCP_XFF_TRUSTED_HOPS`, defaulting to the secure `RemoteAddr`. This is a breaking change: proxy deployments relying on automatic `X-Forwarded-For` forwarding must now set `MCP_REMOTE_IP_METHOD=X-Forwarded-For` and `MCP_XFF_TRUSTED_HOPS`. [388](https://github.com/hashicorp/terraform-mcp-server/pull/388)
+
 
 FEATURES
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ automation and interaction capabilities for Infrastructure as Code (IaC) develop
 | `MCP_RATE_LIMIT_GLOBAL` | Global rate limit (format: `rps:burst`) | `10:20` |
 | `MCP_RATE_LIMIT_SESSION` | Per-session rate limit (format: `rps:burst`) | `5:10` |
 | `MCP_ORGANIZATION_ALLOWLIST` | CSV list of HCP Terraform organization names allowed to access the HTTP server | `""` (empty) |
+| `MCP_FORWARD_CLIENT_IP` | Forward the client IP to HCP Terraform / TFE via `X-Forwarded-For`. Set to `true` to enable | `false` |
+| `MCP_REMOTE_IP_METHOD` | How the client IP is sourced when forwarding is enabled: `RemoteAddr` (direct connection only), `X-Real-IP`, or `X-Forwarded-For` | `RemoteAddr` |
+| `MCP_XFF_TRUSTED_HOPS` | Number of trusted proxy hops counted from the right of the `X-Forwarded-For` chain. Only used when `MCP_REMOTE_IP_METHOD=X-Forwarded-For` | `0` |
 | `ENABLE_TF_OPERATIONS` | Enable tools that require explicit approval | `false` |
 | `OTEL_METRICS_ENABLED` | Enable tools and server metrics using otel | `false` |
 | `OTEL_METRICS_SERVICE_VERSION` | Version of the terraform-mcp-server sending metrics, which is used to set metric attributes. It also helps track metrics across different deployments | `latest` |
@@ -578,6 +581,39 @@ export MCP_SESSION_MODE=stateless
 When running the MCP server centrally (StreamableHTTP mode) for multiple users, each user can pass their own Terraform token via HTTP headers for RBAC enforcement. This allows a single server instance to serve multiple users with different permissions.
 
 When `MCP_ORGANIZATION_ALLOWLIST` or `--organization-allowlist` is configured, the allowlist must be a CSV list of HCP Terraform organization names. The server requires `Authorization: Bearer <token>` and rejects requests unless that token can access at least one organization in the CSV allowlist. Organization name matching is case-insensitive. If the configured CSV value parses to zero organization names, the server exits with a malformed organization allowlist error.
+
+## Client IP Forwarding
+
+When running the MCP server centrally behind a proxy or load balancer, you can forward the originating client's IP to HCP Terraform / TFE via the `X-Forwarded-For` header. This is off by default and must be enabled with `MCP_FORWARD_CLIENT_IP=true`.
+
+When enabled, the server sources the client IP according to `MCP_REMOTE_IP_METHOD`:
+
+| Method | Behavior |
+|--------|----------|
+| `RemoteAddr` (default) | Uses only the address of the direct TCP connection. Ignores `X-Forwarded-For` and `X-Real-IP`. |
+| `X-Real-IP` | Uses the `X-Real-IP` header if it is a valid IP, otherwise falls back to `RemoteAddr`. |
+| `X-Forwarded-For` | Uses the `X-Forwarded-For` chain, selecting the entry `MCP_XFF_TRUSTED_HOPS` positions from the right. Falls back to `RemoteAddr` if the value is missing or invalid. |
+
+### Trust model
+
+`X-Forwarded-For` and `X-Real-IP` are set by clients and intermediary proxies, so they can be spoofed unless a trusted proxy in front of the server overwrites them. For this reason the default is `RemoteAddr`, which trusts only the peer the server is directly connected to. Only enable `X-Real-IP` or `X-Forwarded-For` when the server sits behind a proxy you control that sets these headers.
+
+### Trusted hops
+
+When using `X-Forwarded-For`, `MCP_XFF_TRUSTED_HOPS` is the number of proxies you operate between the server and the internet. Hops are counted from the right of the chain, since each proxy appends the address it received the request from and the rightmost entry is set by the proxy closest to the server. The server skips that many trusted entries and takes the next one to the left.
+
+For example, with `MCP_XFF_TRUSTED_HOPS=1` and a header of `200.1.2.3, 10.1.1.10`, the server selects `200.1.2.3`. With `MCP_XFF_TRUSTED_HOPS=2` and `108.0.0.1, 200.1.2.3, 10.1.1.10, 192.168.0.1`, it selects `200.1.2.3`. If the hop count is greater than the number of entries, or the selected entry is not a valid IP, the server falls back to `RemoteAddr`.
+
+Setting the hop count too low will trust a client-supplied value; setting it too high will trust an address further into your own infrastructure. Set it to the exact number of proxies you run.
+
+### Limitations
+
+- The server reads only the first `X-Forwarded-For` header on a request. It is valid for a request to carry multiple `X-Forwarded-For` headers, but Go's standard library returns only the first, and the server does not join them. If your proxy chain emits multiple headers, configure it to emit a single combined `X-Forwarded-For` header.
+- IPv4 and IPv6 addresses are both supported. Values that are not valid IPs are rejected and the server falls back to `RemoteAddr`.
+
+### Migrating from earlier versions
+
+Earlier versions used the leftmost `X-Forwarded-For` value when the header was present, with no configuration. This was insecure, since the leftmost value is the most easily spoofed. The default is now `RemoteAddr`. **If you run the server behind a proxy and rely on `X-Forwarded-For` being forwarded to HCP Terraform / TFE, set `MCP_REMOTE_IP_METHOD=X-Forwarded-For` and `MCP_XFF_TRUSTED_HOPS` to the number of proxies you operate.**
 
 ### Supported Headers
 

--- a/pkg/client/middleware.go
+++ b/pkg/client/middleware.go
@@ -7,8 +7,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/go-tfe"
@@ -17,6 +19,20 @@ import (
 )
 
 const OrganizationAllowlistEnv = "MCP_ORGANIZATION_ALLOWLIST"
+
+const (
+	// RemoteIPMethodEnv selects how the client IP is sourced for X-Forwarded-For.
+	// The valid values are: "RemoteAddr" (default), "X-Real-IP", "X-Forwarded-For".
+	RemoteIPMethodEnv = "MCP_REMOTE_IP_METHOD"
+
+	// XFFTrustedHopsEnv sets the number of trusted proxy hops, counted from the
+	// right of the X-Forwarded-For chain. Only used with the X-Forwarded-For method.
+	XFFTrustedHopsEnv = "MCP_XFF_TRUSTED_HOPS"
+
+	RemoteIPMethodRemoteAddr = "RemoteAddr"
+	RemoteIPMethodXRealIP    = "X-Real-IP"
+	RemoteIPMethodXFF        = "X-Forwarded-For"
+)
 
 var ErrMalformedOrganizationAllowlist = errors.New("malformed organization allowlist")
 
@@ -265,6 +281,7 @@ func getTokenFromAuthHeader(r *http.Request) string {
 // This middleware extracts Terraform configuration from HTTP headers, query parameters,
 // or environment variables and adds them to the request context for use by MCP tools
 func TerraformContextMiddleware(logger *log.Logger) func(http.Handler) http.Handler {
+	clientIPCfg := LoadClientIPConfigFromEnv()
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
@@ -322,9 +339,11 @@ func TerraformContextMiddleware(logger *log.Logger) func(http.Handler) http.Hand
 
 			// Capture client IP for X-Forwarded-For header forwarding
 			if utils.GetEnv(ForwardClientIP, "") == "true" {
-				clientIP := getClientIP(r)
-				ctx = context.WithValue(ctx, contextKey(ClientIPKey), clientIP)
-				logger.Debugf("Client IP captured for forwarding: %s", clientIP)
+				clientIP := getClientIP(r, clientIPCfg)
+				if clientIP != "" {
+					ctx = context.WithValue(ctx, contextKey(ClientIPKey), clientIP)
+					logger.Debugf("Client IP captured for forwarding (method=%s): %s", clientIPCfg.Method, clientIP)
+				}
 			}
 			// Call the next handler with the enriched context
 			next.ServeHTTP(w, r.WithContext(ctx))
@@ -332,22 +351,108 @@ func TerraformContextMiddleware(logger *log.Logger) func(http.Handler) http.Hand
 	}
 }
 
-// getClientIP extracts the client IP from the request
-func getClientIP(r *http.Request) string {
-	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		if idx := strings.Index(xff, ","); idx != -1 {
-			return strings.TrimSpace(xff[:idx])
+// ClientIPConfig controls how the client IP is sourced for forwarding.
+type ClientIPConfig struct {
+	// The Method is one of the RemoteIPMethod consts. It defaults to RemoteAddr.
+	Method string
+	// TrustedHops is the number of proxy hops to trust from the right of the
+	// X-Forwarded-For chain. Only used when the selected method is X-Forwarded-For.
+	TrustedHops int
+}
+
+// The LoadClientIPConfigFromEnv reads the client-IP sourcing config from the env.
+// The default is RemoteAddr, which trusts only the direct connection.
+func LoadClientIPConfigFromEnv() ClientIPConfig {
+	method := strings.TrimSpace(os.Getenv(RemoteIPMethodEnv))
+	switch method {
+	case RemoteIPMethodXRealIP, RemoteIPMethodXFF, RemoteIPMethodRemoteAddr:
+	default:
+		method = RemoteIPMethodRemoteAddr
+	}
+
+	hops := 0
+	if raw := strings.TrimSpace(os.Getenv(XFFTrustedHopsEnv)); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n > 0 {
+			hops = n
 		}
-		return strings.TrimSpace(xff)
 	}
 
-	if xri := r.Header.Get("X-Real-IP"); xri != "" {
-		return strings.TrimSpace(xri)
-	}
+	return ClientIPConfig{Method: method, TrustedHops: hops}
+}
 
+// The getClientIP returns the client IP from the request based on the cfg. It returns a
+// validated IP str, or "" if none could be determined.
+//
+// RemoteAddr (the default) trusts only the direct TCP peer. X-Real-IP and
+// X-Forwarded-For are opt-in, since those headers are client-supplied and can be
+// spoofed unless a trusted proxy sets them.
+func getClientIP(r *http.Request, cfg ClientIPConfig) string {
+	switch cfg.Method {
+	case RemoteIPMethodXRealIP:
+		if ip := parseIP(r.Header.Get("X-Real-IP")); ip != "" {
+			return ip
+		}
+		return remoteAddrIP(r)
+
+	case RemoteIPMethodXFF:
+		if ip := ipFromXFF(r.Header.Get("X-Forwarded-For"), cfg.TrustedHops); ip != "" {
+			return ip
+		}
+		return remoteAddrIP(r)
+
+	default: // RemoteIPMethodRemoteAddr
+		return remoteAddrIP(r)
+	}
+}
+
+// remoteAddrIP returns the validated IP from r.RemoteAddr, it handles >  IPv4, IPv6,
+// and addresses with or without a port.
+func remoteAddrIP(r *http.Request) string {
 	addr := r.RemoteAddr
-	if idx := strings.LastIndex(addr, ":"); idx != -1 {
-		return addr[:idx]
+	if addr == "" {
+		return ""
 	}
-	return addr
+	if host, _, err := net.SplitHostPort(addr); err == nil {
+		return parseIP(host)
+	}
+	return parseIP(addr)
+}
+
+// ipFromXFF returns the trusted client IP from an X-Forwarded-For chain.
+//
+// hops is the number of trusted proxies between the server and the client,
+// counted from the right (the rightmost entry is set by the nearest proxy).
+// It skips those hops and returns the next entry to the left, which is the
+// first client-supplied address beyond the trusted proxies.
+// .  example flow on how it works, and what the logic represents >
+//
+//	hops=1, "200.1.2.3, 10.1.1.10"                         -> "200.1.2.3"
+//	hops=2, "108.0.0.1, 200.1.2.3, 10.1.1.10, 192.168.0.1" -> "200.1.2.3"
+//
+// Returns "" if the chain is empty, hops is <= 0, the position is out of range,
+// or the entry is not a valid IP.
+func ipFromXFF(xff string, hops int) string {
+	if xff == "" || hops <= 0 {
+		return ""
+	}
+	parts := strings.Split(xff, ",")
+	// Skip hops trusted proxies from the right, then take the next entry left.
+	// hops=1 -> parts[len-2], hops=2 -> parts[len-3].
+	idx := len(parts) - hops - 1
+	if idx < 0 || idx >= len(parts) {
+		return ""
+	}
+	return parseIP(parts[idx])
+}
+
+func parseIP(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	ip := net.ParseIP(s)
+	if ip == nil {
+		return ""
+	}
+	return ip.String()
 }

--- a/pkg/client/middleware_test.go
+++ b/pkg/client/middleware_test.go
@@ -1137,33 +1137,121 @@ func TestTerraformContextMiddleware_AllowAddressEnvWhenTokenFromEnv(t *testing.T
 func TestGetClientIP(t *testing.T) {
 	tests := []struct {
 		name       string
-		headers    map[string]string
+		cfg        ClientIPConfig
 		remoteAddr string
+		headers    map[string]string
 		expected   string
 	}{
+		//default method: RemoteAddr (secure)
 		{
-			name:       "X-Forwarded-For single IP",
-			headers:    map[string]string{"X-Forwarded-For": "192.168.1.100"},
-			remoteAddr: "10.0.0.1:12345",
-			expected:   "192.168.1.100",
+			name:       "default RemoteAddr ipv4 with port",
+			cfg:        ClientIPConfig{Method: RemoteIPMethodRemoteAddr},
+			remoteAddr: "203.0.113.5:54321",
+			expected:   "203.0.113.5",
 		},
 		{
-			name:       "X-Forwarded-For multiple IPs takes first",
-			headers:    map[string]string{"X-Forwarded-For": "192.168.1.100, 10.0.0.50"},
-			remoteAddr: "10.0.0.1:12345",
-			expected:   "192.168.1.100",
+			name:       "default RemoteAddr ipv6 with port",
+			cfg:        ClientIPConfig{Method: RemoteIPMethodRemoteAddr},
+			remoteAddr: "[2001:db8::1]:54321",
+			expected:   "2001:db8::1",
 		},
 		{
-			name:       "X-Real-IP fallback",
-			headers:    map[string]string{"X-Real-IP": "192.168.1.200"},
-			remoteAddr: "10.0.0.1:12345",
-			expected:   "192.168.1.200",
+			name:       "default RemoteAddr ipv4 no port",
+			cfg:        ClientIPConfig{Method: RemoteIPMethodRemoteAddr},
+			remoteAddr: "203.0.113.5",
+			expected:   "203.0.113.5",
 		},
 		{
-			name:       "RemoteAddr fallback strips port",
-			headers:    map[string]string{},
-			remoteAddr: "10.0.0.1:12345",
+			name:       "RemoteAddr ignores spoofed XFF header",
+			cfg:        ClientIPConfig{Method: RemoteIPMethodRemoteAddr},
+			remoteAddr: "203.0.113.5:443",
+			headers:    map[string]string{"X-Forwarded-For": "1.2.3.4"},
+			expected:   "203.0.113.5", // header is NOT trusted in default mode
+		},
+		{
+			name:       "RemoteAddr garbage returns empty",
+			cfg:        ClientIPConfig{Method: RemoteIPMethodRemoteAddr},
+			remoteAddr: "not-an-ip",
+			expected:   "",
+		},
+
+		//X-Real-IP method
+		{
+			name:       "X-Real-IP valid ipv4",
+			cfg:        ClientIPConfig{Method: RemoteIPMethodXRealIP},
+			remoteAddr: "10.0.0.1:80",
+			headers:    map[string]string{"X-Real-IP": "198.51.100.7"},
+			expected:   "198.51.100.7",
+		},
+		{
+			name:       "X-Real-IP valid ipv6",
+			cfg:        ClientIPConfig{Method: RemoteIPMethodXRealIP},
+			remoteAddr: "10.0.0.1:80",
+			headers:    map[string]string{"X-Real-IP": "2001:db8::beef"},
+			expected:   "2001:db8::beef",
+		},
+		{
+			name:       "X-Real-IP missing falls back to RemoteAddr",
+			cfg:        ClientIPConfig{Method: RemoteIPMethodXRealIP},
+			remoteAddr: "10.0.0.1:80",
 			expected:   "10.0.0.1",
+		},
+		{
+			name:       "X-Real-IP invalid falls back to RemoteAddr",
+			cfg:        ClientIPConfig{Method: RemoteIPMethodXRealIP},
+			remoteAddr: "10.0.0.1:80",
+			headers:    map[string]string{"X-Real-IP": "garbage"},
+			expected:   "10.0.0.1",
+		},
+
+		//X-Forwarded-For method (hops counted from the right)
+		{
+			name:       "XFF hops=1 two entries (SecOps example)",
+			cfg:        ClientIPConfig{Method: RemoteIPMethodXFF, TrustedHops: 1},
+			remoteAddr: "10.1.1.10:80",
+			headers:    map[string]string{"X-Forwarded-For": "200.1.2.3, 10.1.1.10"},
+			expected:   "200.1.2.3",
+		},
+		{
+			name:       "XFF hops=2 four entries (SecOps example)",
+			cfg:        ClientIPConfig{Method: RemoteIPMethodXFF, TrustedHops: 2},
+			remoteAddr: "192.168.0.1:80",
+			headers:    map[string]string{"X-Forwarded-For": "108.0.0.1, 200.1.2.3, 10.1.1.10, 192.168.0.1"},
+			expected:   "200.1.2.3",
+		},
+		{
+			name:       "XFF ipv6 entry",
+			cfg:        ClientIPConfig{Method: RemoteIPMethodXFF, TrustedHops: 1},
+			remoteAddr: "10.1.1.10:80",
+			headers:    map[string]string{"X-Forwarded-For": "2001:db8::5, 10.1.1.10"},
+			expected:   "2001:db8::5",
+		},
+		{
+			name:       "XFF hops exceeds chain length falls back to RemoteAddr",
+			cfg:        ClientIPConfig{Method: RemoteIPMethodXFF, TrustedHops: 5},
+			remoteAddr: "10.1.1.10:80",
+			headers:    map[string]string{"X-Forwarded-For": "200.1.2.3, 10.1.1.10"},
+			expected:   "10.1.1.10", // out of range -> "" from ipFromXFF -> RemoteAddr fallback
+		},
+		{
+			name:       "XFF hops unset (0) falls back to RemoteAddr",
+			cfg:        ClientIPConfig{Method: RemoteIPMethodXFF, TrustedHops: 0},
+			remoteAddr: "10.1.1.10:80",
+			headers:    map[string]string{"X-Forwarded-For": "200.1.2.3, 10.1.1.10"},
+			expected:   "10.1.1.10",
+		},
+		{
+			name:       "XFF selected entry invalid falls back to RemoteAddr",
+			cfg:        ClientIPConfig{Method: RemoteIPMethodXFF, TrustedHops: 1},
+			remoteAddr: "10.1.1.10:80",
+			headers:    map[string]string{"X-Forwarded-For": "not-an-ip, 10.1.1.10"},
+			expected:   "10.1.1.10",
+		},
+		{
+			name:       "XFF empty header falls back to RemoteAddr",
+			cfg:        ClientIPConfig{Method: RemoteIPMethodXFF, TrustedHops: 1},
+			remoteAddr: "10.1.1.10:80",
+			expected:   "10.1.1.10",
 		},
 	}
 
@@ -1174,8 +1262,34 @@ func TestGetClientIP(t *testing.T) {
 			for k, v := range tc.headers {
 				req.Header.Set(k, v)
 			}
-			result := getClientIP(req)
+			result := getClientIP(req, tc.cfg)
 			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestLoadClientIPConfigFromEnv(t *testing.T) {
+	tests := []struct {
+		name       string
+		methodEnv  string
+		hopsEnv    string
+		wantMethod string
+		wantHops   int
+	}{
+		{"unset defaults to RemoteAddr", "", "", RemoteIPMethodRemoteAddr, 0},
+		{"unrecognized defaults to RemoteAddr", "bogus", "", RemoteIPMethodRemoteAddr, 0},
+		{"X-Real-IP", RemoteIPMethodXRealIP, "", RemoteIPMethodXRealIP, 0},
+		{"XFF with hops", RemoteIPMethodXFF, "2", RemoteIPMethodXFF, 2},
+		{"XFF with invalid hops maps to 0", RemoteIPMethodXFF, "abc", RemoteIPMethodXFF, 0},
+		{"XFF with negative hops maps to 0", RemoteIPMethodXFF, "-3", RemoteIPMethodXFF, 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(RemoteIPMethodEnv, tc.methodEnv)
+			t.Setenv(XFFTrustedHopsEnv, tc.hopsEnv)
+			cfg := LoadClientIPConfigFromEnv()
+			assert.Equal(t, tc.wantMethod, cfg.Method)
+			assert.Equal(t, tc.wantHops, cfg.TrustedHops)
 		})
 	}
 }


### PR DESCRIPTION
## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

Makes the client IP sourcing logic in `getClientIP` configurable and fixes several security and correctness issues flagged by SecOps.

Previously the server determined the client IP (forwarded to HCP Terraform / TFE as `X-Forwarded-For`) by trusting the **leftmost** `X-Forwarded-For` value. That entry is the most attacker-controllable part of the chain. There was also  no IPv6 support  and never validated that values were actually IP addresses.

TESTING
I verified the behavior against a running `streamable-http` server with debug logging:
```
# Default RemoteAddr ignores a spoofed X-Forwarded-For
$ curl -s http://localhost:8080/mcp -H "X-Forwarded-For: 1.2.3.4" ...
DEBU Client IP captured for forwarding (method=RemoteAddr): 127.0.0.1
# spoofed 1.2.3.4 ignored, direct peer 127.0.0.1 used

# X-Forwarded-For with MCP_XFF_TRUSTED_HOPS=1
$ curl -s http://localhost:8080/mcp -H "X-Forwarded-For: 200.1.2.3, 10.1.1.10" ...
DEBU Client IP captured for forwarding (method=X-Forwarded-For): 200.1.2.3
# skipped rightmost trusted hop, and selected 200.1.2.3 (which matches SecOps spec)

# X-Real-IP
$ curl -s http://localhost:8080/mcp -H "X-Real-IP: 198.51.100.7" ...
DEBU Client IP captured for forwarding (method=X-Real-IP): 198.51.100.7
# used the header value as-is
```
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
