### PR TITLE
Add env variable to allow redirecting the root of the server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ FIXES
 FEATURES
 
 * [New Tool] `force_unlock_workspace` Force unlocks a Terraform workspace stuck in a run-held lock. Requires workspace admin permissions and is gated behind `ENABLE_TF_OPERATIONS=true`
+* [Configuration] Add a `MCP_REDIRECT_ROOT_URL` environment variable to allow redirecting `/` of the server when visited in-browser. 
 
 # 1.0.0
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ automation and interaction capabilities for Infrastructure as Code (IaC) develop
 | `TRANSPORT_HOST` | Host to bind the HTTP server | `127.0.0.1` |
 | `TRANSPORT_PORT` | HTTP server port | `8080` |
 | `MCP_ENDPOINT` | HTTP server endpoint path | `/mcp` |
+| `MCP_REDIRECT_ROOT_URL` | URL to redirect requests to `/` to | `""` |
 | `MCP_KEEP_ALIVE` | Keep-alive interval for SSE connections (e.g., 30s, 1m). 0 to disable | `0` |
 | `MCP_SESSION_MODE` | Session mode: `stateful` or `stateless` | `stateful` |
 | `MCP_ALLOWED_ORIGINS` | Comma-separated list of allowed origins for CORS | `""` (empty) |

--- a/cmd/terraform-mcp-server/init.go
+++ b/cmd/terraform-mcp-server/init.go
@@ -332,6 +332,14 @@ func streamableHTTPServerInit(ctx context.Context, hcServer *server.MCPServer, l
 	mux.Handle(endpointPath, streamableServer)
 	mux.Handle(endpointPath+"/", streamableServer)
 
+	if redirectURL := os.Getenv("MCP_REDIRECT_ROOT_URL"); redirectURL != "" {
+		logger.Infof("Requests to `/` will be redirected to %s", redirectURL)
+		// handle root direct if it's configured
+		mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, redirectURL, http.StatusSeeOther)
+		})
+	}
+
 	// Add health check endpoint
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
This PR adds an option to configure a redirect for `/` if the server is configured to serve the MCP protocol at `/mcp`. This is useful to be able to redirect end users to documentation if they hit the root of the server in their browser. Currently they just see a bare `404` error. 

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
