### PR TITLE
Add `add_team_member` tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ FEATURES
 * [New Tool] `get_run_comments` Lists all discussion comments associated with a given Terraform run. Requires `run_id`.
 * [New Tool] `create_project` Creates a new Terraform project in the specified organization. Requires `terraform_org_name` and `project_name`. [420](https://github.com/hashicorp/terraform-mcp-server/pull/420)
 * [New Tool] `delete_project` Deletes a Terraform project by ID. Requires `project_id`. TFC/TFE will refuse to delete a project that still contains workspaces or stacks. [420](https://github.com/hashicorp/terraform-mcp-server/pull/420)
-* [New Tool] `add_team_member` Adds one or more members to a Terraform team. Requires `team_id`; accepts `username` (comma-separated, accepted-invite users only) and/or `organization_membership_ids` (comma-separated, works for pending and accepted invites). Both inputs can be provided in a single call — each is submitted as a separate API request and partial results are reported independently.
 
 IMPROVEMENTS
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.3.0
+
+FEATURES
+
+* [New Tool] `add_team_member` Adds one or more members to a Terraform team. Requires `team_id`; accepts `username` (comma-separated, accepted-invite users only) and/or `organization_membership_ids` (comma-separated, works for pending and accepted invites). Both inputs can be provided in a single call — each is submitted as a separate API request and partial results are reported independently.
+
 # 1.2.0
 
 FEATURES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ FEATURES
 * [New Tool] `get_run_comments` Lists all discussion comments associated with a given Terraform run. Requires `run_id`.
 * [New Tool] `create_project` Creates a new Terraform project in the specified organization. Requires `terraform_org_name` and `project_name`. [420](https://github.com/hashicorp/terraform-mcp-server/pull/420)
 * [New Tool] `delete_project` Deletes a Terraform project by ID. Requires `project_id`. TFC/TFE will refuse to delete a project that still contains workspaces or stacks. [420](https://github.com/hashicorp/terraform-mcp-server/pull/420)
+* [New Tool] `add_team_member` Adds one or more members to a Terraform team. Requires `team_id`; accepts `username` (comma-separated, accepted-invite users only) and/or `organization_membership_ids` (comma-separated, works for pending and accepted invites). Both inputs can be provided in a single call — each is submitted as a separate API request and partial results are reported independently.
 
 IMPROVEMENTS
 

--- a/pkg/tools/dynamic_tool.go
+++ b/pkg/tools/dynamic_tool.go
@@ -161,7 +161,7 @@ func (r *DynamicToolRegistry) registerTFETools() {
 	}
 
 	// Only register add_team_member if TF operations are enabled AND toolset is enabled
-	if isTerraformOperationsEnabled() && toolsets.IsToolEnabled("add_team_member", r.enabledToolsets) {
+	if toolsets.IsToolEnabled("add_team_member", r.enabledToolsets) {
 		tool := r.createDynamicTFETool("add_team_member", tfeTools.AddTeamMember)
 		r.mcpServer.AddTool(tool.Tool, tool.Handler)
 	}

--- a/pkg/tools/dynamic_tool.go
+++ b/pkg/tools/dynamic_tool.go
@@ -160,6 +160,12 @@ func (r *DynamicToolRegistry) registerTFETools() {
 		r.mcpServer.AddTool(tool.Tool, tool.Handler)
 	}
 
+	// Only register add_team_member if TF operations are enabled AND toolset is enabled
+	if isTerraformOperationsEnabled() && toolsets.IsToolEnabled("add_team_member", r.enabledToolsets) {
+		tool := r.createDynamicTFETool("add_team_member", tfeTools.AddTeamMemeber)
+		r.mcpServer.AddTool(tool.Tool, tool.Handler)
+	}
+
 	// Registry-private toolset - Private provider tools
 	if toolsets.IsToolEnabled("search_private_providers", r.enabledToolsets) {
 		tool := r.createDynamicTFETool("search_private_providers", tfeTools.SearchPrivateProviders)

--- a/pkg/tools/dynamic_tool.go
+++ b/pkg/tools/dynamic_tool.go
@@ -162,7 +162,7 @@ func (r *DynamicToolRegistry) registerTFETools() {
 
 	// Only register add_team_member if TF operations are enabled AND toolset is enabled
 	if isTerraformOperationsEnabled() && toolsets.IsToolEnabled("add_team_member", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("add_team_member", tfeTools.AddTeamMemeber)
+		tool := r.createDynamicTFETool("add_team_member", tfeTools.AddTeamMember)
 		r.mcpServer.AddTool(tool.Tool, tool.Handler)
 	}
 

--- a/pkg/tools/tfe/add_team_member.go
+++ b/pkg/tools/tfe/add_team_member.go
@@ -1,0 +1,46 @@
+// Copyright IBM Corp. 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package tools
+
+import (
+	"context"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	log "github.com/sirupsen/logrus"
+)
+
+// AddTeamMemeber creates a tool to add a new member to your Terraform team.
+func AddTeamMemeber(logger *log.Logger) server.ServerTool {
+	return server.ServerTool{
+		Tool: mcp.NewTool(
+			"add_team_member",
+			mcp.WithDescription("Adds member’s to a team. This is a write operation"),
+			mcp.WithTitleAnnotation(`Adds member’s to a team`),
+			mcp.WithOpenWorldHintAnnotation(true),
+			mcp.WithReadOnlyHintAnnotation(false),
+			mcp.WithDestructiveHintAnnotation(false),
+			mcp.WithString("team_id",
+				mcp.Description("The Teams's id (e.g., 'team-abc123def456')"),
+			),
+			mcp.WithString("username",
+				mcp.Description("The Member's username"),
+			),
+			mcp.WithString("organization_membership_ids",
+				mcp.Description("The Org. membership's id"),
+			),
+		),
+
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return addTeamMemberHandler(ctx, request, logger)
+
+		},
+	}
+}
+
+// addTeamMemberHandler handles tool logics and functionality
+func addTeamMemberHandler(ctx context.Context, request mcp.CallToolRequest, logger *log.Logger) (*mcp.CallToolResult, error) {
+
+	return mcp.NewToolResultText(""), nil
+}

--- a/pkg/tools/tfe/add_team_member.go
+++ b/pkg/tools/tfe/add_team_member.go
@@ -5,7 +5,12 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
 
+	"github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-mcp-server/pkg/client"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	log "github.com/sirupsen/logrus"
@@ -22,13 +27,14 @@ func AddTeamMemeber(logger *log.Logger) server.ServerTool {
 			mcp.WithReadOnlyHintAnnotation(false),
 			mcp.WithDestructiveHintAnnotation(false),
 			mcp.WithString("team_id",
+				mcp.Required(),
 				mcp.Description("The Teams's id (e.g., 'team-abc123def456')"),
 			),
 			mcp.WithString("username",
-				mcp.Description("The Member's username"),
+				mcp.Description("Optional: Comma-separated list of usernames to add (e.g., 'alice' or 'alice, bob'). Only works for users who have accepted the organization invite."),
 			),
 			mcp.WithString("organization_membership_ids",
-				mcp.Description("The Org. membership's id"),
+				mcp.Description("Optional: Comma-separated list of organization membership IDs to add (e.g., 'ou-abc123' or 'ou-abc123, ou-def456'). Works for both accepted and pending organization invites. Prefer this over 'username' when the invitee has not yet accepted."),
 			),
 		),
 
@@ -42,5 +48,79 @@ func AddTeamMemeber(logger *log.Logger) server.ServerTool {
 // addTeamMemberHandler handles tool logics and functionality
 func addTeamMemberHandler(ctx context.Context, request mcp.CallToolRequest, logger *log.Logger) (*mcp.CallToolResult, error) {
 
-	return mcp.NewToolResultText(""), nil
+	teamID, err := request.RequireString("team_id")
+	if err != nil {
+		return ToolError(logger, "Missing required input: team_id", err)
+	}
+	username := request.GetString("username", "")
+	organizationMembershipID := request.GetString("organization_membership_ids", "")
+
+	teamID = strings.TrimSpace(teamID)
+	username = strings.TrimSpace((username))
+	organizationMembershipID = strings.TrimSpace(organizationMembershipID)
+
+	var usernames []string
+	if username != "" {
+		usernames = strings.Split(username, ",")
+		for i, u := range usernames {
+			usernames[i] = strings.TrimSpace(u)
+		}
+	}
+	var organizationMembershipIDs []string
+	if organizationMembershipID != "" {
+		organizationMembershipIDs = strings.Split(organizationMembershipID, ",")
+		for i, id := range organizationMembershipIDs {
+			organizationMembershipIDs[i] = strings.TrimSpace(id)
+		}
+	}
+
+	tfeClient, err := client.GetTfeClientFromContext(ctx, logger)
+	if err != nil {
+		return ToolError(logger, "Failed to get Terraform client", err)
+	}
+	if tfeClient == nil {
+		return ToolError(logger, "Failed to get Terraform client - ensure TFE_TOKEN and TFE_ADDRESS are configured", nil)
+	}
+
+	if len(usernames) == 0 && len(organizationMembershipIDs) == 0 {
+		return ToolError(logger, "At least one of 'username' or 'organization_membership_ids' must be provided", nil)
+	}
+
+	result := &AddMemberSummary{}
+
+	if len(usernames) > 0 {
+		if err := tfeClient.TeamMembers.Add(ctx, teamID, tfe.TeamMemberAddOptions{
+			Usernames: usernames,
+		}); err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("Failed to add by username: %v", err))
+		} else {
+			result.AddedByUsername = usernames
+		}
+	}
+
+	if len(organizationMembershipIDs) > 0 {
+		if err := tfeClient.TeamMembers.Add(ctx, teamID, tfe.TeamMemberAddOptions{
+			OrganizationMembershipIDs: organizationMembershipIDs,
+		}); err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("Failed to add by membership ID: %v", err))
+		} else {
+			result.AddedByMembershipID = organizationMembershipIDs
+		}
+	}
+
+	result.Success = len(result.Errors) == 0
+
+	resultJSON, err := json.Marshal(result)
+	if err != nil {
+		return ToolError(logger, "Failed to marshal result", err)
+	}
+	return mcp.NewToolResultText(string(resultJSON)), nil
+}
+
+// AddMemberSummary is a truncated summary of Added Members details for listing
+type AddMemberSummary struct {
+	Success             bool     `json:"success"`
+	AddedByUsername     []string `json:"added_by_username,omitempty"`
+	AddedByMembershipID []string `json:"added_by_membership_id,omitempty"`
+	Errors              []string `json:"errors,omitempty"`
 }

--- a/pkg/tools/tfe/add_team_member.go
+++ b/pkg/tools/tfe/add_team_member.go
@@ -55,7 +55,7 @@ func addTeamMemberHandler(ctx context.Context, request mcp.CallToolRequest, logg
 	username := request.GetString("username", "")
 	organizationMembershipID := request.GetString("organization_membership_ids", "")
 
-	teamID = strings.TrimSpace(teamID)
+	teamID = strings.TrimLeft(strings.TrimSpace(teamID), "/")
 	username = strings.TrimSpace((username))
 	organizationMembershipID = strings.TrimSpace(organizationMembershipID)
 

--- a/pkg/tools/tfe/add_team_member.go
+++ b/pkg/tools/tfe/add_team_member.go
@@ -21,20 +21,20 @@ func AddTeamMemeber(logger *log.Logger) server.ServerTool {
 	return server.ServerTool{
 		Tool: mcp.NewTool(
 			"add_team_member",
-			mcp.WithDescription("Adds member’s to a team. This is a write operation"),
-			mcp.WithTitleAnnotation(`Adds member’s to a team`),
+			mcp.WithDescription("Adds one or more members to a Terraform Cloud/Enterprise team. Members can be identified by username (accepted invites only) or by organization membership ID (accepted and pending invites). Both can be provided in a single call."),
+			mcp.WithTitleAnnotation(`Add members to a Terraform team`),
 			mcp.WithOpenWorldHintAnnotation(true),
 			mcp.WithReadOnlyHintAnnotation(false),
 			mcp.WithDestructiveHintAnnotation(false),
 			mcp.WithString("team_id",
 				mcp.Required(),
-				mcp.Description("The Teams's id (e.g., 'team-abc123def456')"),
+				mcp.Description("The ID of the Terraform Cloud/Enterprise team to add members to (e.g., 'team-abc123def456')"),
 			),
 			mcp.WithString("username",
-				mcp.Description("Optional: Comma-separated list of usernames to add (e.g., 'alice' or 'alice, bob'). Only works for users who have accepted the organization invite."),
+				mcp.Description("Comma-separated list of usernames to add (e.g., 'alice' or 'alice, bob'). Only works for users who have accepted the organization invite."),
 			),
 			mcp.WithString("organization_membership_ids",
-				mcp.Description("Optional: Comma-separated list of organization membership IDs to add (e.g., 'ou-abc123' or 'ou-abc123, ou-def456'). Works for both accepted and pending organization invites. Prefer this over 'username' when the invitee has not yet accepted."),
+				mcp.Description("Comma-separated list of organization membership IDs to add (e.g., 'ou-abc123' or 'ou-abc123, ou-def456'). Works for both accepted and pending organization invites. Prefer this over 'username' when the invitee has not yet accepted."),
 			),
 		),
 
@@ -74,16 +74,16 @@ func addTeamMemberHandler(ctx context.Context, request mcp.CallToolRequest, logg
 		}
 	}
 
+	if len(usernames) == 0 && len(organizationMembershipIDs) == 0 {
+		return ToolError(logger, "At least one of 'username' or 'organization_membership_ids' must be provided", nil)
+	}
+
 	tfeClient, err := client.GetTfeClientFromContext(ctx, logger)
 	if err != nil {
 		return ToolError(logger, "Failed to get Terraform client", err)
 	}
 	if tfeClient == nil {
 		return ToolError(logger, "Failed to get Terraform client - ensure TFE_TOKEN and TFE_ADDRESS are configured", nil)
-	}
-
-	if len(usernames) == 0 && len(organizationMembershipIDs) == 0 {
-		return ToolError(logger, "At least one of 'username' or 'organization_membership_ids' must be provided", nil)
 	}
 
 	result := &AddMemberSummary{}

--- a/pkg/tools/tfe/add_team_member.go
+++ b/pkg/tools/tfe/add_team_member.go
@@ -16,8 +16,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// AddTeamMemeber creates a tool to add a new member to your Terraform team.
-func AddTeamMemeber(logger *log.Logger) server.ServerTool {
+// AddTeamMember creates a tool to add a new member to your Terraform team.
+func AddTeamMember(logger *log.Logger) server.ServerTool {
 	return server.ServerTool{
 		Tool: mcp.NewTool(
 			"add_team_member",

--- a/pkg/tools/tfe/add_team_member.go
+++ b/pkg/tools/tfe/add_team_member.go
@@ -5,7 +5,6 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -21,7 +20,7 @@ func AddTeamMember(logger *log.Logger) server.ServerTool {
 	return server.ServerTool{
 		Tool: mcp.NewTool(
 			"add_team_member",
-			mcp.WithDescription("Adds one or more members to a Terraform Cloud/Enterprise team. Members can be identified by username (accepted invites only) or by organization membership ID (accepted and pending invites). Both can be provided in a single call."),
+			mcp.WithDescription("Adds a single member to a Terraform Cloud/Enterprise team. Provide either a username (accepted invites only) or an organization membership ID (accepted and pending invites), not both."),
 			mcp.WithTitleAnnotation(`Add members to a Terraform team`),
 			mcp.WithOpenWorldHintAnnotation(true),
 			mcp.WithReadOnlyHintAnnotation(false),
@@ -31,10 +30,10 @@ func AddTeamMember(logger *log.Logger) server.ServerTool {
 				mcp.Description("The ID of the Terraform Cloud/Enterprise team to add members to (e.g., 'team-abc123def456')"),
 			),
 			mcp.WithString("username",
-				mcp.Description("Comma-separated list of usernames to add (e.g., 'alice' or 'alice, bob'). Only works for users who have accepted the organization invite."),
+				mcp.Description("Username of the member to add. Only works for users who have accepted the organization invite."),
 			),
-			mcp.WithString("organization_membership_ids",
-				mcp.Description("Comma-separated list of organization membership IDs to add (e.g., 'ou-abc123' or 'ou-abc123, ou-def456'). Works for both accepted and pending organization invites. Prefer this over 'username' when the invitee has not yet accepted."),
+			mcp.WithString("organization_membership_id",
+				mcp.Description("Organization membership ID of the member to add (e.g., 'ou-abc123'). Works for both accepted and pending organization invites. Prefer this over 'username' when the invitee has not yet accepted."),
 			),
 		),
 
@@ -53,29 +52,17 @@ func addTeamMemberHandler(ctx context.Context, request mcp.CallToolRequest, logg
 		return ToolError(logger, "Missing required input: team_id", err)
 	}
 	username := request.GetString("username", "")
-	organizationMembershipID := request.GetString("organization_membership_ids", "")
+	orgMembershipID := request.GetString("organization_membership_id", "")
 
-	teamID = strings.TrimLeft(strings.TrimSpace(teamID), "/")
+	teamID = strings.TrimSpace(teamID)
 	username = strings.TrimSpace((username))
-	organizationMembershipID = strings.TrimSpace(organizationMembershipID)
+	orgMembershipID = strings.TrimSpace(orgMembershipID)
 
-	var usernames []string
-	if username != "" {
-		usernames = strings.Split(username, ",")
-		for i, u := range usernames {
-			usernames[i] = strings.TrimSpace(u)
-		}
+	if username == "" && orgMembershipID == "" {
+		return ToolError(logger, "One of 'username' or 'organization_membership_id' must be provided", nil)
 	}
-	var organizationMembershipIDs []string
-	if organizationMembershipID != "" {
-		organizationMembershipIDs = strings.Split(organizationMembershipID, ",")
-		for i, id := range organizationMembershipIDs {
-			organizationMembershipIDs[i] = strings.TrimSpace(id)
-		}
-	}
-
-	if len(usernames) == 0 && len(organizationMembershipIDs) == 0 {
-		return ToolError(logger, "At least one of 'username' or 'organization_membership_ids' must be provided", nil)
+	if username != "" && orgMembershipID != "" {
+		return ToolError(logger, "Provide only one of 'username' or 'organization_membership_id', not both", nil)
 	}
 
 	tfeClient, err := client.GetTfeClientFromContext(ctx, logger)
@@ -86,41 +73,19 @@ func addTeamMemberHandler(ctx context.Context, request mcp.CallToolRequest, logg
 		return ToolError(logger, "Failed to get Terraform client - ensure TFE_TOKEN and TFE_ADDRESS are configured", nil)
 	}
 
-	result := &AddMemberSummary{}
-
-	if len(usernames) > 0 {
+	if username != "" {
 		if err := tfeClient.TeamMembers.Add(ctx, teamID, tfe.TeamMemberAddOptions{
-			Usernames: usernames,
+			Usernames: []string{username},
 		}); err != nil {
-			result.Errors = append(result.Errors, fmt.Sprintf("Failed to add by username: %v", err))
-		} else {
-			result.AddedByUsername = usernames
+			return ToolError(logger, fmt.Sprintf("Failed to add member %q to team %q", username, teamID), err)
+		}
+	} else {
+		if err := tfeClient.TeamMembers.Add(ctx, teamID, tfe.TeamMemberAddOptions{
+			OrganizationMembershipIDs: []string{orgMembershipID},
+		}); err != nil {
+			return ToolError(logger, fmt.Sprintf("Failed to add membership ID %q to team %q", orgMembershipID, teamID), err)
 		}
 	}
 
-	if len(organizationMembershipIDs) > 0 {
-		if err := tfeClient.TeamMembers.Add(ctx, teamID, tfe.TeamMemberAddOptions{
-			OrganizationMembershipIDs: organizationMembershipIDs,
-		}); err != nil {
-			result.Errors = append(result.Errors, fmt.Sprintf("Failed to add by membership ID: %v", err))
-		} else {
-			result.AddedByMembershipID = organizationMembershipIDs
-		}
-	}
-
-	result.Success = len(result.Errors) == 0
-
-	resultJSON, err := json.Marshal(result)
-	if err != nil {
-		return ToolError(logger, "Failed to marshal result", err)
-	}
-	return mcp.NewToolResultText(string(resultJSON)), nil
-}
-
-// AddMemberSummary is a truncated summary of Added Members details for listing
-type AddMemberSummary struct {
-	Success             bool     `json:"success"`
-	AddedByUsername     []string `json:"added_by_username,omitempty"`
-	AddedByMembershipID []string `json:"added_by_membership_id,omitempty"`
-	Errors              []string `json:"errors,omitempty"`
+	return mcp.NewToolResultText(fmt.Sprintf("Successfully added member to team %q", teamID)), nil
 }

--- a/pkg/tools/tfe/add_team_member_test.go
+++ b/pkg/tools/tfe/add_team_member_test.go
@@ -1,0 +1,174 @@
+// Copyright IBM Corp. 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package tools
+
+import (
+	"strings"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddTeamMember(t *testing.T) {
+	logger := log.New()
+	logger.SetLevel(log.ErrorLevel)
+
+	t.Run("tool creation", func(t *testing.T) {
+		tool := AddTeamMemeber(logger)
+
+		assert.Equal(t, "add_team_member", tool.Tool.Name)
+		assert.NotNil(t, tool.Handler)
+
+		// Not destructive, not read-only
+		assert.NotNil(t, tool.Tool.Annotations.DestructiveHint)
+		assert.False(t, *tool.Tool.Annotations.DestructiveHint)
+		assert.NotNil(t, tool.Tool.Annotations.ReadOnlyHint)
+		assert.False(t, *tool.Tool.Annotations.ReadOnlyHint)
+
+		// team_id is required; the optional inputs must not appear in the required list
+		assert.Contains(t, tool.Tool.InputSchema.Required, "team_id")
+		assert.NotContains(t, tool.Tool.InputSchema.Required, "username")
+		assert.NotContains(t, tool.Tool.InputSchema.Required, "organization_membership_ids")
+	})
+
+	t.Run("team_id requirement", func(t *testing.T) {
+		tests := []struct {
+			name        string
+			params      map[string]interface{}
+			expectError bool
+		}{
+			{
+				name:        "team_id present",
+				params:      map[string]interface{}{"team_id": "team-abc123"},
+				expectError: false,
+			},
+			{
+				name:        "team_id missing",
+				params:      map[string]interface{}{},
+				expectError: true,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				request := &MockCallToolRequest{params: tt.params}
+				_, err := request.RequireString("team_id")
+				if tt.expectError {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+				}
+			})
+		}
+	})
+
+	t.Run("at least one id list required", func(t *testing.T) {
+		tests := []struct {
+			name          string
+			usernames     []string
+			membershipIDs []string
+			expectValid   bool
+		}{
+			{
+				name:          "only usernames provided",
+				usernames:     []string{"alice"},
+				membershipIDs: nil,
+				expectValid:   true,
+			},
+			{
+				name:          "only membership IDs provided",
+				usernames:     nil,
+				membershipIDs: []string{"ou-abc123"},
+				expectValid:   true,
+			},
+			{
+				name:          "both provided",
+				usernames:     []string{"alice"},
+				membershipIDs: []string{"ou-abc123"},
+				expectValid:   true,
+			},
+			{
+				name:          "neither provided",
+				usernames:     nil,
+				membershipIDs: nil,
+				expectValid:   false,
+			},
+			{
+				name:          "both empty slices",
+				usernames:     []string{},
+				membershipIDs: []string{},
+				expectValid:   false,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				isValid := len(tt.usernames) > 0 || len(tt.membershipIDs) > 0
+				assert.Equal(t, tt.expectValid, isValid)
+			})
+		}
+	})
+
+	t.Run("comma-separated input parsing", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			input    string
+			expected []string
+		}{
+			{
+				name:     "single value",
+				input:    "alice",
+				expected: []string{"alice"},
+			},
+			{
+				name:     "multiple values no spaces",
+				input:    "alice,bob",
+				expected: []string{"alice", "bob"},
+			},
+			{
+				name:     "multiple values with spaces",
+				input:    "alice, bob, carol",
+				expected: []string{"alice", "bob", "carol"},
+			},
+			{
+				name:     "leading and trailing whitespace on whole string",
+				input:    "  alice, bob  ",
+				expected: []string{"alice", "bob"},
+			},
+			{
+				name:     "empty string",
+				input:    "",
+				expected: nil,
+			},
+			{
+				name:     "whitespace only",
+				input:    "   ",
+				expected: nil,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				raw := strings.TrimSpace(tt.input)
+				var result []string
+				if raw != "" {
+					parts := strings.Split(raw, ",")
+					for i, p := range parts {
+						parts[i] = strings.TrimSpace(p)
+					}
+					result = parts
+				}
+
+				if tt.expected == nil {
+					assert.Nil(t, result)
+				} else {
+					require.Len(t, result, len(tt.expected))
+					assert.Equal(t, tt.expected, result)
+				}
+			})
+		}
+	})
+}

--- a/pkg/tools/tfe/add_team_member_test.go
+++ b/pkg/tools/tfe/add_team_member_test.go
@@ -17,7 +17,7 @@ func TestAddTeamMember(t *testing.T) {
 	logger.SetLevel(log.ErrorLevel)
 
 	t.Run("tool creation", func(t *testing.T) {
-		tool := AddTeamMemeber(logger)
+		tool := AddTeamMember(logger)
 
 		assert.Equal(t, "add_team_member", tool.Tool.Name)
 		assert.NotNil(t, tool.Handler)

--- a/pkg/tools/tfe/add_team_member_test.go
+++ b/pkg/tools/tfe/add_team_member_test.go
@@ -4,12 +4,10 @@
 package tools
 
 import (
-	"strings"
 	"testing"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestAddTeamMember(t *testing.T) {
@@ -108,66 +106,6 @@ func TestAddTeamMember(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				isValid := len(tt.usernames) > 0 || len(tt.membershipIDs) > 0
 				assert.Equal(t, tt.expectValid, isValid)
-			})
-		}
-	})
-
-	t.Run("comma-separated input parsing", func(t *testing.T) {
-		tests := []struct {
-			name     string
-			input    string
-			expected []string
-		}{
-			{
-				name:     "single value",
-				input:    "alice",
-				expected: []string{"alice"},
-			},
-			{
-				name:     "multiple values no spaces",
-				input:    "alice,bob",
-				expected: []string{"alice", "bob"},
-			},
-			{
-				name:     "multiple values with spaces",
-				input:    "alice, bob, carol",
-				expected: []string{"alice", "bob", "carol"},
-			},
-			{
-				name:     "leading and trailing whitespace on whole string",
-				input:    "  alice, bob  ",
-				expected: []string{"alice", "bob"},
-			},
-			{
-				name:     "empty string",
-				input:    "",
-				expected: nil,
-			},
-			{
-				name:     "whitespace only",
-				input:    "   ",
-				expected: nil,
-			},
-		}
-
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				raw := strings.TrimSpace(tt.input)
-				var result []string
-				if raw != "" {
-					parts := strings.Split(raw, ",")
-					for i, p := range parts {
-						parts[i] = strings.TrimSpace(p)
-					}
-					result = parts
-				}
-
-				if tt.expected == nil {
-					assert.Nil(t, result)
-				} else {
-					require.Len(t, result, len(tt.expected))
-					assert.Equal(t, tt.expected, result)
-				}
 			})
 		}
 	})

--- a/pkg/toolsets/mapping.go
+++ b/pkg/toolsets/mapping.go
@@ -64,6 +64,7 @@ var ToolToToolset = map[string]string{
 	"list_state_versions":                 Terraform,
 	"get_state_version":                   Terraform,
 	"get_run_comments":                    Terraform,
+	"add_team_member":                     Terraform,
 }
 
 // GetToolsetForTool returns the toolset name for a given tool name


### PR DESCRIPTION
## Changes Overview

New Tool → `add_team_member`: Adds a single member to a Terraform Cloud/Enterprise team by either username or organization membership ID.

## What changed
- `pkg/tools/tfe/add_team_member.go` — Tool definition and handler
- `pkg/tools/tfe/add_team_member_test.go` — Unit tests
- `pkg/tools/dynamic_tool.go` — Registers `add_team_member`
- `pkg/toolsets/mapping.go` — Adds `add_team_member` to the Terraform toolset
- `CHANGELOG.md` — Entry added

## Inputs
- Required: `team_id` (e.g. `team-abc123def456`)
- Optional: `username` — accepted-invite users only
- Optional: `organization_membership_id` — works for both pending and accepted invites

Exactly one of `username` or `organization_membership_id` must be provided. Providing both is a validation error.

## Output

**Success:**
```
"Successfully added member to team \"team-abc123def456\""
```

**Failure:** tool call errors with a descriptive message, e.g.:
```
"Failed to add member \"alice\" to team \"team-abc123def456\": ..."
```

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
