### PR TITLE
Add shared secret header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ FEATURES
 * [New Tool] `force_unlock_workspace` Force unlocks a Terraform workspace stuck in a run-held lock. Requires workspace admin permissions and is gated behind `ENABLE_TF_OPERATIONS=true`
 * [Configuration] Add a `MCP_REDIRECT_ROOT_URL` environment variable to allow redirecting `/` of the server when visited in-browser. 
 
+IMPROVEMENTS
+
+* Add `TF_MCP_SHARED_SECRET` to send an `X-Tf-Mcp-Secret` header on requests to HCP Terraform / TFE, allowing the backend to identify requests from a trusted MCP deployment [392](https://github.com/hashicorp/terraform-mcp-server/pull/392)
+
 # 1.0.0
 
 FEATURES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ IMPROVEMENTS
 
 * Add `version` field to the `/health` endpoint response to make it easier to identify which version is deployed at a glance. [410](https://github.com/hashicorp/terraform-mcp-server/pull/410)
 * Add optional Instana instrumentation (metrics and HTTP request tracing) for the streamable-http server, gated behind `INSTANA_ENABLED` [411](https://github.com/hashicorp/terraform-mcp-server/pull/411)
+* Add `TF_MCP_SHARED_SECRET` to send an `X-Tf-Mcp-Secret` header on requests to HCP Terraform / TFE, allowing the backend to identify requests from a trusted MCP deployment [392](https://github.com/hashicorp/terraform-mcp-server/pull/392)
 
 FIXES
 
@@ -26,7 +27,6 @@ FEATURES
 
 IMPROVEMENTS
 
-* Add `TF_MCP_SHARED_SECRET` to send an `X-Tf-Mcp-Secret` header on requests to HCP Terraform / TFE, allowing the backend to identify requests from a trusted MCP deployment [392](https://github.com/hashicorp/terraform-mcp-server/pull/392)
 
 # 1.0.0
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ automation and interaction capabilities for Infrastructure as Code (IaC) develop
 |----------|-------------|---------|
 | `TFE_ADDRESS` | Sets the Terraform Enterprise/HCP Terraform address for API calls. Must include the protocol (e.g., `https://app.terraform.io`). In streamable-http mode this is the only way to set the address; it cannot be supplied by clients via header or query parameter. | Optional |
 | `TFE_TOKEN` | Terraform Enterprise API token | `""` (empty) |
+| `TF_MCP_SHARED_SECRET` | Shared secret sent as the `X-Tf-Mcp-Secret` header on requests to HCP Terraform / TFE, used to identify requests originating from a hosted MCP deployment. Should only be used over TLS. | `""` (empty) |
 | `TFE_SKIP_TLS_VERIFY` | Skip HCP Terraform or Terraform Enterprise TLS verification | `false` |
 | `LOG_LEVEL` | Logging level: `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `panic` (overrides `--log-level` flag) | `info` |
 | `LOG_FORMAT` | Logging format: `text` or `json` (overrides `--log-format` flag)| `text` |
@@ -644,6 +645,7 @@ curl -X POST http://localhost:8080/mcp \
 ### Security Considerations
 
 - **TFE_ADDRESS cannot be set by clients.** In streamable-http mode the Terraform address is sourced only from the server-side `TFE_ADDRESS` environment variable (or the default). Requests that attempt to set `TFE_ADDRESS` via HTTP header or query parameter are rejected with a 403. This prevents a client from redirecting requests, and the `Authorization` token, to a malicious server.
+- **Hosted deployment identification:** setting `TF_MCP_SHARED_SECRET` sends that value as the `X-Tf-Mcp-Secret` header on every HCP Terraform / TFE request, letting the backend identify requests from a known hosted deployment (e.g. to apply IP allowlists). It is a static secret sent in a header, so only use it over TLS and treat the value as a credential.
 - **Never pass tokens in query parameters** - the server will reject such requests with a 400 error.
 - Always use TLS (`MCP_TLS_CERT_FILE`/`MCP_TLS_KEY_FILE`) when deploying centrally to protect tokens in transit.
 - Configure `MCP_ALLOWED_ORIGINS` to restrict which clients can connect.

--- a/pkg/client/tfe_client.go
+++ b/pkg/client/tfe_client.go
@@ -24,6 +24,8 @@ const (
 	DefaultTerraformAddress = "https://app.terraform.io"
 	ForwardClientIP         = "MCP_FORWARD_CLIENT_IP"
 	ClientIPKey             = "CLIENT_IP"
+	SharedSecretEnv         = "TF_MCP_SHARED_SECRET"
+	SharedSecretHeader      = "X-Tf-Mcp-Secret"
 )
 
 var activeTfeClients sync.Map
@@ -70,6 +72,12 @@ func newTfeClient(terraformAddress string, terraformSkipTLSVerify bool, terrafor
 	if clientIP != "" {
 		config.Headers.Set("X-Forwarded-For", clientIP)
 	}
+
+	// Attach the shared secret (if configured) so Atlas can identify requests
+	// from a HashiCorp-hosted deployment. Deploy-time static; never logged.
+	if secret := utils.GetEnv(SharedSecretEnv, ""); secret != "" {
+		config.Headers.Set(SharedSecretHeader, secret)
+	}
 	config.HTTPClient = createHTTPClient(terraformSkipTLSVerify, logger)
 
 	client, err := tfe.NewClient(config)
@@ -79,6 +87,36 @@ func newTfeClient(terraformAddress string, terraformSkipTLSVerify bool, terrafor
 	}
 
 	return client, nil
+}
+
+// the buildTFEConfig func assembles the go-tfe client configuration, including the outbound
+// headers set on every request (User-Agent, optional X-Forwarded-For, and the
+// optional hosted-deployment shared secret).
+//
+// This is split out from newTfeClient so the header logic can be unit-tested (I feel this feature should be tested, so if the header logic gets refactored in the future, we can catch the regression):
+// tfe.NewClient consumes the config and does not expose the headers back, so we can
+// assert against the *tfe.Config this returns instead.
+func buildTFEConfig(terraformAddress string, terraformSkipTLSVerify bool, terraformToken string, clientIP string, logger *log.Logger) *tfe.Config {
+	config := &tfe.Config{
+		Address:           terraformAddress,
+		Token:             terraformToken,
+		RetryServerErrors: true,
+		Headers:           make(http.Header),
+	}
+
+	config.Headers.Set("User-Agent", fmt.Sprintf("terraform-mcp-server/%s", version.GetHumanVersion()))
+	if clientIP != "" {
+		config.Headers.Set("X-Forwarded-For", clientIP)
+	}
+
+	// Attach the shared secret (if configured) so Atlas can identify requests
+	// from a HashiCorp-hosted deployment.
+	if secret := utils.GetEnv(SharedSecretEnv, ""); secret != "" {
+		config.Headers.Set(SharedSecretHeader, secret)
+	}
+
+	config.HTTPClient = createHTTPClient(terraformSkipTLSVerify, logger)
+	return config
 }
 
 // GetTfeClient retrieves the TFE client for the given session

--- a/pkg/client/tfe_client.go
+++ b/pkg/client/tfe_client.go
@@ -61,24 +61,7 @@ func newTfeClient(terraformAddress string, terraformSkipTLSVerify bool, terrafor
 		return nil, utils.LogAndReturnError(logger, "required input: no Terraform token provided", nil)
 	}
 
-	config := &tfe.Config{
-		Address:           terraformAddress,
-		Token:             terraformToken,
-		RetryServerErrors: true,
-		Headers:           make(http.Header),
-	}
-
-	config.Headers.Set("User-Agent", fmt.Sprintf("terraform-mcp-server/%s", version.GetHumanVersion()))
-	if clientIP != "" {
-		config.Headers.Set("X-Forwarded-For", clientIP)
-	}
-
-	// Attach the shared secret (if configured) so Atlas can identify requests
-	// from a HashiCorp-hosted deployment. Deploy-time static; never logged.
-	if secret := utils.GetEnv(SharedSecretEnv, ""); secret != "" {
-		config.Headers.Set(SharedSecretHeader, secret)
-	}
-	config.HTTPClient = createHTTPClient(terraformSkipTLSVerify, logger)
+	config := buildTFEConfig(terraformAddress, terraformSkipTLSVerify, terraformToken, clientIP, logger)
 
 	client, err := tfe.NewClient(config)
 	if err != nil {
@@ -89,13 +72,13 @@ func newTfeClient(terraformAddress string, terraformSkipTLSVerify bool, terrafor
 	return client, nil
 }
 
-// the buildTFEConfig func assembles the go-tfe client configuration, including the outbound
+// buildTFEConfig assembles the go-tfe client configuration, including the outbound
 // headers set on every request (User-Agent, optional X-Forwarded-For, and the
-// optional hosted-deployment shared secret).
+// optional shared secret).
 //
-// This is split out from newTfeClient so the header logic can be unit-tested (I feel this feature should be tested, so if the header logic gets refactored in the future, we can catch the regression):
-// tfe.NewClient consumes the config and does not expose the headers back, so we can
-// assert against the *tfe.Config this returns instead.
+// It is split out from newTfeClient so the header logic can be unit-tested: tfe.NewClient
+// consumes the config and does not expose the headers back, so the tests assert against
+// the *tfe.Config returned here instead.
 func buildTFEConfig(terraformAddress string, terraformSkipTLSVerify bool, terraformToken string, clientIP string, logger *log.Logger) *tfe.Config {
 	config := &tfe.Config{
 		Address:           terraformAddress,
@@ -109,8 +92,8 @@ func buildTFEConfig(terraformAddress string, terraformSkipTLSVerify bool, terraf
 		config.Headers.Set("X-Forwarded-For", clientIP)
 	}
 
-	// Attach the shared secret (if configured) so Atlas can identify requests
-	// from a HashiCorp-hosted deployment.
+	// Attach the shared secret (if configured) so the backend (HCP Terraform / TFE)
+	// can identify requests from a trusted MCP deployment.
 	if secret := utils.GetEnv(SharedSecretEnv, ""); secret != "" {
 		config.Headers.Set(SharedSecretHeader, secret)
 	}

--- a/pkg/client/tfe_client_test.go
+++ b/pkg/client/tfe_client_test.go
@@ -11,6 +11,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// This tests the buildTFEConfig directly due to tfe.NewClient consuming the config and
+// it oesn't give the headers back to assert on. The newTfeClient func calls this, so it covers the prod path.
+
 func TestBuildTFEConfig_SharedSecret(t *testing.T) {
 	logger := log.New()
 	logger.SetOutput(io.Discard)

--- a/pkg/client/tfe_client_test.go
+++ b/pkg/client/tfe_client_test.go
@@ -1,0 +1,44 @@
+// Copyright IBM Corp. 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package client
+
+import (
+	"io"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildTFEConfig_SharedSecret(t *testing.T) {
+	logger := log.New()
+	logger.SetOutput(io.Discard)
+
+	t.Run("sets shared secret header when env is set", func(t *testing.T) {
+		t.Setenv(SharedSecretEnv, "super-secret-value")
+		cfg := buildTFEConfig("https://app.terraform.io", false, "token", "", logger)
+		assert.Equal(t, "super-secret-value", cfg.Headers.Get(SharedSecretHeader))
+	})
+
+	t.Run("omits shared secret header when env is unset", func(t *testing.T) {
+		t.Setenv(SharedSecretEnv, "")
+		cfg := buildTFEConfig("https://app.terraform.io", false, "token", "", logger)
+		assert.Empty(t, cfg.Headers.Get(SharedSecretHeader))
+	})
+}
+
+func TestBuildTFEConfig_ForwardedFor(t *testing.T) {
+	logger := log.New()
+	logger.SetOutput(io.Discard)
+
+	t.Run("sets X-Forwarded-For when clientIP is provided", func(t *testing.T) {
+		cfg := buildTFEConfig("https://app.terraform.io", false, "token", "203.0.113.5", logger)
+		assert.Equal(t, "203.0.113.5", cfg.Headers.Get("X-Forwarded-For"))
+	})
+
+	t.Run("omits X-Forwarded-For when clientIP is empty", func(t *testing.T) {
+		cfg := buildTFEConfig("https://app.terraform.io", false, "token", "", logger)
+		assert.Empty(t, cfg.Headers.Get("X-Forwarded-For"))
+	})
+}


### PR DESCRIPTION
## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

This PR adds a configurable shared secret that the server sends as the `X-Tf-Mcp-Secret` header on every go-tfe request. 

This allow HCPT/TFE to be able to distinguish requests from a trusted MCP deployment from requests coming from someone else's self-hosted/local instance, so it can enforce IP allowlists on the hosted deployment's traffic.

We already send `X-Forwarded-For`, but that alone doesn't allow HCPT or TFE operators to establish trust. The shared secret provides that identification.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
