### PR TITLE
add `create_team`

### DIFF
--- a/.github/workflows/hcpt_test.yml
+++ b/.github/workflows/hcpt_test.yml
@@ -35,5 +35,6 @@ jobs:
         env:
           TF_MCP_ENDPOINT: http://localhost:8080/mcp
           TFE_TOKEN: ${{ secrets.TFE_TOKEN_TESTING }}
+          TFE_ORG_NAME: ${{ secrets.TEST_TF_ORG_NAME }}
         run: |
           make test-hcpt

--- a/.github/workflows/hcpt_test.yml
+++ b/.github/workflows/hcpt_test.yml
@@ -35,6 +35,6 @@ jobs:
         env:
           TF_MCP_ENDPOINT: http://localhost:8080/mcp
           TFE_TOKEN: ${{ secrets.TFE_TOKEN_TESTING }}
-          TFE_ORG_NAME: ${{ secrets.TEST_TF_ORG_NAME }}
+          TFE_ORG_NAME: ${{ vars.TEST_TF_ORG_NAME }}
         run: |
           make test-hcpt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ FEATURES
 * [New Tool] `get_run_comments` Lists all discussion comments associated with a given Terraform run. Requires `run_id`.
 * [New Tool] `create_project` Creates a new Terraform project in the specified organization. Requires `terraform_org_name` and `project_name`. [420](https://github.com/hashicorp/terraform-mcp-server/pull/420)
 * [New Tool] `delete_project` Deletes a Terraform project by ID. Requires `project_id`. TFC/TFE will refuse to delete a project that still contains workspaces or stacks. [420](https://github.com/hashicorp/terraform-mcp-server/pull/420)
+* [New Tool] `create_team` Creates a new team in a Terraform Cloud/Enterprise organization. Requires `terraform_org_name` and `team_name`; optional `visibility` ("secret" or "organization"). [427](https://github.com/hashicorp/terraform-mcp-server/pull/427)
 
 IMPROVEMENTS
 

--- a/pkg/tools/dynamic_tool.go
+++ b/pkg/tools/dynamic_tool.go
@@ -116,6 +116,22 @@ func (r *DynamicToolRegistry) registerTFETools() {
 		r.mcpServer.AddTool(tool.Tool, tool.Handler)
 	}
 
+	if toolsets.IsToolEnabled("create_project", r.enabledToolsets) {
+		tool := r.createDynamicTFETool("create_project", tfeTools.CreateProject)
+		r.mcpServer.AddTool(tool.Tool, tool.Handler)
+	}
+
+	if isTerraformOperationsEnabled() && toolsets.IsToolEnabled("delete_project", r.enabledToolsets) {
+		tool := r.createDynamicTFETool("delete_project", tfeTools.DeleteProject)
+		r.mcpServer.AddTool(tool.Tool, tool.Handler)
+	}
+
+	// Terraform toolset - Team tools
+	if toolsets.IsToolEnabled("create_team", r.enabledToolsets) {
+		tool := r.createDynamicTFETool("create_team", tfeTools.CreateTeam)
+		r.mcpServer.AddTool(tool.Tool, tool.Handler)
+	}
+
 	// Terraform toolset - Workspace management tools
 	if toolsets.IsToolEnabled("list_workspaces", r.enabledToolsets) {
 		tool := r.createDynamicTFETool("list_workspaces", tfeTools.ListWorkspaces)
@@ -137,24 +153,11 @@ func (r *DynamicToolRegistry) registerTFETools() {
 		r.mcpServer.AddTool(tool.Tool, tool.Handler)
 	}
 
-	// Only register create_project if TF operations are enabled AND toolset is enabled
-	if isTerraformOperationsEnabled() && toolsets.IsToolEnabled("create_project", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("create_project", tfeTools.CreateProject)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	// Only register delete_project if TF operations are enabled AND toolset is enabled
-	if isTerraformOperationsEnabled() && toolsets.IsToolEnabled("delete_project", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("delete_project", tfeTools.DeleteProject)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	// Only register delete_workspace_safely if TF operations are enabled AND toolset is enabled
 	if isTerraformOperationsEnabled() && toolsets.IsToolEnabled("delete_workspace_safely", r.enabledToolsets) {
 		tool := r.createDynamicTFETool("delete_workspace_safely", tfeTools.DeleteWorkspaceSafely)
 		r.mcpServer.AddTool(tool.Tool, tool.Handler)
 	}
-	// Only register force_unlock_workspace if TF operations are enabled AND toolset is enabled
+
 	if isTerraformOperationsEnabled() && toolsets.IsToolEnabled("force_unlock_workspace", r.enabledToolsets) {
 		tool := r.createDynamicTFETool("force_unlock_workspace", tfeTools.ForceUnlockWorkspace)
 		r.mcpServer.AddTool(tool.Tool, tool.Handler)

--- a/pkg/tools/tfe/create_team.go
+++ b/pkg/tools/tfe/create_team.go
@@ -1,0 +1,101 @@
+// Copyright IBM Corp. 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"slices"
+	"strings"
+
+	"github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-mcp-server/pkg/client"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+var validTeamVisibilities = []string{"secret", "organization"}
+var validTeamVisibilitiesStr = strings.Join(validTeamVisibilities, ", ")
+
+type TeamSummary struct {
+	ID         string `json:"team_id"`
+	Name       string `json:"team_name"`
+	Visibility string `json:"visibility"`
+}
+
+// CreateTeam creates a tool to create a new team in a Terraform Cloud/Enterprise organization.
+func CreateTeam(logger *log.Logger) server.ServerTool {
+	return server.ServerTool{
+		Tool: mcp.NewTool("create_team",
+			mcp.WithDescription(`Creates a new team in a Terraform Cloud/Enterprise organization.`),
+			mcp.WithTitleAnnotation("Create a new team in a Terraform organization"),
+			mcp.WithOpenWorldHintAnnotation(true),
+			mcp.WithReadOnlyHintAnnotation(false),
+			mcp.WithDestructiveHintAnnotation(false),
+			mcp.WithString("terraform_org_name",
+				mcp.Required(),
+				mcp.Description(terraformOrgNameDescription),
+			),
+			mcp.WithString("team_name",
+				mcp.Required(),
+				mcp.Description("The unique name of the team to create in the Terraform organization"),
+			),
+			mcp.WithString("visibility",
+				mcp.Description("Optional team visibility: "+validTeamVisibilitiesStr+`. Defaults to "secret" if not set.`),
+			),
+		),
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return createTeamHandler(ctx, request, logger)
+		},
+	}
+}
+
+func createTeamHandler(ctx context.Context, request mcp.CallToolRequest, logger *log.Logger) (*mcp.CallToolResult, error) {
+	terraformOrgName, err := request.RequireString("terraform_org_name")
+	if err != nil {
+		return ToolError(logger, "missing required input: terraform_org_name", err)
+	}
+	terraformOrgName = strings.TrimSpace(terraformOrgName)
+
+	teamName, err := request.RequireString("team_name")
+	if err != nil {
+		return ToolError(logger, "missing required input: team_name", err)
+	}
+	teamName = strings.TrimSpace(teamName)
+
+	visibility := strings.ToLower(strings.TrimSpace(request.GetString("visibility", "")))
+	if visibility != "" && !slices.Contains(validTeamVisibilities, visibility) {
+		return ToolErrorf(logger, "invalid visibility %q - must be one of: %s", visibility, validTeamVisibilitiesStr)
+	}
+
+	tfeClient, err := client.GetTfeClientFromContext(ctx, logger)
+	if err != nil {
+		return ToolError(logger, "failed to get Terraform client", err)
+	}
+	if tfeClient == nil {
+		return ToolError(logger, "failed to get Terraform client - ensure TFE_TOKEN and TFE_ADDRESS are configured", nil)
+	}
+
+	options := tfe.TeamCreateOptions{
+		Name: tfe.String(teamName),
+	}
+
+	if visibility != "" {
+		options.Visibility = tfe.String(visibility)
+	}
+
+	team, err := tfeClient.Teams.Create(ctx, terraformOrgName, options)
+	if err != nil {
+		return ToolErrorf(logger, "failed to create team %q in org %q: %v", teamName, terraformOrgName, err)
+	}
+
+	teamJSON, err := json.Marshal(&TeamSummary{team.ID, team.Name, team.Visibility})
+	if err != nil {
+		return ToolError(logger, "failed to marshal created team summary", err)
+	}
+
+	return mcp.NewToolResultText(string(teamJSON)), nil
+}

--- a/pkg/tools/tfe/create_team.go
+++ b/pkg/tools/tfe/create_team.go
@@ -24,6 +24,7 @@ type TeamSummary struct {
 	ID         string `json:"team_id"`
 	Name       string `json:"team_name"`
 	Visibility string `json:"visibility"`
+	UserCount  int    `json:"user_count,omitempty"`
 }
 
 // CreateTeam creates a tool to create a new team in a Terraform Cloud/Enterprise organization.
@@ -44,7 +45,7 @@ func CreateTeam(logger *log.Logger) server.ServerTool {
 				mcp.Description("The unique name of the team to create in the Terraform organization"),
 			),
 			mcp.WithString("visibility",
-				mcp.Description("Optional team visibility: "+validTeamVisibilitiesStr+`. Defaults to "secret" if not set.`),
+				mcp.Description("Optional team visibility: "+validTeamVisibilitiesStr+`. If omitted, the API defaults to "secret".`),
 			),
 		),
 		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -92,7 +93,12 @@ func createTeamHandler(ctx context.Context, request mcp.CallToolRequest, logger 
 		return ToolErrorf(logger, "failed to create team %q in org %q: %v", teamName, terraformOrgName, err)
 	}
 
-	teamJSON, err := json.Marshal(&TeamSummary{team.ID, team.Name, team.Visibility})
+	teamJSON, err := json.Marshal(&TeamSummary{
+		team.ID,
+		team.Name,
+		team.Visibility,
+		team.UserCount,
+	})
 	if err != nil {
 		return ToolError(logger, "failed to marshal created team summary", err)
 	}

--- a/pkg/tools/tfe/create_team_test.go
+++ b/pkg/tools/tfe/create_team_test.go
@@ -1,0 +1,107 @@
+// Copyright IBM Corp. 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package tools
+
+import (
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateTeam(t *testing.T) {
+	logger := log.New()
+	logger.SetLevel(log.ErrorLevel)
+
+	t.Run("tool creation", func(t *testing.T) {
+		tool := CreateTeam(logger)
+
+		assert.Equal(t, "create_team", tool.Tool.Name)
+		assert.Contains(t, tool.Tool.Description, "Creates a new team")
+		assert.NotNil(t, tool.Handler)
+
+		// Verify annotations: writes state, not destructive, calls external TFE API
+		assert.NotNil(t, tool.Tool.Annotations.ReadOnlyHint)
+		assert.False(t, *tool.Tool.Annotations.ReadOnlyHint)
+		assert.NotNil(t, tool.Tool.Annotations.DestructiveHint)
+		assert.False(t, *tool.Tool.Annotations.DestructiveHint)
+		assert.NotNil(t, tool.Tool.Annotations.OpenWorldHint)
+		assert.True(t, *tool.Tool.Annotations.OpenWorldHint)
+
+		// Check that required parameters are defined
+		assert.Contains(t, tool.Tool.InputSchema.Required, "terraform_org_name")
+		assert.Contains(t, tool.Tool.InputSchema.Required, "team_name")
+
+		// visibility is optional
+		_, hasVisibility := tool.Tool.InputSchema.Properties["visibility"]
+		assert.True(t, hasVisibility)
+		assert.NotContains(t, tool.Tool.InputSchema.Required, "visibility")
+	})
+
+	t.Run("parameter validation", func(t *testing.T) {
+		tests := []struct {
+			name          string
+			params        map[string]interface{}
+			expectOrgErr  bool
+			expectTeamErr bool
+		}{
+			{
+				name: "both params present",
+				params: map[string]interface{}{
+					"terraform_org_name": "my-org",
+					"team_name":          "my-team",
+				},
+				expectOrgErr:  false,
+				expectTeamErr: false,
+			},
+			{
+				name: "missing terraform_org_name",
+				params: map[string]interface{}{
+					"team_name": "my-team",
+				},
+				expectOrgErr:  true,
+				expectTeamErr: false,
+			},
+			{
+				name: "missing team_name",
+				params: map[string]interface{}{
+					"terraform_org_name": "my-org",
+				},
+				expectOrgErr:  false,
+				expectTeamErr: true,
+			},
+			{
+				name:          "both params missing",
+				params:        map[string]interface{}{},
+				expectOrgErr:  true,
+				expectTeamErr: true,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				request := &MockCallToolRequest{params: tt.params}
+
+				orgName, orgErr := request.RequireString("terraform_org_name")
+				teamName, teamErr := request.RequireString("team_name")
+
+				if tt.expectOrgErr {
+					assert.Error(t, orgErr)
+					assert.Contains(t, orgErr.Error(), "terraform_org_name")
+				} else {
+					assert.NoError(t, orgErr)
+					assert.Equal(t, tt.params["terraform_org_name"], orgName)
+				}
+
+				if tt.expectTeamErr {
+					assert.Error(t, teamErr)
+					assert.Contains(t, teamErr.Error(), "team_name")
+				} else {
+					assert.NoError(t, teamErr)
+					assert.Equal(t, tt.params["team_name"], teamName)
+				}
+			})
+		}
+	})
+}

--- a/pkg/toolsets/mapping.go
+++ b/pkg/toolsets/mapping.go
@@ -23,11 +23,16 @@ var ToolToToolset = map[string]string{
 	"search_private_providers":     RegistryPrivate,
 	"get_private_provider_details": RegistryPrivate,
 
-	// Terraform tools (TFE/TFC workspaces, runs, variables, etc.)
-	"list_terraform_orgs":                 Terraform,
-	"list_terraform_projects":             Terraform,
-	"create_project":                      Terraform,
-	"delete_project":                      Terraform,
+	// Terraform tools - Organization and Project
+	"list_terraform_orgs":     Terraform,
+	"list_terraform_projects": Terraform,
+	"create_project":          Terraform,
+	"delete_project":          Terraform,
+
+	// Terraform tools - Team
+	"create_team": Terraform,
+
+	// Terraform tools - Workspace management
 	"list_workspaces":                     Terraform,
 	"get_workspace_details":               Terraform,
 	"create_workspace":                    Terraform,

--- a/test/terraform/create_team_test.go
+++ b/test/terraform/create_team_test.go
@@ -53,7 +53,7 @@ func TestCreateTeam(t *testing.T) {
 	// Verify against the TFE API directly
 	createdTeam, err := client.Teams.Read(t.Context(), teamID)
 	require.NoError(t, err, "Team reported as created should be readable via the TFE API")
-	assert.Equal(t, teamName, createdTeam.Name, "Team name in TFE should match what was requested")
+	assert.Equal(t, teamName, createdTeam.Name, "Created team name does not match requested name")
 	assert.Equal(t, visibility, createdTeam.Visibility)
 	assert.Zero(t, createdTeam.UserCount)
 }

--- a/test/terraform/create_team_test.go
+++ b/test/terraform/create_team_test.go
@@ -1,0 +1,59 @@
+package terraform
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestCreateTeam(t *testing.T) {
+
+	if tfeOrgName == "" {
+		t.Skip("You need to supply TFE_ORG_NAME to run this test")
+	}
+
+	s := newTestingSession(t)
+	defer s.Close()
+
+	client := tfeClient(t)
+	teamName := fmt.Sprintf("mcp-test-team-%d", time.Now().Unix())
+	visibility := "organization"
+
+	// Skip if the organization does not support team management.
+	entitlements, err := client.Organizations.ReadEntitlements(t.Context(), tfeOrgName)
+	require.NoError(t, err, "Failed to read entitlements for organization %q", tfeOrgName)
+
+	if !entitlements.Teams {
+		t.Skipf("Organization %q does not have the Teams entitlement", tfeOrgName)
+	}
+
+	result, resultText := callTool(t, s, "create_team", map[string]any{
+		"terraform_org_name": tfeOrgName,
+		"team_name":          teamName,
+		"visibility":         visibility,
+	})
+
+	require.False(t, result.IsError, "create_team returned an error: %s", resultText)
+	require.NotEmpty(t, resultText, "Tool call result must not be empty")
+
+	teamID := gjson.Get(resultText, "team_id").String()
+	require.NotEmpty(t, teamID, "Tool response should include a team ID")
+	defer client.Teams.Delete(t.Context(), teamID)
+
+	assert.Equal(t, teamName, gjson.Get(resultText, "team_name").String(),
+		"Tool response should report the created team name")
+
+	assert.Equal(t, visibility, gjson.Get(resultText, "visibility").String(),
+		"Tool response should report the requested visibility")
+
+	// Verify against the TFE API directly
+	createdTeam, err := client.Teams.Read(t.Context(), teamID)
+	require.NoError(t, err, "Team reported as created should be readable via the TFE API")
+	assert.Equal(t, teamName, createdTeam.Name, "Team name in TFE should match what was requested")
+	assert.Equal(t, visibility, createdTeam.Visibility)
+	assert.Zero(t, createdTeam.UserCount)
+}

--- a/test/terraform/create_team_test.go
+++ b/test/terraform/create_team_test.go
@@ -52,7 +52,7 @@ func TestCreateTeam(t *testing.T) {
 
 	// Verify against the TFE API directly
 	createdTeam, err := client.Teams.Read(t.Context(), teamID)
-	require.NoError(t, err, "Team reported as created should be readable via the TFE API")
+	require.NoError(t, err, "Team reported as created but produced an error when reading")
 	assert.Equal(t, teamName, createdTeam.Name, "Created team name does not match requested name")
 	assert.Equal(t, visibility, createdTeam.Visibility)
 	assert.Zero(t, createdTeam.UserCount)

--- a/test/terraform/team_test.go
+++ b/test/terraform/team_test.go
@@ -1,14 +1,26 @@
 package terraform
 
 import (
-	"fmt"
+	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 )
+
+const alphaNum = "abcdefghijklmnopqrstuvwxyz012346789"
+
+func randomTeamName() string {
+	const suffixLength = 8
+
+	suffix := make([]byte, suffixLength)
+	for i := range suffix {
+		suffix[i] = alphaNum[rand.Intn(len(alphaNum))]
+	}
+
+	return "mcp-test-team-" + string(suffix)
+}
 
 func TestCreateTeam(t *testing.T) {
 
@@ -20,7 +32,7 @@ func TestCreateTeam(t *testing.T) {
 	defer s.Close()
 
 	client := tfeClient(t)
-	teamName := fmt.Sprintf("mcp-test-team-%d", time.Now().Unix())
+	teamName := randomTeamName()
 	visibility := "organization"
 
 	// Skip if the organization does not support team management.

--- a/test/terraform/team_test.go
+++ b/test/terraform/team_test.go
@@ -1,26 +1,12 @@
 package terraform
 
 import (
-	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 )
-
-const alphaNum = "abcdefghijklmnopqrstuvwxyz012346789"
-
-func randomTeamName() string {
-	const suffixLength = 8
-
-	suffix := make([]byte, suffixLength)
-	for i := range suffix {
-		suffix[i] = alphaNum[rand.Intn(len(alphaNum))]
-	}
-
-	return "mcp-test-team-" + string(suffix)
-}
 
 func TestCreateTeam(t *testing.T) {
 
@@ -32,7 +18,7 @@ func TestCreateTeam(t *testing.T) {
 	defer s.Close()
 
 	client := tfeClient(t)
-	teamName := randomTeamName()
+	teamName := randomName("team-")
 	visibility := "organization"
 
 	// Skip if the organization does not support team management.

--- a/test/terraform/terraform_test.go
+++ b/test/terraform/terraform_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-tfe"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -16,6 +17,8 @@ const toolCallTimeout = 30 * time.Second
 var (
 	mcpEndpoint string
 	tfeToken    string
+	tfeAddress  string
+	tfeOrgName  string
 
 	testingClient *mcp.Client
 )
@@ -34,6 +37,8 @@ func (t *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 func init() {
 	mcpEndpoint = os.Getenv("TF_MCP_ENDPOINT")
 	tfeToken = os.Getenv("TFE_TOKEN")
+	tfeAddress = os.Getenv("TFE_ADDRESS")
+	tfeOrgName = os.Getenv("TFE_ORG_NAME")
 
 	testingClient = mcp.NewClient(&mcp.Implementation{
 		Name:    "terraform-mcp-server-test-harness",
@@ -71,6 +76,29 @@ func newTestingSession(t *testing.T) *mcp.ClientSession {
 	}
 
 	return session
+}
+
+// newTFEClient creates a client that bypasses the MCP server and communicates
+// directly with the TFE API. It can verify create, update, and delete tool calls
+// against the actual API.
+func tfeClient(t *testing.T) *tfe.Client {
+	if tfeToken == "" {
+		t.Skip("You need to supply TFE_TOKEN to run these tests")
+	}
+
+	address := tfeAddress
+	if address == "" {
+		address = "https://app.terraform.io"
+	}
+
+	client, err := tfe.NewClient(&tfe.Config{
+		Address: address,
+		Token:   tfeToken,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create direct TFE client: %v", err)
+	}
+	return client
 }
 
 func getTextContent(result *mcp.CallToolResult) string {

--- a/test/terraform/terraform_test.go
+++ b/test/terraform/terraform_test.go
@@ -2,6 +2,7 @@ package terraform
 
 import (
 	"context"
+	"math/rand"
 	"net/http"
 	"os"
 	"strings"
@@ -12,7 +13,11 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-const toolCallTimeout = 30 * time.Second
+const (
+	toolCallTimeout  = 30 * time.Second
+	alphaNum         = "abcdefghijklmnopqrstuvwxyz0123456789"
+	randomNameLength = 8
+)
 
 var (
 	mcpEndpoint string
@@ -32,6 +37,15 @@ func (t *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	req = req.Clone(req.Context())
 	req.Header.Set("Authorization", "Bearer "+t.token)
 	return t.roundtripper.RoundTrip(req)
+}
+
+func randomName(prefix string) string {
+	suffix := make([]byte, randomNameLength)
+	for i := range suffix {
+		suffix[i] = alphaNum[rand.Intn(len(alphaNum))]
+	}
+
+	return prefix + string(suffix)
 }
 
 func init() {


### PR DESCRIPTION
Adds a `create_team` tool to the Terraform toolset for creating teams in Terraform Cloud or Terraform Enterprise organizations.

## Changes
- `create_team.go`: `CreateTeam` and `createTeamHandler`
- `create_team_test.go`: unit tests
- `mapping.go` and `dynamic_tool`: register create_team with Terraform toolset and lazily adds it to the MCP server when enabled and available for an authenticated TFE session.
- CHANGELOG.md

## Testing

- Added unit tests for tool creation and parameters validation.
- Tested locally through the MCP AI Agent. The tool reaches the TFE API correctly but creation fails only because team management requires HCP Terraform Plus tier, not due to any implementation issue. 