### PR TITLE
Fix security issues related to session - client mapping, stateless mode session handling and session end cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ FIXES
 * Disable client-supplied `TFE_ADDRESS` in streamable-http mode. Previously a client could override the Terraform address via HTTP header or query parameter, redirecting the server's requests and Authorization bearer token to an arbitrary endpoint. The address must now be configured server-side via the `TFE_ADDRESS` env var. This is a breaking change: clients supplying the address via header or query parameter now receive a 403. [389](https://github.com/hashicorp/terraform-mcp-server/pull/389)
 * Fix http server not serving TLS when configured [391](https://github.com/hashicorp/terraform-mcp-server/pull/391)
 * Make client IP sourcing configurable and fix insecure X-Forwarded-For handling. The server previously trusted the leftmost `X-Forwarded-For` value,had no IPv6 support, and did not validate IPs. Sourcing is now configurable via `MCP_REMOTE_IP_METHOD` (`RemoteAddr`, `X-Real-IP`, `X-Forwarded-For`) and `MCP_XFF_TRUSTED_HOPS`, defaulting to the secure `RemoteAddr`. This is a breaking change: proxy deployments relying on automatic `X-Forwarded-For` forwarding must now set `MCP_REMOTE_IP_METHOD=X-Forwarded-For` and `MCP_XFF_TRUSTED_HOPS`. [388](https://github.com/hashicorp/terraform-mcp-server/pull/388)
-
+* Fix security vulnerabilities for cross-tenant HCP Terraform token reuse in stateless HTTP mode (multi-tenant token bleed), session-scoped TFE client cache bypassing per-token request validation in StreamableHTTP mode and cleaning up at end of session [395](https://github.com/hashicorp/terraform-mcp-server/pull/395)
 
 FEATURES
 

--- a/cmd/terraform-mcp-server/main.go
+++ b/cmd/terraform-mcp-server/main.go
@@ -45,10 +45,13 @@ func runHTTPServer(logger *log.Logger, host string, port string, endpointPath st
 	hooks.AddOnRegisterSession(func(ctx context.Context, session server.ClientSession) {
 		client.NewSessionHandler(ctx, session, logger)
 	})
+	hcServer, rateLimiter := NewServer(version.Version, logger, enabledToolsets, server.WithHooks(hooks))
+	registerToolsAndResources(hcServer, logger, enabledToolsets)
+
 	hooks.AddOnUnregisterSession(func(ctx context.Context, session server.ClientSession) {
 		// Clean up client info populated in the metrics hooks, for the session
 		sessionClientInfo.Delete(session.SessionID())
-		client.EndSessionHandler(ctx, session, logger)
+		client.EndSessionHandler(ctx, session, rateLimiter, logger)
 	})
 	// When running multiple sessions of the MCP server (load balancing), calling client.NewSessionHandler
 	// in both BeforeListTools and BeforeCallTool ensures that a session that was not initialized during
@@ -68,11 +71,6 @@ func runHTTPServer(logger *log.Logger, host string, port string, endpointPath st
 		}
 	})
 	attachMetricsHooks(hooks, metricsConfig, logger)
-
-	opts := []server.ServerOption{server.WithHooks(hooks)}
-
-	hcServer := NewServer(version.Version, logger, enabledToolsets, opts...)
-	registerToolsAndResources(hcServer, logger, enabledToolsets)
 
 	return streamableHTTPServerInit(ctx, hcServer, logger, host, port, endpointPath, heartbeatInterval, organizationAllowlist)
 }
@@ -152,17 +150,17 @@ func runStdioServer(logger *log.Logger, enabledToolsets []string) error {
 	hooks.AddOnRegisterSession(func(ctx context.Context, session server.ClientSession) {
 		client.NewSessionHandler(ctx, session, logger)
 	})
-	hooks.AddOnUnregisterSession(func(ctx context.Context, session server.ClientSession) {
-		client.EndSessionHandler(ctx, session, logger)
-	})
-
-	hcServer := NewServer(version.Version, logger, enabledToolsets, server.WithHooks(hooks))
+	hcServer, rateLimiter := NewServer(version.Version, logger, enabledToolsets, server.WithHooks(hooks))
 	registerToolsAndResources(hcServer, logger, enabledToolsets)
+
+	hooks.AddOnUnregisterSession(func(ctx context.Context, session server.ClientSession) {
+		client.EndSessionHandler(ctx, session, rateLimiter, logger)
+	})
 
 	return serverInit(ctx, hcServer, logger)
 }
 
-func NewServer(version string, logger *log.Logger, enabledToolsets []string, opts ...server.ServerOption) *server.MCPServer {
+func NewServer(version string, logger *log.Logger, enabledToolsets []string, opts ...server.ServerOption) (*server.MCPServer, *client.RateLimitMiddleware) {
 	// Create rate limiting middleware with environment-based configuration
 	rateLimitConfig := client.LoadRateLimitConfigFromEnv()
 	rateLimitMiddleware := client.NewRateLimitMiddleware(rateLimitConfig, logger)
@@ -183,7 +181,7 @@ func NewServer(version string, logger *log.Logger, enabledToolsets []string, opt
 		version,
 		opts...,
 	)
-	return s
+	return s, rateLimitMiddleware
 }
 
 // parseToolsets parses and validates the toolsets flag value

--- a/cmd/terraform-mcp-server/main_metrics_test.go
+++ b/cmd/terraform-mcp-server/main_metrics_test.go
@@ -269,7 +269,7 @@ func TestNewServerWithHooksOptionPassesThrough(t *testing.T) {
 	customHooks := &mcpserver.Hooks{}
 	customHooks.AddBeforeCallTool(func(ctx context.Context, id any, message *mcp.CallToolRequest) {})
 
-	srv := NewServer("test-version", metricsTestLogger(), nil, mcpserver.WithHooks(customHooks))
+	srv, _ := NewServer("test-version", metricsTestLogger(), nil, mcpserver.WithHooks(customHooks))
 	hooks := getServerHooksForTest(t, srv)
 
 	require.GreaterOrEqual(t, len(hooks.OnBeforeCallTool), 1)

--- a/pkg/client/ratelimit.go
+++ b/pkg/client/ratelimit.go
@@ -161,24 +161,6 @@ func getSessionIDFromContext(ctx context.Context) string {
 	return ""
 }
 
-// CleanupSessions removes inactive session limiters to prevent memory leaks
-func (m *RateLimitMiddleware) CleanupSessions(activeSessions []string) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	activeSet := make(map[string]bool)
-	for _, sessionID := range activeSessions {
-		activeSet[sessionID] = true
-	}
-
-	for sessionID := range m.sessionLimiters {
-		if !activeSet[sessionID] {
-			delete(m.sessionLimiters, sessionID)
-			m.logger.Debugf("Cleaned up rate limiter for inactive session: %s", sessionID)
-		}
-	}
-}
-
 // DeleteSession removes the rate limiter for a session when it ends.
 func (m *RateLimitMiddleware) DeleteSession(sessionID string) {
 	if sessionID == "" {

--- a/pkg/client/ratelimit.go
+++ b/pkg/client/ratelimit.go
@@ -178,3 +178,13 @@ func (m *RateLimitMiddleware) CleanupSessions(activeSessions []string) {
 		}
 	}
 }
+
+// DeleteSession removes the rate limiter for a session when it ends.
+func (m *RateLimitMiddleware) DeleteSession(sessionID string) {
+	if sessionID == "" {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.sessionLimiters, sessionID)
+}

--- a/pkg/client/ratelimit.go
+++ b/pkg/client/ratelimit.go
@@ -187,4 +187,5 @@ func (m *RateLimitMiddleware) DeleteSession(sessionID string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	delete(m.sessionLimiters, sessionID)
+	m.logger.Debugf("Cleaned up sessionLimiters for session: %s", sessionID)
 }

--- a/pkg/client/registry_client.go
+++ b/pkg/client/registry_client.go
@@ -21,7 +21,7 @@ var (
 func NewHttpClient(sessionId string, terraformSkipTLSVerify bool, logger *log.Logger) *http.Client {
 	client := createHTTPClient(terraformSkipTLSVerify, logger)
 	activeHttpClients.Store(sessionId, client)
-	logger.WithField("session_id", sessionId).Info("Created HTTP client")
+	logger.Info("Created HTTP client")
 	return client
 }
 

--- a/pkg/client/session.go
+++ b/pkg/client/session.go
@@ -15,6 +15,10 @@ type contextKey string
 
 // NewSessionHandler initializes clients for the session
 func NewSessionHandler(ctx context.Context, session server.ClientSession, logger *log.Logger) {
+	if _, ok := activeTfeClients.Load(session.SessionID()); ok {
+		return
+	}
+
 	// Create both TFE and HTTP clients for the session
 	tfeClient, err := CreateTfeClientForSession(ctx, session, logger)
 	if err != nil {
@@ -37,7 +41,7 @@ func NewSessionHandler(ctx context.Context, session server.ClientSession, logger
 }
 
 // EndSessionHandler cleans up clients when the session ends
-func EndSessionHandler(_ context.Context, session server.ClientSession, logger *log.Logger) {
+func EndSessionHandler(_ context.Context, session server.ClientSession, rateLimiter *RateLimitMiddleware, logger *log.Logger) {
 	// Unregister from tool registry if it was registered
 	if registryCallback := getToolRegistryCallback(); registryCallback != nil {
 		registryCallback.UnregisterSessionWithTFE(session.SessionID())
@@ -45,6 +49,9 @@ func EndSessionHandler(_ context.Context, session server.ClientSession, logger *
 
 	DeleteTfeClient(session.SessionID())
 	DeleteHttpClient(session.SessionID())
+	if rateLimiter != nil {
+		rateLimiter.DeleteSession(session.SessionID())
+	}
 	logger.Info("Cleaned up clients for session")
 }
 

--- a/pkg/client/session.go
+++ b/pkg/client/session.go
@@ -15,10 +15,6 @@ type contextKey string
 
 // NewSessionHandler initializes clients for the session
 func NewSessionHandler(ctx context.Context, session server.ClientSession, logger *log.Logger) {
-	if _, ok := activeTfeClients.Load(session.SessionID()); ok {
-		return
-	}
-
 	// Create both TFE and HTTP clients for the session
 	tfeClient, err := CreateTfeClientForSession(ctx, session, logger)
 	if err != nil {
@@ -49,7 +45,7 @@ func EndSessionHandler(_ context.Context, session server.ClientSession, logger *
 
 	DeleteTfeClient(session.SessionID())
 	DeleteHttpClient(session.SessionID())
-	logger.WithField("session_id", session.SessionID()).Info("Cleaned up clients for session")
+	logger.Info("Cleaned up clients for session")
 }
 
 // ToolRegistryCallback defines the interface for interacting with the tool registry

--- a/pkg/client/tfe_client.go
+++ b/pkg/client/tfe_client.go
@@ -5,6 +5,7 @@ package client
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"net/http"
 	"sync"
@@ -27,15 +28,25 @@ const (
 
 var activeTfeClients sync.Map
 
+type cachedTfeClient struct {
+	client  *tfe.Client
+	token   [32]byte // Store the hash of the token instead of raw value
+	address string
+}
+
 // NewTfeClient creates a new TFE client for the given session
 func NewTfeClient(sessionId string, terraformAddress string, terraformSkipTLSVerify bool, terraformToken string, clientIP string, logger *log.Logger) (*tfe.Client, error) {
 	client, err := newTfeClient(terraformAddress, terraformSkipTLSVerify, terraformToken, clientIP, logger)
 	if err != nil {
 		return nil, err
 	}
-
-	activeTfeClients.Store(sessionId, client)
-	logger.WithField("session_id", sessionId).Info("Created TFE client")
+	// Store the token and address along with the client per session ID
+	activeTfeClients.Store(sessionId, cachedTfeClient{
+		client:  client,
+		token:   sha256.Sum256([]byte(terraformToken)),
+		address: terraformAddress,
+	})
+	logger.Info("Created TFE client")
 	return client, nil
 }
 
@@ -75,7 +86,7 @@ func newTfeClient(terraformAddress string, terraformSkipTLSVerify bool, terrafor
 // GetTfeClient retrieves the TFE client for the given session
 func GetTfeClient(sessionId string) *tfe.Client {
 	if value, ok := activeTfeClients.Load(sessionId); ok {
-		return value.(*tfe.Client)
+		return value.(cachedTfeClient).client
 	}
 	return nil
 }
@@ -92,12 +103,25 @@ func GetTfeClientFromContext(ctx context.Context, logger *log.Logger) (*tfe.Clie
 		return nil, fmt.Errorf("no active session")
 	}
 
-	// Try to get existing client
-	client := GetTfeClient(session.SessionID())
-	if client != nil {
-		return client, nil
+	// Try to get token and address from the current request
+	currentAddress := ctx.Value(contextKey(TerraformAddress)).(string)
+	if currentAddress == "" {
+		currentAddress = utils.GetEnv(TerraformAddress, DefaultTerraformAddress)
 	}
-
+	currentToken := ctx.Value(contextKey(TerraformToken)).(string)
+	if currentToken == "" {
+		currentToken = utils.GetEnv(TerraformToken, "")
+	}
+	// Check if the cached session ID's token+address match the current token+address
+	if value, ok := activeTfeClients.Load(session.SessionID()); ok {
+		cachedClient := value.(cachedTfeClient)
+		currentTokenHash := sha256.Sum256([]byte(currentToken))
+		if cachedClient.token == currentTokenHash && cachedClient.address == currentAddress {
+			return cachedClient.client, nil
+		}
+		// Current request token and address not found in cache. Delete the session ID from the sync map.
+		activeTfeClients.Delete(session.SessionID())
+	}
 	logger.Warnf("TFE client not found, creating a new one")
 	return CreateTfeClientForSession(ctx, session, logger)
 }

--- a/pkg/client/tfe_client.go
+++ b/pkg/client/tfe_client.go
@@ -112,6 +112,12 @@ func GetTfeClientFromContext(ctx context.Context, logger *log.Logger) (*tfe.Clie
 	if currentToken == "" {
 		currentToken = utils.GetEnv(TerraformToken, "")
 	}
+
+	// In a stateless mode the server does not assign any session ID to requests. We need to create new TF clients for every request in that case.
+	if session.SessionID() == "" {
+		return NewTfeClientForToken(currentAddress, parseTerraformSkipTLSVerify(ctx), currentToken, ctx.Value(contextKey(ClientIPKey)).(string), logger)
+	}
+
 	// Check if the cached session ID's token+address match the current token+address
 	if value, ok := activeTfeClients.Load(session.SessionID()); ok {
 		cachedClient := value.(cachedTfeClient)

--- a/pkg/client/tfe_client.go
+++ b/pkg/client/tfe_client.go
@@ -104,18 +104,20 @@ func GetTfeClientFromContext(ctx context.Context, logger *log.Logger) (*tfe.Clie
 	}
 
 	// Try to get token and address from the current request
-	currentAddress := ctx.Value(contextKey(TerraformAddress)).(string)
+	currentAddress, _ := ctx.Value(contextKey(TerraformAddress)).(string)
 	if currentAddress == "" {
 		currentAddress = utils.GetEnv(TerraformAddress, DefaultTerraformAddress)
 	}
-	currentToken := ctx.Value(contextKey(TerraformToken)).(string)
+	currentToken, _ := ctx.Value(contextKey(TerraformToken)).(string)
 	if currentToken == "" {
 		currentToken = utils.GetEnv(TerraformToken, "")
 	}
 
 	// In a stateless mode the server does not assign any session ID to requests. We need to create new TF clients for every request in that case.
 	if session.SessionID() == "" {
-		return NewTfeClientForToken(currentAddress, parseTerraformSkipTLSVerify(ctx), currentToken, ctx.Value(contextKey(ClientIPKey)).(string), logger)
+		logger.Info("Session ID is empty. Creating a new TF client.")
+		clientIP, _ := ctx.Value(contextKey(ClientIPKey)).(string)
+		return NewTfeClientForToken(currentAddress, parseTerraformSkipTLSVerify(ctx), currentToken, clientIP, logger)
 	}
 
 	// Check if the cached session ID's token+address match the current token+address

--- a/pkg/client/tfe_client.go
+++ b/pkg/client/tfe_client.go
@@ -29,9 +29,8 @@ const (
 var activeTfeClients sync.Map
 
 type cachedTfeClient struct {
-	client  *tfe.Client
-	token   [32]byte // Store the hash of the token instead of raw value
-	address string
+	client *tfe.Client
+	token  [32]byte // Store the hash of the token instead of raw value
 }
 
 // NewTfeClient creates a new TFE client for the given session
@@ -42,9 +41,8 @@ func NewTfeClient(sessionId string, terraformAddress string, terraformSkipTLSVer
 	}
 	// Store the token and address along with the client per session ID
 	activeTfeClients.Store(sessionId, cachedTfeClient{
-		client:  client,
-		token:   sha256.Sum256([]byte(terraformToken)),
-		address: terraformAddress,
+		client: client,
+		token:  sha256.Sum256([]byte(terraformToken)),
 	})
 	logger.Info("Created TFE client")
 	return client, nil
@@ -103,11 +101,7 @@ func GetTfeClientFromContext(ctx context.Context, logger *log.Logger) (*tfe.Clie
 		return nil, fmt.Errorf("no active session")
 	}
 
-	// Try to get token and address from the current request
-	currentAddress, _ := ctx.Value(contextKey(TerraformAddress)).(string)
-	if currentAddress == "" {
-		currentAddress = utils.GetEnv(TerraformAddress, DefaultTerraformAddress)
-	}
+	// Try to get token from the current request
 	currentToken, _ := ctx.Value(contextKey(TerraformToken)).(string)
 	if currentToken == "" {
 		currentToken = utils.GetEnv(TerraformToken, "")
@@ -116,6 +110,10 @@ func GetTfeClientFromContext(ctx context.Context, logger *log.Logger) (*tfe.Clie
 	// In a stateless mode the server does not assign any session ID to requests. We need to create new TF clients for every request in that case.
 	if session.SessionID() == "" {
 		logger.Info("Session ID is empty. Creating a new TF client.")
+		currentAddress, _ := ctx.Value(contextKey(TerraformAddress)).(string)
+		if currentAddress == "" {
+			currentAddress = utils.GetEnv(TerraformAddress, DefaultTerraformAddress)
+		}
 		clientIP, _ := ctx.Value(contextKey(ClientIPKey)).(string)
 		return NewTfeClientForToken(currentAddress, parseTerraformSkipTLSVerify(ctx), currentToken, clientIP, logger)
 	}
@@ -124,7 +122,7 @@ func GetTfeClientFromContext(ctx context.Context, logger *log.Logger) (*tfe.Clie
 	if value, ok := activeTfeClients.Load(session.SessionID()); ok {
 		cachedClient := value.(cachedTfeClient)
 		currentTokenHash := sha256.Sum256([]byte(currentToken))
-		if cachedClient.token == currentTokenHash && cachedClient.address == currentAddress {
+		if cachedClient.token == currentTokenHash {
 			return cachedClient.client, nil
 		}
 		// Current request token and address not found in cache. Delete the session ID from the sync map.


### PR DESCRIPTION
## PCI review checklist

This PR handles the security vulnerabilities mentioned in:
https://hashicorp.atlassian.net/browse/SECVULN-49459 - Cross-tenant HCP Terraform token reuse in stateless HTTP mode (multi-tenant token bleed)
https://hashicorp.atlassian.net/browse/SECVULN-47947 - Session-scoped TFE client cache bypasses per-token request validation in StreamableHTTP mode

In addition, it also adds a clean way of deleting session limiters for a session when a session unregisters. This functionality replaces the CleanupSessions in ratelimit.go which was never called before.




<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
