### PR TITLE
Disable client-supplied TFE_ADDRESS in streamable-http mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.0.1
+
+SECURITY
+
+* Disable client-supplied `TFE_ADDRESS` in streamable-http mode. Previously a client could override the Terraform address via HTTP header or query parameter, redirecting the server's requests and Authorization bearer token to an arbitrary endpoint. The address must now be configured server-side via the `TFE_ADDRESS` env var. This is a breaking change: clients supplying the address via header or query parameter now receive a 403. [389](https://github.com/hashicorp/terraform-mcp-server/pull/389)
+
 # 1.0.0
 
 FEATURES

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ automation and interaction capabilities for Infrastructure as Code (IaC) develop
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `TFE_ADDRESS` | HCP Terraform or TFE address | `"https://app.terraform.io"` |
+| `TFE_ADDRESS` | Sets the Terraform Enterprise/HCP Terraform address for API calls. Must include the protocol (e.g., `https://app.terraform.io`). In streamable-http mode this is the only way to set the address; it cannot be supplied by clients via header or query parameter. | Optional |
 | `TFE_TOKEN` | Terraform Enterprise API token | `""` (empty) |
 | `TFE_SKIP_TLS_VERIFY` | Skip HCP Terraform or Terraform Enterprise TLS verification | `false` |
 | `LOG_LEVEL` | Logging level: `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `panic` (overrides `--log-level` flag) | `info` |
@@ -585,7 +585,6 @@ When `MCP_ORGANIZATION_ALLOWLIST` or `--organization-allowlist` is configured, t
 |--------|-------------|
 | `TFE_TOKEN` | Terraform API token |
 | `Authorization: Bearer <token>` | Alternative method using standard Bearer auth |
-| `TFE_ADDRESS` | Override the Terraform address (blocked when server token is set via env) |
 | `TFE_SKIP_TLS_VERIFY` | Skip TLS verification for the request |
 
 ### Example: curl
@@ -606,7 +605,7 @@ curl -X POST http://localhost:8080/mcp \
 
 ### Security Considerations
 
-- **TFE_ADDRESS override is blocked** when the server has `TFE_TOKEN` set via environment variable. This prevents attackers from redirecting requests to a malicious server that could harvest tokens.
+- **TFE_ADDRESS cannot be set by clients.** In streamable-http mode the Terraform address is sourced only from the server-side `TFE_ADDRESS` environment variable (or the default). Requests that attempt to set `TFE_ADDRESS` via HTTP header or query parameter are rejected with a 403. This prevents a client from redirecting requests, and the `Authorization` token, to a malicious server.
 - **Never pass tokens in query parameters** - the server will reject such requests with a 400 error.
 - Always use TLS (`MCP_TLS_CERT_FILE`/`MCP_TLS_KEY_FILE`) when deploying centrally to protect tokens in transit.
 - Configure `MCP_ALLOWED_ORIGINS` to restrict which clients can connect.

--- a/pkg/client/middleware.go
+++ b/pkg/client/middleware.go
@@ -167,8 +167,10 @@ func OrganizationAllowlistMiddleware(allowlist []string, logger *log.Logger) fun
 			}
 
 			if r.Header.Get(TerraformAddress) != "" || r.URL.Query().Get(TerraformAddress) != "" {
-				logger.Warn("Rejecting request: Terraform address override is not allowed when organization allowlist is configured")
-				http.Error(w, "Cannot specify Terraform address when organization allowlist is configured", http.StatusForbidden)
+				if logger != nil {
+					logger.Warn("Rejecting request: Terraform address cannot be specified via header or query parameter")
+				}
+				http.Error(w, "Cannot specify Terraform address via header or query parameter", http.StatusForbidden)
 				return
 			}
 
@@ -263,24 +265,29 @@ func getTokenFromAuthHeader(r *http.Request) string {
 // This middleware extracts Terraform configuration from HTTP headers, query parameters,
 // or environment variables and adds them to the request context for use by MCP tools
 func TerraformContextMiddleware(logger *log.Logger) func(http.Handler) http.Handler {
-	// Check at startup if token is configured via env var
-	tokenFromEnv := utils.GetEnv(TerraformToken, "") != ""
-
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			requiredHeaders := []string{TerraformAddress, TerraformToken, TerraformSkipTLSVerify}
 			ctx := r.Context()
-			for _, header := range requiredHeaders {
-				var headerValue string
 
-				//If TFE_TOKEN is set via env var, reject TFE_ADDRESS from headers.
-				// This will help prevent potential attackers from redirecting requests to a bad server
-				// that could harvest the Authorization header containing the token.
-				if header == TerraformAddress && tokenFromEnv && r.Header.Get(header) != "" {
-					logger.Warn("Rejecting Terraform-Address header: cannot override address when token is set via environment variable")
-					http.Error(w, "Cannot specify Terraform address via header when token is configured server-side", http.StatusForbidden)
-					return
-				}
+			// TFE_ADDRESS is never sourced from the client in streamable-http mode.
+			// Allowing a client to set the address via header or query parameter would
+			// let it redirect requests (and the Authorization token) to an arbitrary
+			// server. We Reject those attempts and source the address via server-side only.
+			if r.Header.Get(TerraformAddress) != "" || r.URL.Query().Get(TerraformAddress) != "" {
+				logger.Warn("Rejecting request: Terraform address cannot be specified via header or query parameter")
+				http.Error(w, "Cannot specify Terraform address via header or query parameter", http.StatusForbidden)
+				return
+			}
+			terraformAddress := utils.GetEnv(TerraformAddress, DefaultTerraformAddress)
+			ctx = context.WithValue(ctx, contextKey(TerraformAddress), terraformAddress)
+			if logger != nil {
+				logger.Debug("Terraform address configured server-side")
+			}
+
+			// The remaining vals may still be sourced from the client.
+			clientHeaders := []string{TerraformToken, TerraformSkipTLSVerify}
+			for _, header := range clientHeaders {
+				var headerValue string
 
 				// Check standard header first
 				headerValue = r.Header.Get(header)
@@ -310,8 +317,6 @@ func TerraformContextMiddleware(logger *log.Logger) func(http.Handler) http.Hand
 				// Log the source of the configuration (without exposing sensitive values)
 				if header == TerraformToken && headerValue != "" {
 					logger.Debug("Terraform token provided via request context")
-				} else if header == TerraformAddress && headerValue != "" {
-					logger.Debug("Terraform address configured via request context")
 				}
 			}
 

--- a/pkg/client/middleware_test.go
+++ b/pkg/client/middleware_test.go
@@ -678,21 +678,17 @@ func TestTerraformContextMiddleware(t *testing.T) {
 		{
 			name: "headers take priority over query params and env vars",
 			headers: map[string]string{
-				TerraformAddress:       "https://header.terraform.io",
 				TerraformToken:         "header-token",
 				TerraformSkipTLSVerify: "true",
 			},
 			queryParams: map[string]string{
-				TerraformAddress:       "https://query.terraform.io",
 				TerraformSkipTLSVerify: "false",
 			},
 			envVars: map[string]string{
-				TerraformAddress:       "https://env.terraform.io",
 				TerraformSkipTLSVerify: "false",
 			},
 			expectedStatus: http.StatusOK,
 			expectedContextVals: map[string]string{
-				TerraformAddress:       "https://header.terraform.io",
 				TerraformToken:         "header-token",
 				TerraformSkipTLSVerify: "true",
 			},
@@ -726,18 +722,15 @@ func TestTerraformContextMiddleware(t *testing.T) {
 			name:    "query params take priority over env vars (except token)",
 			headers: map[string]string{},
 			queryParams: map[string]string{
-				TerraformAddress:       "https://query.terraform.io",
 				TerraformSkipTLSVerify: "true",
 			},
 			envVars: map[string]string{
-				TerraformAddress:       "https://env.terraform.io",
 				TerraformToken:         "env-token",
 				TerraformSkipTLSVerify: "false",
 			},
 			expectedStatus: http.StatusOK,
 			expectedContextVals: map[string]string{
-				TerraformAddress:       "https://query.terraform.io",
-				TerraformToken:         "env-token", // From env since not in query
+				TerraformToken:         "env-token",
 				TerraformSkipTLSVerify: "true",
 			},
 		},
@@ -761,12 +754,12 @@ func TestTerraformContextMiddleware(t *testing.T) {
 			name:    "empty values result in empty context values",
 			headers: map[string]string{},
 			queryParams: map[string]string{
-				TerraformAddress: "", // Empty value
+				TerraformAddress: "", // Empty value, not treated as an override attempt
 			},
 			envVars:        map[string]string{},
 			expectedStatus: http.StatusOK,
 			expectedContextVals: map[string]string{
-				TerraformAddress:       "",
+				TerraformAddress:       DefaultTerraformAddress,
 				TerraformToken:         "",
 				TerraformSkipTLSVerify: "",
 			},
@@ -775,8 +768,7 @@ func TestTerraformContextMiddleware(t *testing.T) {
 			name:    "token in query params is rejected for security",
 			headers: map[string]string{},
 			queryParams: map[string]string{
-				TerraformAddress: "https://query.terraform.io",
-				TerraformToken:   "query-token", // This should cause an error
+				TerraformToken: "query-token", // This should produce an err / cause an err
 			},
 			envVars:        map[string]string{},
 			expectedStatus: http.StatusBadRequest,
@@ -784,37 +776,45 @@ func TestTerraformContextMiddleware(t *testing.T) {
 			errorMessage:   "Terraform token should not be provided in query parameters",
 		},
 		{
+			name:    "address in query params is rejected",
+			headers: map[string]string{},
+			queryParams: map[string]string{
+				TerraformAddress: "https://query.terraform.io",
+			},
+			envVars:        map[string]string{},
+			expectedStatus: http.StatusForbidden,
+			expectError:    true,
+			errorMessage:   "Cannot specify Terraform address via header or query parameter",
+		},
+		{
 			name: "canonical header names are handled correctly",
 			headers: map[string]string{
-				"tfe_address":         "https://canonical.terraform.io", // lowercase
-				"TFE_TOKEN":           "canonical-token",                // uppercase
-				"tfe_skip_tls_verify": "true",                           // mixed case
+				"TFE_TOKEN":           "canonical-token", // uppercase
+				"tfe_skip_tls_verify": "true",            // mixed case
 			},
 			queryParams:    map[string]string{},
 			envVars:        map[string]string{},
 			expectedStatus: http.StatusOK,
 			expectedContextVals: map[string]string{
-				TerraformAddress:       "https://canonical.terraform.io",
 				TerraformToken:         "canonical-token",
 				TerraformSkipTLSVerify: "true",
 			},
 		},
 		{
-			name: "mixed sources - headers override query params, query params override env",
+			name: "mixed sources - token via header, skip-tls via query, address from env",
 			headers: map[string]string{
-				TerraformAddress: "https://header.terraform.io", // Header wins
-				TerraformToken:   "header-token",                // Must provide token via header too
+				TerraformToken: "header-token",
 			},
 			queryParams: map[string]string{
 				TerraformSkipTLSVerify: "true", // Query param wins over env
 			},
 			envVars: map[string]string{
-				TerraformAddress:       "https://env.terraform.io", // Overridden by header
-				TerraformSkipTLSVerify: "false",                    // Overridden by query param
+				TerraformAddress:       "https://env.terraform.io",
+				TerraformSkipTLSVerify: "false", // Overridden by query param
 			},
 			expectedStatus: http.StatusOK,
 			expectedContextVals: map[string]string{
-				TerraformAddress:       "https://header.terraform.io",
+				TerraformAddress:       "https://env.terraform.io",
 				TerraformToken:         "header-token",
 				TerraformSkipTLSVerify: "true",
 			},
@@ -927,16 +927,14 @@ func TestTerraformContextMiddleware_SecurityLogging(t *testing.T) {
 		// "Terraform token provided via request context" but doesn't contain "secret-token"
 	})
 
-	t.Run("address provided via header is logged", func(t *testing.T) {
+	t.Run("address provided via header is rejected", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/mcp", nil)
 		req.Header.Set(TerraformAddress, "https://custom.terraform.io")
 
 		rr := httptest.NewRecorder()
 		handler.ServeHTTP(rr, req)
 
-		assert.Equal(t, http.StatusOK, rr.Code)
-		// Note: In a real test, you'd capture the log output and verify it contains
-		// "Terraform address configured via request context"
+		assert.Equal(t, http.StatusForbidden, rr.Code)
 	})
 }
 
@@ -987,7 +985,7 @@ func TestTerraformContextMiddleware_EdgeCases(t *testing.T) {
 	t.Run("very long header values are handled", func(t *testing.T) {
 		mockHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
-			val := ctx.Value(contextKey(TerraformAddress))
+			val := ctx.Value(contextKey(TerraformToken))
 			assert.NotNil(t, val)
 			w.WriteHeader(http.StatusOK)
 		})
@@ -995,11 +993,11 @@ func TestTerraformContextMiddleware_EdgeCases(t *testing.T) {
 		middleware := TerraformContextMiddleware(logger)
 		handler := middleware(mockHandler)
 
-		// Create a very long address value
-		longAddress := "https://" + strings.Repeat("a", 1000) + ".terraform.io"
+		// Create a very long token value
+		longToken := strings.Repeat("a", 1000)
 
 		req := httptest.NewRequest("GET", "/mcp", nil)
-		req.Header.Set(TerraformAddress, longAddress)
+		req.Header.Set(TerraformToken, longToken)
 
 		rr := httptest.NewRecorder()
 		handler.ServeHTTP(rr, req)
@@ -1008,12 +1006,10 @@ func TestTerraformContextMiddleware_EdgeCases(t *testing.T) {
 	})
 }
 
-// TestTerraformContextMiddleware_RejectAddressHeaderWhenTokenFromEnv tests that the middleware
-// rejects Terraform-Address headers when TFE_TOKEN is set via env var.
-func TestTerraformContextMiddleware_RejectAddressHeaderWhenTokenFromEnv(t *testing.T) {
-	// Set TFE_TOKEN via environment variable
-	os.Setenv(TerraformToken, "test-token-from-env")
-	defer os.Unsetenv(TerraformToken)
+// TestTerraformContextMiddleware_RejectAddressHeader tests that the middleware
+// rejects a Terraform address supplied via header, regardless of how the token is set.
+func TestTerraformContextMiddleware_RejectAddressHeader(t *testing.T) {
+	os.Unsetenv(TerraformToken)
 
 	logger := log.New()
 	logger.SetOutput(io.Discard)
@@ -1035,21 +1031,16 @@ func TestTerraformContextMiddleware_RejectAddressHeaderWhenTokenFromEnv(t *testi
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
-	// Should be rejected with a 403
 	assert.Equal(t, http.StatusForbidden, rr.Code)
-
-	// The handler should not be reached
 	assert.False(t, handlerReached, "handler should not have been reached when address header is rejected")
-
-	// Confirm error message
-	assert.Contains(t, rr.Body.String(), "Cannot specify Terraform address via header")
+	assert.Contains(t, rr.Body.String(), "Cannot specify Terraform address via header or query parameter")
 }
 
-// TestTerraformContextMiddleware_AllowAddressHeaderWhenTokenFromHeader tests that the middleware
-// allows Terraform-Address headers when TFE_TOKEN is not set via env var.
-// legit use case where a user can provide both address and token via headers.
-func TestTerraformContextMiddleware_AllowAddressHeaderWhenTokenFromHeader(t *testing.T) {
-	// Ensure TFE_TOKEN is NOT set via environment
+// TestTerraformContextMiddleware_RejectAddressHeaderWithBearerToken tests that a client
+// may not override the Terraform address even when supplying its own bearer token.
+// This was previously allowed but is now rejected: a client could otherwise redirect
+// the request and its token to an arbitrary server.
+func TestTerraformContextMiddleware_RejectAddressHeaderWithBearerToken(t *testing.T) {
 	os.Unsetenv(TerraformToken)
 
 	logger := log.New()
@@ -1065,7 +1056,6 @@ func TestTerraformContextMiddleware_AllowAddressHeaderWhenTokenFromHeader(t *tes
 
 	handler := middleware(nextHandler)
 
-	// Create request with both address and token from headers this is a legit use case
 	req := httptest.NewRequest("POST", "/mcp", nil)
 	req.Header.Set(TerraformAddress, "https://app.terraform.io")
 	req.Header.Set("Authorization", "Bearer user-provided-token")
@@ -1073,11 +1063,35 @@ func TestTerraformContextMiddleware_AllowAddressHeaderWhenTokenFromHeader(t *tes
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
-	// Should be allowed
-	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+	assert.False(t, handlerReached, "handler should not have been reached when address header is rejected")
+}
 
-	// Handler should have been reached
-	assert.True(t, handlerReached, "handler should have been reached when token is not from env")
+// TestTerraformContextMiddleware_RejectAddressQueryParam tests that the middleware
+// rejects a Terraform address supplied via query parameter.
+func TestTerraformContextMiddleware_RejectAddressQueryParam(t *testing.T) {
+	os.Unsetenv(TerraformToken)
+
+	logger := log.New()
+	logger.SetOutput(io.Discard)
+
+	middleware := TerraformContextMiddleware(logger)
+
+	handlerReached := false
+	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerReached = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := middleware(nextHandler)
+
+	req := httptest.NewRequest("POST", "/mcp?TFE_ADDRESS=https://malicious-server.com", nil)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+	assert.False(t, handlerReached, "handler should not have been reached when address query param is rejected")
 }
 
 // TestTerraformContextMiddleware_AllowAddressEnvWhenTokenFromEnv tests that the middleware


### PR DESCRIPTION
## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

This PR disables client-supplied `TFE_ADDRESS` in streamable-http mode. Previously a client could set the Terraform address via HTTP header or query parameter, which would redirect the server's requests,  and the `Authorization` bearer token, to an arbitrary endpoint. This removes that capability entirely.

Addresses https://hashicorp.atlassian.net/browse/TFECO-12757 

This PR will introduce a breaking change

The Clients that previously supplied the Terraform address via the `TFE_ADDRESS` header or query parameter (including the "both address and token via headers" pattern) will now receive a `403 err`. The address must now be configured server-side via the `TFE_ADDRESS` env var.

AI assisted with the test cleanup, and updated test messages via find and replace

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
