### PR TITLE
add organization allowlist tool middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ FEATURES
 
 IMPROVEMENTS
 
-* Extend the existing HTTP-layer `OrganizationAllowlistMiddleware` with a new MCP tool-layer `OrganizationAllowlistToolMiddleware` that rejects tool calls whose `terraform_org_name` argument is not in the allowlist configured via `MCP_ORGANIZATION_ALLOWLIST`.
+* Extend the existing HTTP-layer `OrganizationAllowlistMiddleware` with a new MCP tool-layer `OrganizationAllowlistToolMiddleware` that rejects tool calls whose `terraform_org_name` argument is not in the allowlist configured via `MCP_ORGANIZATION_ALLOWLIST`. [430](https://github.com/hashicorp/terraform-mcp-server/pull/430)
 
 # 1.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 FEATURES
 
-* [New Tool] `create_project` Creates a new Terraform project in the specified organization. Requires `terraform_org_name` and `project_name`.
-* [New Tool] `delete_project` Deletes a Terraform project by ID. Requires `project_id`. TFC/TFE will refuse to delete a project that still contains workspaces or stacks.
+* [New Tool] `create_project` Creates a new Terraform project in the specified organization. Requires `terraform_org_name` and `project_name`. [420](https://github.com/hashicorp/terraform-mcp-server/pull/420)
+* [New Tool] `delete_project` Deletes a Terraform project by ID. Requires `project_id`. TFC/TFE will refuse to delete a project that still contains workspaces or stacks. [420](https://github.com/hashicorp/terraform-mcp-server/pull/420)
+
+IMPROVEMENTS
+
+* Extend the existing HTTP-layer `OrganizationAllowlistMiddleware` with a new MCP tool-layer `OrganizationAllowlistToolMiddleware` that rejects tool calls whose `terraform_org_name` argument is not in the allowlist configured via `MCP_ORGANIZATION_ALLOWLIST`.
 
 # 1.1.1
 

--- a/cmd/terraform-mcp-server/main.go
+++ b/cmd/terraform-mcp-server/main.go
@@ -45,7 +45,15 @@ func runHTTPServer(logger *log.Logger, host string, port string, endpointPath st
 	hooks.AddOnRegisterSession(func(ctx context.Context, session server.ClientSession) {
 		client.NewSessionHandler(ctx, session, logger)
 	})
-	hcServer, rateLimiter := NewServer(version.Version, logger, enabledToolsets, server.WithHooks(hooks))
+	hcServer, rateLimiter := NewServer(
+		version.Version,
+		logger,
+		enabledToolsets,
+		server.WithHooks(hooks),
+		server.WithToolHandlerMiddleware(
+			client.OrganizationAllowlistToolMiddleware(organizationAllowlist, logger),
+		),
+	)
 	registerToolsAndResources(hcServer, logger, enabledToolsets)
 
 	hooks.AddOnUnregisterSession(func(ctx context.Context, session server.ClientSession) {

--- a/cmd/terraform-mcp-server/main.go
+++ b/cmd/terraform-mcp-server/main.go
@@ -45,15 +45,24 @@ func runHTTPServer(logger *log.Logger, host string, port string, endpointPath st
 	hooks.AddOnRegisterSession(func(ctx context.Context, session server.ClientSession) {
 		client.NewSessionHandler(ctx, session, logger)
 	})
+
+	serverOpts := []server.ServerOption{
+		server.WithHooks(hooks),
+	}
+
+	// Only register the middleware when an organization allowlist is configured
+	if len(organizationAllowlist) > 0 {
+		serverOpts = append(serverOpts, server.WithToolHandlerMiddleware(
+			client.OrganizationAllowlistToolMiddleware(organizationAllowlist, logger),
+		))
+	}
 	hcServer, rateLimiter := NewServer(
 		version.Version,
 		logger,
 		enabledToolsets,
-		server.WithHooks(hooks),
-		server.WithToolHandlerMiddleware(
-			client.OrganizationAllowlistToolMiddleware(organizationAllowlist, logger),
-		),
+		serverOpts...,
 	)
+
 	registerToolsAndResources(hcServer, logger, enabledToolsets)
 
 	hooks.AddOnUnregisterSession(func(ctx context.Context, session server.ClientSession) {

--- a/pkg/client/org_allowlist_tool_middleware.go
+++ b/pkg/client/org_allowlist_tool_middleware.go
@@ -28,7 +28,7 @@ func OrganizationAllowlistToolMiddleware(allowlist []string, logger *log.Logger)
 	return func(nextToolHandler server.ToolHandlerFunc) server.ToolHandlerFunc {
 		return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			// if tool doesn't have orgNameArgument, skipped without need to check
-			organizationName := request.GetString(orgNameArgument, "")
+			organizationName := strings.TrimSpace(request.GetString(orgNameArgument, ""))
 			if organizationName == "" {
 				return nextToolHandler(ctx, request)
 			}

--- a/pkg/client/org_allowlist_tool_middleware.go
+++ b/pkg/client/org_allowlist_tool_middleware.go
@@ -16,24 +16,17 @@ import (
 const orgNameArgument = "terraform_org_name"
 
 func OrganizationAllowlistToolMiddleware(allowlist []string, logger *log.Logger) server.ToolHandlerMiddleware {
-	allowedOrganizations := OrganizationAllowlistSet(allowlist)
-
-	// if no allowed organization listed, skip to next toolmiddleware without need to initialize OrganizationAllowlistToolMiddleware
-	if len(allowedOrganizations) == 0 {
-		return func(nextToolHandler server.ToolHandlerFunc) server.ToolHandlerFunc {
-			return nextToolHandler
-		}
-	}
+	allowedOrganizations := buildAllowedOrganizationsMap(allowlist)
 
 	return func(nextToolHandler server.ToolHandlerFunc) server.ToolHandlerFunc {
 		return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			// if tool doesn't have orgNameArgument, skipped without need to check
-			organizationName := strings.TrimSpace(request.GetString(orgNameArgument, ""))
+			// Skip allowlist enforcement for tools without an organization argument.
+			organizationName := strings.ToLower(strings.TrimSpace(request.GetString(orgNameArgument, "")))
 			if organizationName == "" {
 				return nextToolHandler(ctx, request)
 			}
 
-			if _, allowed := allowedOrganizations[strings.ToLower(organizationName)]; !allowed {
+			if _, allowed := allowedOrganizations[organizationName]; !allowed {
 				logger.Warnf("Rejecting tool call %q: organization %q is not in the configured allowlist",
 					request.Params.Name, organizationName)
 				return mcp.NewToolResultError(fmt.Sprintf(
@@ -46,12 +39,12 @@ func OrganizationAllowlistToolMiddleware(allowlist []string, logger *log.Logger)
 }
 
 // builds a lookup set from allowlist
-func OrganizationAllowlistSet(allowlist []string) map[string]struct{} {
-	allowedSet := make(map[string]struct{}, len(allowlist))
+func buildAllowedOrganizationsMap(allowlist []string) map[string]struct{} {
+	allowedOrganizations := make(map[string]struct{}, len(allowlist))
 	for _, organizationName := range allowlist {
 		if organizationName != "" {
-			allowedSet[organizationName] = struct{}{}
+			allowedOrganizations[organizationName] = struct{}{}
 		}
 	}
-	return allowedSet
+	return allowedOrganizations
 }

--- a/pkg/client/org_allowlist_tool_middleware.go
+++ b/pkg/client/org_allowlist_tool_middleware.go
@@ -1,0 +1,57 @@
+// Copyright IBM Corp. 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package client
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	log "github.com/sirupsen/logrus"
+)
+
+const orgNameArgument = "terraform_org_name"
+
+func OrganizationAllowlistToolMiddleware(allowlist []string, logger *log.Logger) server.ToolHandlerMiddleware {
+	allowedOrganizations := OrganizationAllowlistSet(allowlist)
+
+	// if no allowed organization listed, skip to next toolmiddleware without need to initialize OrganizationAllowlistToolMiddleware
+	if len(allowedOrganizations) == 0 {
+		return func(nextToolHandler server.ToolHandlerFunc) server.ToolHandlerFunc {
+			return nextToolHandler
+		}
+	}
+
+	return func(nextToolHandler server.ToolHandlerFunc) server.ToolHandlerFunc {
+		return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			// if tool doesn't have orgNameArgument, skipped without need to check
+			organizationName := request.GetString(orgNameArgument, "")
+			if organizationName == "" {
+				return nextToolHandler(ctx, request)
+			}
+
+			if _, allowed := allowedOrganizations[strings.ToLower(organizationName)]; !allowed {
+				logger.Warnf("Rejecting tool call %q: organization %q is not in the configured allowlist",
+					request.Params.Name, organizationName)
+				return mcp.NewToolResultError(fmt.Sprintf(
+					"Terraform organization %q is not allowed by this server", organizationName)), nil
+			}
+
+			return nextToolHandler(ctx, request)
+		}
+	}
+}
+
+// builds a lookup set from allowlist
+func OrganizationAllowlistSet(allowlist []string) map[string]struct{} {
+	allowedSet := make(map[string]struct{}, len(allowlist))
+	for _, organizationName := range allowlist {
+		if organizationName != "" {
+			allowedSet[organizationName] = struct{}{}
+		}
+	}
+	return allowedSet
+}

--- a/pkg/client/org_allowlist_tool_middleware_test.go
+++ b/pkg/client/org_allowlist_tool_middleware_test.go
@@ -20,11 +20,6 @@ func TestOrganizationAllowlistToolMiddleware(t *testing.T) {
 		wantAllowed bool
 	}{
 		{
-			name:        "allows request when allowlist is empty",
-			arguments:   map[string]any{orgNameArgument: "any-org"},
-			wantAllowed: true,
-		},
-		{
 			name:        "allows tool without organization argument",
 			allowlist:   []string{"allowed-org"},
 			arguments:   map[string]any{},

--- a/pkg/client/org_allowlist_tool_middleware_test.go
+++ b/pkg/client/org_allowlist_tool_middleware_test.go
@@ -1,0 +1,80 @@
+// Copyright IBM Corp. 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package client
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOrganizationAllowlistToolMiddleware(t *testing.T) {
+	tests := []struct {
+		name        string
+		allowlist   []string
+		arguments   map[string]any
+		wantAllowed bool
+	}{
+		{
+			name:        "allows request when allowlist is empty",
+			arguments:   map[string]any{orgNameArgument: "any-org"},
+			wantAllowed: true,
+		},
+		{
+			name:        "allows tool without organization argument",
+			allowlist:   []string{"allowed-org"},
+			arguments:   map[string]any{},
+			wantAllowed: true,
+		},
+		{
+			name:        "allows organization in allowlist",
+			allowlist:   []string{"allowed-org"},
+			arguments:   map[string]any{orgNameArgument: "allowed-org"},
+			wantAllowed: true,
+		},
+		{
+			name:        "rejects organization not in allowlist",
+			allowlist:   []string{"allowed-org"},
+			arguments:   map[string]any{orgNameArgument: "blocked-org"},
+			wantAllowed: false,
+		},
+	}
+
+	logger := log.New()
+	logger.SetLevel(log.ErrorLevel)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			nextCalled := false
+
+			mockHandler := func(
+				context.Context,
+				mcp.CallToolRequest,
+			) (*mcp.CallToolResult, error) {
+				nextCalled = true
+				return mcp.NewToolResultText("success"), nil
+			}
+
+			handler := OrganizationAllowlistToolMiddleware(
+				test.allowlist,
+				logger,
+			)(mockHandler)
+
+			request := mcp.CallToolRequest{
+				Params: mcp.CallToolParams{
+					Name:      "test_tool",
+					Arguments: test.arguments,
+				},
+			}
+
+			result, err := handler(context.Background(), request)
+			assert.NoError(t, err)
+			assert.Equal(t, test.wantAllowed, nextCalled)
+			assert.Equal(t, !test.wantAllowed, result.IsError)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Adds an organization allowlist middleware for tool calls made through the HTTP server.

When an allowlist is configured, the middleware checks tool requests that include the `terraform_org_name` argument. Requests are rejected if the specified organization is not included in the configured allowlist.

Tools that do not use `terraform_org_name` continue to run normally. If the allowlist is empty, the middleware is not initialized and all tool requests are passed through unchanged.

## Changes

- `org_allowlist_tool_middleware.go`: Adds `OrganizationAllowlistToolMiddleware`. Builds a lookup set from the configured organization allowlist. Allows tools without a `terraform_org_name` argument to bypass the allowlist check. Rejects tool calls when the specified organization is not in the allowlist. Logs rejected tool calls with the tool and organization names.
- `org_allowlist_tool_middleware_test.go`: Adds unit tests covering allowed organizations, rejected organizations, tools without an organization argument, and empty allowlists.
- `main.go`: Registers `OrganizationAllowlistToolMiddleware` in `runHTTPServer`.

## Testing

- Added unit tests for the organization allowlist middleware.
- Tested locally with MCP Inspector, including allowed, rejected, bypassed, and empty-allowlist cases.