### PR TITLE
fix: prevent organization allowlist token bypass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 FIXES
 
+* Ensure organization allowlist validation and downstream Terraform API requests use the same Authorization bearer token, preventing a conflicting `TFE_TOKEN` header from bypassing the allowlist. [396](https://github.com/hashicorp/terraform-mcp-server/pull/396)
 * Disable client-supplied `TFE_ADDRESS` in streamable-http mode. Previously a client could override the Terraform address via HTTP header or query parameter, redirecting the server's requests and Authorization bearer token to an arbitrary endpoint. The address must now be configured server-side via the `TFE_ADDRESS` env var. This is a breaking change: clients supplying the address via header or query parameter now receive a 403. [389](https://github.com/hashicorp/terraform-mcp-server/pull/389)
 * Fix http server not serving TLS when configured [391](https://github.com/hashicorp/terraform-mcp-server/pull/391)
 * Make client IP sourcing configurable and fix insecure X-Forwarded-For handling. The server previously trusted the leftmost `X-Forwarded-For` value,had no IPv6 support, and did not validate IPs. Sourcing is now configurable via `MCP_REMOTE_IP_METHOD` (`RemoteAddr`, `X-Real-IP`, `X-Forwarded-For`) and `MCP_XFF_TRUSTED_HOPS`, defaulting to the secure `RemoteAddr`. This is a breaking change: proxy deployments relying on automatic `X-Forwarded-For` forwarding must now set `MCP_REMOTE_IP_METHOD=X-Forwarded-For` and `MCP_XFF_TRUSTED_HOPS`. [388](https://github.com/hashicorp/terraform-mcp-server/pull/388)

--- a/README.md
+++ b/README.md
@@ -581,7 +581,7 @@ export MCP_SESSION_MODE=stateless
 
 When running the MCP server centrally (StreamableHTTP mode) for multiple users, each user can pass their own Terraform token via HTTP headers for RBAC enforcement. This allows a single server instance to serve multiple users with different permissions.
 
-When `MCP_ORGANIZATION_ALLOWLIST` or `--organization-allowlist` is configured, the allowlist must be a CSV list of HCP Terraform organization names. The server requires `Authorization: Bearer <token>` and rejects requests unless that token can access at least one organization in the CSV allowlist. Organization name matching is case-insensitive. If the configured CSV value parses to zero organization names, the server exits with a malformed organization allowlist error.
+When `MCP_ORGANIZATION_ALLOWLIST` or `--organization-allowlist` is configured, the allowlist must be a CSV list of HCP Terraform organization names. The server requires `Authorization: Bearer <token>` and rejects requests unless that token can access at least one organization in the CSV allowlist. The bearer token takes precedence if the request also includes a `TFE_TOKEN` header, ensuring the token validated by the allowlist is the token used for Terraform API requests. Organization name matching is case-insensitive. If the configured CSV value parses to zero organization names, the server exits with a malformed organization allowlist error.
 
 ## Client IP Forwarding
 

--- a/pkg/client/middleware.go
+++ b/pkg/client/middleware.go
@@ -272,7 +272,7 @@ func tokenHasAllowedOrganization(ctx context.Context, lister organizationLister,
 func getTokenFromAuthHeader(r *http.Request) string {
 	authHeader := r.Header.Get("Authorization")
 	if strings.HasPrefix(authHeader, "Bearer ") {
-		return strings.TrimPrefix(authHeader, "Bearer ")
+		return strings.TrimSpace(strings.TrimPrefix(authHeader, "Bearer "))
 	}
 	return ""
 }
@@ -306,12 +306,14 @@ func TerraformContextMiddleware(logger *log.Logger) func(http.Handler) http.Hand
 			for _, header := range clientHeaders {
 				var headerValue string
 
-				// Check standard header first
-				headerValue = r.Header.Get(header)
-
-				// For token, also support Authorization: Bearer header as fallback
-				if headerValue == "" && header == TerraformToken {
+				// The allowlist validates the Authorization bearer token, so it must
+				// also be the token used for downstream Terraform API requests.
+				if header == TerraformToken {
 					headerValue = getTokenFromAuthHeader(r)
+				}
+
+				if headerValue == "" {
+					headerValue = r.Header.Get(header)
 				}
 
 				if headerValue == "" {

--- a/pkg/client/middleware_test.go
+++ b/pkg/client/middleware_test.go
@@ -495,6 +495,52 @@ func TestOrganizationAllowlistMiddleware(t *testing.T) {
 	}
 }
 
+func TestOrganizationAllowlistUsesValidatedTokenDownstream(t *testing.T) {
+	logger := log.New()
+	logger.SetLevel(log.ErrorLevel)
+
+	upstreamAuthorization := make(chan string, 1)
+	terraformServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v2/organizations" {
+			select {
+			case upstreamAuthorization <- r.Header.Get("Authorization"):
+			default:
+			}
+		}
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		_, err := io.WriteString(w, `{"data":[{"id":"alpha","type":"organizations","attributes":{"name":"alpha"}}]}`)
+		assert.NoError(t, err)
+	}))
+	t.Cleanup(terraformServer.Close)
+	t.Setenv(TerraformAddress, terraformServer.URL)
+
+	var downstreamToken string
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		downstreamToken, _ = r.Context().Value(contextKey(TerraformToken)).(string)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := TerraformContextMiddleware(logger)(
+		OrganizationAllowlistMiddleware([]string{"alpha"}, logger)(next),
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer allowed-token")
+	req.Header.Set(TerraformToken, "different-token")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	select {
+	case authorization := <-upstreamAuthorization:
+		assert.Equal(t, "Bearer allowed-token", authorization)
+	default:
+		t.Error("expected organization allowlist request")
+	}
+	assert.Equal(t, "allowed-token", downstreamToken)
+}
+
 func TestTokenHasAllowedOrganization(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -623,7 +669,12 @@ func TestGetTokenFromAuthHeader(t *testing.T) {
 		{
 			name:     "Bearer with whitespace token",
 			headers:  map[string]string{"Authorization": "Bearer   "},
-			expected: "  ",
+			expected: "",
+		},
+		{
+			name:     "Bearer token with surrounding whitespace",
+			headers:  map[string]string{"Authorization": "Bearer   my-token  "},
+			expected: "my-token",
 		},
 		{
 			name:     "Bearer lowercase",
@@ -706,7 +757,7 @@ func TestTerraformContextMiddleware(t *testing.T) {
 			},
 		},
 		{
-			name: "standard header takes priority over Authorization Bearer",
+			name: "Authorization Bearer takes priority over standard header",
 			headers: map[string]string{
 				TerraformToken:  "standard-token",
 				"Authorization": "Bearer bearer-token",
@@ -715,7 +766,7 @@ func TestTerraformContextMiddleware(t *testing.T) {
 			envVars:        map[string]string{},
 			expectedStatus: http.StatusOK,
 			expectedContextVals: map[string]string{
-				TerraformToken: "standard-token",
+				TerraformToken: "bearer-token",
 			},
 		},
 		{

--- a/pkg/client/middleware_test.go
+++ b/pkg/client/middleware_test.go
@@ -499,13 +499,10 @@ func TestOrganizationAllowlistUsesValidatedTokenDownstream(t *testing.T) {
 	logger := log.New()
 	logger.SetLevel(log.ErrorLevel)
 
-	upstreamAuthorization := make(chan string, 1)
+	var upstreamAuthorization string
 	terraformServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/api/v2/organizations" {
-			select {
-			case upstreamAuthorization <- r.Header.Get("Authorization"):
-			default:
-			}
+			upstreamAuthorization = r.Header.Get("Authorization")
 		}
 		w.Header().Set("Content-Type", "application/vnd.api+json")
 		_, err := io.WriteString(w, `{"data":[{"id":"alpha","type":"organizations","attributes":{"name":"alpha"}}]}`)
@@ -532,12 +529,7 @@ func TestOrganizationAllowlistUsesValidatedTokenDownstream(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 
 	assert.Equal(t, http.StatusOK, rr.Code)
-	select {
-	case authorization := <-upstreamAuthorization:
-		assert.Equal(t, "Bearer allowed-token", authorization)
-	default:
-		t.Error("expected organization allowlist request")
-	}
+	assert.Equal(t, "Bearer allowed-token", upstreamAuthorization)
 	assert.Equal(t, "allowed-token", downstreamToken)
 }
 


### PR DESCRIPTION
## What was wrong

When the organization allowlist was enabled, the server checked the token from the `Authorization: Bearer ...` header to decide whether a request could access an allowed organization.

However, the request context preferred the token from the `TFE_TOKEN` header. A caller could provide an allowed token in the Authorization header and a different token in the `TFE_TOKEN` header. The request would pass the allowlist check, but Terraform API operations would use the different, unchecked token.

## What changed

The Authorization bearer token now takes precedence over the `TFE_TOKEN` header. This makes the token checked by the organization allowlist the same token used for downstream Terraform API requests.

Bearer tokens are also trimmed of surrounding whitespace so the value checked by the allowlist exactly matches the value stored in the request context. Requests can still use the `TFE_TOKEN` header as a fallback when no bearer token is present and the organization allowlist is not enabled.

The README now documents the precedence when both headers are provided.

## How this is tested

`TestTerraformContextMiddleware` provides different values in the Authorization and `TFE_TOKEN` headers and verifies that the request context receives the bearer token. This proves downstream Terraform clients will select the token that the allowlist checks.

`TestOrganizationAllowlistUsesValidatedTokenDownstream` composes the Terraform context and organization allowlist middleware in the same order used by the HTTP server. It sends an allowed bearer token together with a different `TFE_TOKEN`, then verifies two things:

- The fake Terraform API receives the allowed bearer token when the server checks organization membership.
- The wrapped downstream handler receives that same allowed token instead of the conflicting `TFE_TOKEN` value.

The bearer-token parsing tests also verify that blank tokens are rejected and surrounding whitespace is removed consistently.

The complete test suite passes with:

```text
go test ./... -count=1
```
