### PR TITLE
Replace localhost TLS bypass with --insecure-no-tls flag

### DIFF
--- a/.github/workflows/loadtest.yml
+++ b/.github/workflows/loadtest.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Start server
         run: |
-          ./terraform-mcp-server http -p 8080 &
+          ./terraform-mcp-server http -p 8080 --insecure-no-tls &
           sleep 3
           curl -sf http://localhost:8080/health || exit 1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ FEATURES
 * [New Tool] `get_state_version` Retrieves a Terraform state version. If `state_version_id` is provided, retrieves that specific state version. Otherwise, retrieves the latest state version for the specified `workspace_id`. One of `state_version_id` or `workspace_id` must be provided.
 * [New Tool] `get_run_comments` Lists all discussion comments associated with a given Terraform run. Requires `run_id`.
 
+BREAKING CHANGES
+
+* The StreamableHTTP server no longer skips the TLS requirement when binding to localhost or `0.0.0.0`. TLS is now required unless you explicitly opt out with the `--insecure-no-tls` flag (or `INSECURE_NO_TLS=true`). Deployments that previously relied on the localhost/`0.0.0.0` bypass must now opt out explicitly.
+
 # 1.1.0
 
 FIXES

--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ automation and interaction capabilities for Infrastructure as Code (IaC) develop
 | `MCP_SESSION_MODE` | Session mode: `stateful` or `stateless` | `stateful` |
 | `MCP_ALLOWED_ORIGINS` | Comma-separated list of allowed origins for CORS | `""` (empty) |
 | `MCP_CORS_MODE` | CORS mode: `strict`, `development`, or `disabled` | `strict` |
-| `MCP_TLS_CERT_FILE` | Path to TLS cert file, required for non-localhost deployment (e.g. `/path/to/cert.pem`) | `""` (empty) |
-| `MCP_TLS_KEY_FILE` |  Path to TLS key file, required for non-localhost deployment (e.g. `/path/to/key.pem`)| `""` (empty) |
+| `MCP_TLS_CERT_FILE` | Path to TLS cert file (e.g. `/path/to/cert.pem`). TLS is required unless `INSECURE_NO_TLS` is set. | `""` (empty) |
+| `MCP_TLS_KEY_FILE` | Path to TLS key file (e.g. `/path/to/key.pem`). TLS is required unless `INSECURE_NO_TLS` is set. | `""` (empty) |
+| `INSECURE_NO_TLS` | Allow the StreamableHTTP server to start without TLS. Only use when TLS is terminated upstream (e.g. a reverse proxy or load balancer). Not recommended for production. | `false` |
 | `MCP_RATE_LIMIT_GLOBAL` | Global rate limit (format: `rps:burst`) | `10:20` |
 | `MCP_RATE_LIMIT_SESSION` | Per-session rate limit (format: `rps:burst`) | `5:10` |
 | `MCP_ORGANIZATION_ALLOWLIST` | CSV list of HCP Terraform organization names allowed to access the HTTP server | `""` (empty) |
@@ -67,8 +68,7 @@ automation and interaction capabilities for Infrastructure as Code (IaC) develop
 terraform-mcp-server stdio [--log-file /path/to/log] [--log-level info] [--log-format text] [--toolsets <toolsets>] [--tools <tools>]
 
 # StreamableHTTP mode
-terraform-mcp-server streamable-http [--transport-port 8080] [--transport-host 127.0.0.1] [--mcp-endpoint /mcp] [--organization-allowlist <orgs-csv>] [--log-file /path/to/log] [--log-level info] [--log-format text] [--toolsets <toolsets>] [--tools <tools>]
-```
+terraform-mcp-server streamable-http [--transport-port 8080] [--transport-host 127.0.0.1] [--mcp-endpoint /mcp] [--organization-allowlist <orgs-csv>] [--insecure-no-tls] [--log-file /path/to/log] [--log-level info] [--log-format text] [--toolsets <toolsets>] [--tools <tools>]
 
 ## Instructions
 
@@ -328,7 +328,7 @@ claude mcp add terraform -s user -t stdio -- docker run -i --rm hashicorp/terraf
 
 ```sh
 # Run server (example)
-docker run -p 8080:8080 --rm -e TRANSPORT_MODE=streamable-http -e TRANSPORT_HOST=0.0.0.0 hashicorp/terraform-mcp-server
+docker run -p 8080:8080 --rm -e TRANSPORT_MODE=streamable-http -e TRANSPORT_HOST=0.0.0.0 -e INSECURE_NO_TLS=true hashicorp/terraform-mcp-server
 
 # Add to Claude Code
 claude mcp add --transport http terraform http://localhost:8080/mcp
@@ -479,14 +479,14 @@ make docker-build
 docker run -i --rm terraform-mcp-server:dev
 
 # Run in streamable-http mode
-docker run -p 8080:8080 --rm -e TRANSPORT_MODE=streamable-http -e TRANSPORT_HOST=0.0.0.0 terraform-mcp-server:dev
+docker run -p 8080:8080 --rm -e TRANSPORT_MODE=streamable-http -e TRANSPORT_HOST=0.0.0.0 -e INSECURE_NO_TLS=true terraform-mcp-server:dev
 
 # Filter tools (optional)
 docker run -i --rm terraform-mcp-server:dev --toolsets=registry,terraform
 docker run -i --rm terraform-mcp-server:dev --tools=search_providers,get_provider_details
 ```
 
-> **Note:** When running in Docker, you should set `TRANSPORT_HOST=0.0.0.0` to allow connections from outside the container.
+> **Note:** When running in Docker, set `TRANSPORT_HOST=0.0.0.0` to allow connections from outside the container. Since the server requires TLS by default, also set `INSECURE_NO_TLS=true` if you're terminating TLS elsewhere (or provide `MCP_TLS_CERT_FILE`/`MCP_TLS_KEY_FILE`).
 
 4. (Optional) Test connection in http mode
 

--- a/cmd/terraform-mcp-server/init.go
+++ b/cmd/terraform-mcp-server/init.go
@@ -109,11 +109,16 @@ var (
 			if err != nil {
 				stdlog.Fatal(err)
 			}
+
+			insecureNoTLS, err := cmd.Flags().GetBool("insecure-no-tls")
+			if err != nil {
+				stdlog.Fatal("Failed to get insecure-no-tls flag:", err)
+			}
 			logger.Printf("Starting StreamableHTTP server with host: %s, port: %s, endpoint: %s, heartbeatInterval: %v, enabledToolsets: %v, organizationAllowlistConfigured: %t, organizationAllowlistCount: %d", host, port, endpointPath, heartbeatInterval, enabledToolsets, len(organizationAllowlist) > 0, len(organizationAllowlist))
 			metricsConfig, shutdownMetrics := setupMetrics(logger)
 			defer shutdownMetrics()
 
-			if err := runHTTPServer(logger, host, port, endpointPath, heartbeatInterval, enabledToolsets, metricsConfig, organizationAllowlist); err != nil {
+			if err := runHTTPServer(logger, host, port, endpointPath, heartbeatInterval, enabledToolsets, metricsConfig, organizationAllowlist, insecureNoTLS); err != nil {
 				stdlog.Fatal("failed to run streamableHTTP server:", err)
 			}
 		},
@@ -147,6 +152,7 @@ func init() {
 	streamableHTTPCmd.Flags().Duration("heartbeat-interval", 0, "Heartbeat interval for HTTP connections (e.g., 30s). 0 to disable")
 	streamableHTTPCmd.Flags().String("mcp-endpoint", "/mcp", "Path for streamable HTTP endpoint")
 	streamableHTTPCmd.Flags().String("organization-allowlist", "", "Comma-separated list of HCP Terraform organization names allowed to access the HTTP server")
+	streamableHTTPCmd.Flags().Bool("insecure-no-tls", false, "Allow the server to start without TLS. Not recommended for production use.")
 
 	// Add the same flags to the alias command for backward compatibility
 	httpCmdAlias.Flags().String("transport-host", "127.0.0.1", "Host to bind to")
@@ -154,6 +160,7 @@ func init() {
 	httpCmdAlias.Flags().String("mcp-endpoint", "/mcp", "Path for streamable HTTP endpoint")
 	httpCmdAlias.Flags().Duration("heartbeat-interval", 0, "Heartbeat interval for HTTP connections (e.g., 30s). 0 to disable")
 	httpCmdAlias.Flags().String("organization-allowlist", "", "Comma-separated list of HCP Terraform organization names allowed to access the HTTP server")
+	httpCmdAlias.Flags().Bool("insecure-no-tls", false, "Allow the server to start without TLS. Not recommended for production use.")
 
 	rootCmd.AddCommand(stdioCmd)
 	rootCmd.AddCommand(streamableHTTPCmd)
@@ -294,8 +301,7 @@ func setupInstana(logger *log.Logger) instana.TracerLogger {
 	})
 }
 
-func streamableHTTPServerInit(ctx context.Context, hcServer *server.MCPServer, logger *log.Logger, host string, port string, endpointPath string, heartbeatInterval time.Duration, organizationAllowlist []string) error {
-	// Ensure endpoint path starts with /
+func streamableHTTPServerInit(ctx context.Context, hcServer *server.MCPServer, logger *log.Logger, host string, port string, endpointPath string, heartbeatInterval time.Duration, organizationAllowlist []string, insecureNoTLS bool) error {
 	endpointPath = path.Join("/", endpointPath)
 	var handler http.Handler
 
@@ -410,10 +416,10 @@ func streamableHTTPServerInit(ctx context.Context, hcServer *server.MCPServer, l
 		httpServer.TLSConfig = tlsConfig.Config
 		logger.Infof("TLS enabled with certificate: %s", tlsConfig.CertFile)
 	} else {
-		if !client.IsLocalHost(host) {
-			return fmt.Errorf("TLS is required for non-localhost binding (%s). Set MCP_TLS_CERT_FILE and MCP_TLS_KEY_FILE environment variables", host)
+		if !insecureNoTLS {
+			return fmt.Errorf("TLS is required for the StreamableHTTP server. Set MCP_TLS_CERT_FILE and MCP_TLS_KEY_FILE, or pass --insecure-no-tls to explicitly opt out")
 		}
-		logger.Warnf("TLS is disabled on StreamableHTTP server; this is not recommended for production")
+		logger.Warnf("TLS is disabled on StreamableHTTP server (--insecure-no-tls); this is not recommended for production")
 	}
 
 	// Start server in goroutine

--- a/cmd/terraform-mcp-server/main.go
+++ b/cmd/terraform-mcp-server/main.go
@@ -36,7 +36,7 @@ import (
 var instructions string
 var sessionClientInfo sync.Map // map[string]client.ClientInfo
 
-func runHTTPServer(logger *log.Logger, host string, port string, endpointPath string, heartbeatInterval time.Duration, enabledToolsets []string, metricsConfig client.MetricsConfig, organizationAllowlist []string) error {
+func runHTTPServer(logger *log.Logger, host string, port string, endpointPath string, heartbeatInterval time.Duration, enabledToolsets []string, metricsConfig client.MetricsConfig, organizationAllowlist []string, insecureNoTLS bool) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
@@ -72,7 +72,7 @@ func runHTTPServer(logger *log.Logger, host string, port string, endpointPath st
 	})
 	attachMetricsHooks(hooks, metricsConfig, logger)
 
-	return streamableHTTPServerInit(ctx, hcServer, logger, host, port, endpointPath, heartbeatInterval, organizationAllowlist)
+	return streamableHTTPServerInit(ctx, hcServer, logger, host, port, endpointPath, heartbeatInterval, organizationAllowlist, insecureNoTLS)
 }
 
 func attachMetricsHooks(hooks *server.Hooks, metricsConfig client.MetricsConfig, logger *log.Logger) {
@@ -299,7 +299,8 @@ func main() {
 		if err != nil {
 			stdlog.Fatal(err)
 		}
-		if err := runHTTPServer(logger, host, port, endpointPath, heartbeatInterval, enabledToolsets, metricsConfig, organizationAllowlist); err != nil {
+		insecureNoTLS := strings.ToLower(os.Getenv("INSECURE_NO_TLS")) == "true"
+		if err := runHTTPServer(logger, host, port, endpointPath, heartbeatInterval, enabledToolsets, metricsConfig, organizationAllowlist, insecureNoTLS); err != nil {
 			stdlog.Fatal("failed to run StreamableHTTP server:", err)
 		}
 		return

--- a/e2e/cors_e2e_test.go
+++ b/e2e/cors_e2e_test.go
@@ -93,6 +93,7 @@ func startHTTPContainerWithCORS(t *testing.T, port, mode, origins string) string
 		"docker", "run", "-d", "--rm",
 		"-e", "TRANSPORT_MODE=streamable-http",
 		"-e", "TRANSPORT_HOST=0.0.0.0",
+		"-e", "INSECURE_NO_TLS=true",
 		"-e", "MCP_SESSION_MODE=stateful",
 		"-e", "MCP_RATE_LIMIT_GLOBAL=50:100",
 		"-e", fmt.Sprintf("MCP_CORS_MODE=%s", mode),

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -433,6 +433,7 @@ func startHTTPContainer(t *testing.T, port string) string {
 		"docker", "run", "-d", "--rm",
 		"-e", "TRANSPORT_MODE=streamable-http",
 		"-e", "TRANSPORT_HOST=0.0.0.0",
+		"-e", "INSECURE_NO_TLS=true",
 		"-e", "MCP_SESSION_MODE=stateful",
 		"-e", "MCP_RATE_LIMIT_GLOBAL=50:100",
 		"-e", "MCP_RATE_LIMIT_SESSION=50:100",

--- a/pkg/client/tls.go
+++ b/pkg/client/tls.go
@@ -7,7 +7,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"os"
-	"strings"
 )
 
 type TLSConfig struct {
@@ -74,13 +73,4 @@ func GetTLSConfigFromEnv() (*TLSConfig, error) {
 		CertFile: certFile,
 		KeyFile:  keyFile,
 	}, nil
-}
-
-func IsLocalHost(host string) bool {
-	h := strings.ToLower(host)
-	return h == "localhost" ||
-		h == "127.0.0.1" ||
-		h == "::1" ||
-		h == "[::1]" ||
-		h == "0.0.0.0"
 }


### PR DESCRIPTION
## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

The StreamableHTTP server currently skips the TLS requirement when the bind host are localhost or 0.0.0.0, via IsLocalHost. Since 0.0.0.0 binds all interfaces rather than just localhost, this PR removes that automatic bypass.
TLS is now required for the StreamableHTTP server, and running without it has to be an explicit opt-out rather than something that happens based on the bind host.

Tested locally, checking theaw paths:

No TLS, no opt-out > it errors
--insecure-no-tls flag > starts with a warning
INSECURE_NO_TLS=true > starts with a warning
TLS cert/key set > starts normally

This introduces a breaking change: deployments that relied on the `localhost/0.0.0.0` bypass must now either configure `TLS (MCP_TLS_CERT_FILE/MCP_TLS_KEY_FILE)` or explicitly opt out with` --insecure-no-tls (or INSECURE_NO_TLS=true).`

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
