### PR TITLE
fix: honor JSON log format for metrics logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 FIXES
 
+* Ensure StreamableHTTP startup, metrics configuration, and OTel error logs honor `LOG_FORMAT=json`. [401](https://github.com/hashicorp/terraform-mcp-server/pull/401)
 * Ensure organization allowlist validation and downstream Terraform API requests use the same Authorization bearer token, preventing a conflicting `TFE_TOKEN` header from bypassing the allowlist. [396](https://github.com/hashicorp/terraform-mcp-server/pull/396)
 * Disable client-supplied `TFE_ADDRESS` in streamable-http mode. Previously a client could override the Terraform address via HTTP header or query parameter, redirecting the server's requests and Authorization bearer token to an arbitrary endpoint. The address must now be configured server-side via the `TFE_ADDRESS` env var. This is a breaking change: clients supplying the address via header or query parameter now receive a 403. [389](https://github.com/hashicorp/terraform-mcp-server/pull/389)
 * Fix http server not serving TLS when configured [391](https://github.com/hashicorp/terraform-mcp-server/pull/391)

--- a/cmd/terraform-mcp-server/init.go
+++ b/cmd/terraform-mcp-server/init.go
@@ -99,7 +99,7 @@ var (
 			if err != nil {
 				stdlog.Fatal(err)
 			}
-			stdlog.Printf("Starting StreamableHTTP server with host: %s, port: %s, endpoint: %s, heartbeatInterval: %v, enabledToolsets: %v, organizationAllowlistConfigured: %t, organizationAllowlistCount: %d", host, port, endpointPath, heartbeatInterval, enabledToolsets, len(organizationAllowlist) > 0, len(organizationAllowlist))
+			logger.Infof("Starting StreamableHTTP server with host: %s, port: %s, endpoint: %s, heartbeatInterval: %v, enabledToolsets: %v, organizationAllowlistConfigured: %t, organizationAllowlistCount: %d", host, port, endpointPath, heartbeatInterval, enabledToolsets, len(organizationAllowlist) > 0, len(organizationAllowlist))
 			metricsConfig, shutdownMetrics := setupMetrics(logger)
 			defer shutdownMetrics()
 

--- a/cmd/terraform-mcp-server/main.go
+++ b/cmd/terraform-mcp-server/main.go
@@ -397,7 +397,7 @@ func getOrganizationAllowlist(cmd *cobra.Command) ([]string, error) {
 }
 
 func setupMetrics(logger *log.Logger) (client.MetricsConfig, func()) {
-	metricsConfig := client.LoadMetricsConfigFromEnv()
+	metricsConfig := client.LoadMetricsConfigFromEnvWithLogger(logger)
 	logger.Infof("Metrics enabled: %t endpoint: %s exportInterval: %s", metricsConfig.Enabled, metricsConfig.Endpoint, metricsConfig.ExportInterval)
 	if !metricsConfig.Enabled {
 		return metricsConfig, func() {}
@@ -406,7 +406,7 @@ func setupMetrics(logger *log.Logger) (client.MetricsConfig, func()) {
 	// Context for metrics is for tracking the lifecycle of the metrics setup and shutdown, not tied to individual tool calls.
 	ctxMetrics := context.Background()
 	otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) {
-		log.Errorf("OTel Internal Error: %v", err)
+		logger.Errorf("OTel Internal Error: %v", err)
 	}))
 
 	shutdown, err := initMetrics(ctxMetrics, &metricsConfig, logger)

--- a/pkg/client/metrics.go
+++ b/pkg/client/metrics.go
@@ -48,41 +48,49 @@ func DefaultMetricsConfig() MetricsConfig {
 }
 
 func LoadMetricsConfigFromEnv() MetricsConfig {
+	return LoadMetricsConfigFromEnvWithLogger(log.StandardLogger())
+}
+
+func LoadMetricsConfigFromEnvWithLogger(logger *log.Logger) MetricsConfig {
+	if logger == nil {
+		logger = log.StandardLogger()
+	}
+
 	config := DefaultMetricsConfig()
 	if endpoint := os.Getenv("OTEL_METRICS_ENDPOINT"); endpoint != "" {
 		config.Endpoint = endpoint
-		log.Infof("Using env value for OTEL_METRICS_ENDPOINT: %s", endpoint)
+		logger.Infof("Using env value for OTEL_METRICS_ENDPOINT: %s", endpoint)
 	} else {
-		log.Infof("OTEL_METRICS_ENDPOINT not set in env, using default: %s", config.Endpoint)
+		logger.Infof("OTEL_METRICS_ENDPOINT not set in env, using default: %s", config.Endpoint)
 	}
 	if interval := os.Getenv("OTEL_METRICS_EXPORT_INTERVAL"); interval != "" {
 		if dur, err := time.ParseDuration(interval); err == nil {
 			config.ExportInterval = dur
-			log.Infof("Using env value for OTEL_METRICS_EXPORT_INTERVAL: %s", interval)
+			logger.Infof("Using env value for OTEL_METRICS_EXPORT_INTERVAL: %s", interval)
 		} else {
-			log.Warnf("Error parsing OTEL_METRICS_EXPORT_INTERVAL: %v", err)
-			log.Infof("Using default export interval: %s", config.ExportInterval)
+			logger.Warnf("Error parsing OTEL_METRICS_EXPORT_INTERVAL: %v", err)
+			logger.Infof("Using default export interval: %s", config.ExportInterval)
 		}
 	} else {
-		log.Infof("OTEL_METRICS_EXPORT_INTERVAL not set in env, using default: %s", config.ExportInterval)
+		logger.Infof("OTEL_METRICS_EXPORT_INTERVAL not set in env, using default: %s", config.ExportInterval)
 	}
 	if serviceName := os.Getenv("OTEL_METRICS_SERVICE_NAME"); serviceName != "" {
 		config.ServiceName = serviceName
-		log.Infof("Using env value for OTEL_METRICS_SERVICE_NAME: %s", serviceName)
+		logger.Infof("Using env value for OTEL_METRICS_SERVICE_NAME: %s", serviceName)
 	} else {
-		log.Infof("OTEL_METRICS_SERVICE_NAME not set in env, using default: %s", config.ServiceName)
+		logger.Infof("OTEL_METRICS_SERVICE_NAME not set in env, using default: %s", config.ServiceName)
 	}
 	if serviceVersion := os.Getenv("OTEL_METRICS_SERVICE_VERSION"); serviceVersion != "" {
 		config.ServiceVersion = serviceVersion
-		log.Infof("Using env value for OTEL_METRICS_SERVICE_VERSION: %s", serviceVersion)
+		logger.Infof("Using env value for OTEL_METRICS_SERVICE_VERSION: %s", serviceVersion)
 	} else {
-		log.Infof("OTEL_METRICS_SERVICE_VERSION not set in env, using default: %s", config.ServiceVersion)
+		logger.Infof("OTEL_METRICS_SERVICE_VERSION not set in env, using default: %s", config.ServiceVersion)
 	}
 	if enabled := os.Getenv("OTEL_METRICS_ENABLED"); enabled == "true" {
 		config.Enabled = true
-		log.Infof("OTEL_METRICS_ENABLED set to true in env, enabling metrics")
+		logger.Infof("OTEL_METRICS_ENABLED set to true in env, enabling metrics")
 	} else {
-		log.Infof("OTEL_METRICS_ENABLED not set in env, using default: %t", config.Enabled)
+		logger.Infof("OTEL_METRICS_ENABLED not set in env, using default: %t", config.Enabled)
 	}
 	return config
 }

--- a/pkg/client/metrics_test.go
+++ b/pkg/client/metrics_test.go
@@ -1,8 +1,11 @@
 package client
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -54,6 +57,31 @@ func TestLoadMetricsConfigFromEnv(t *testing.T) {
 		assert.Equal(t, defaults.ServiceVersion, config.ServiceVersion)
 		assert.False(t, config.Enabled)
 	})
+}
+
+func TestLoadMetricsConfigFromEnvWithLoggerUsesConfiguredFormatter(t *testing.T) {
+	t.Setenv("OTEL_METRICS_ENDPOINT", "collector.internal:4318")
+	t.Setenv("OTEL_METRICS_EXPORT_INTERVAL", "not-a-duration")
+	t.Setenv("OTEL_METRICS_SERVICE_NAME", "custom-mcp")
+	t.Setenv("OTEL_METRICS_SERVICE_VERSION", "1.2.3")
+	t.Setenv("OTEL_METRICS_ENABLED", "true")
+
+	var buf bytes.Buffer
+	logger := log.New()
+	logger.SetOutput(&buf)
+	logger.SetFormatter(&log.JSONFormatter{})
+
+	config := LoadMetricsConfigFromEnvWithLogger(logger)
+
+	assert.True(t, config.Enabled)
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		require.NotEmpty(t, line)
+
+		var entry map[string]any
+		require.NoError(t, json.Unmarshal([]byte(line), &entry), "log line should be JSON: %s", line)
+		require.Contains(t, entry, "level")
+		require.Contains(t, entry, "msg")
+	}
 }
 
 func TestRecordToolCallRecordsMetrics(t *testing.T) {


### PR DESCRIPTION
## Summary
- route metrics environment logging through the configured server logger
- log streamable-http startup and OTel error handler messages through the same logger
- add regression coverage that verifies metrics config logs respect a JSON formatter

Fixes #400.

## Validation
- `make build`
- `go test ./pkg/client -run 'TestLoadMetricsConfigFromEnv|TestRecord'`\n- `go test ./cmd/terraform-mcp-server -run 'TestSetupMetrics|TestInitMetrics|TestGetLogFormat|TestInitLogger'`\n- `go test $(go list ./... | grep -v '/e2e$')`\n- manually reproduced `LOG_FORMAT=json OTEL_METRICS_ENABLED=true ... ./bin/terraform-mcp-server streamable-http ...`; the previously plaintext startup/metrics/OTel lines now emit as JSON\n\n`go test ./...` also runs Docker-backed e2e tests in this repo; those fail in my local environment because Docker is not installed (`bash: docker: command not found`).