### PR TITLE
Add `grant_team_access` tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 FEATURES
 
+* [New Tool] `list_teams` Lists all teams within a given Terraform Cloud organization. Requires `terraform_org_name`. Optionally filter by exact team names (`team_names`), or substring search (`search_query`). Supports pagination.
 * [New Tool] `grant_team_access` Grants a team access to a workspace or project by ID. Requires `team_id`, `access_level`, and either `workspace_id` or `project_id` (mutually exclusive). Valid access levels for workspaces: `admin`, `read`, `write`, `plan`, `custom`. Valid access levels for projects: `admin`, `read`, `write`, `maintain`, `custom`.
 
 # 1.2.0
@@ -17,11 +18,6 @@ FEATURES
 IMPROVEMENTS
 
 * Extend the existing HTTP-layer `OrganizationAllowlistMiddleware` with a new MCP tool-layer `OrganizationAllowlistToolMiddleware` that rejects tool calls whose `terraform_org_name` argument is not in the allowlist configured via `MCP_ORGANIZATION_ALLOWLIST`. [430](https://github.com/hashicorp/terraform-mcp-server/pull/430)
-
-# 1.1.1
-
-IMPROVEMENTS
-
 * Add `version` field to the `/health` endpoint response to make it easier to identify which version is deployed at a glance. [410](https://github.com/hashicorp/terraform-mcp-server/pull/410)
 * Add optional Instana instrumentation (metrics and HTTP request tracing) for the streamable-http server, gated behind `INSTANA_ENABLED` [411](https://github.com/hashicorp/terraform-mcp-server/pull/411)
 * Add `TF_MCP_SHARED_SECRET` to send an `X-Tf-Mcp-Secret` header on requests to HCP Terraform / TFE, allowing the backend to identify requests from a trusted MCP deployment [392](https://github.com/hashicorp/terraform-mcp-server/pull/392)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 FEATURES
 
-* [New Tool] `list_teams` Lists all teams within a given Terraform Cloud organization. Requires `terraform_org_name`. Optionally filter by exact team names (`team_names`), or substring search (`search_query`). Supports pagination.
 * [New Tool] `grant_team_access` Grants a team access to a workspace or project by ID. Requires `team_id`, `access_level`, and either `workspace_id` or `project_id` (mutually exclusive). Valid access levels for workspaces: `admin`, `read`, `write`, `plan`, `custom`. Valid access levels for projects: `admin`, `read`, `write`, `maintain`, `custom`.
 
 # 1.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.3.0
+
+FEATURES
+
+* [New Tool] `grant_team_access` Grants a team access to a workspace or project by ID. Requires `team_id`, `access_level`, and either `workspace_id` or `project_id` (mutually exclusive). Valid access levels for workspaces: `admin`, `read`, `write`, `plan`, `custom`. Valid access levels for projects: `admin`, `read`, `write`, `maintain`, `custom`.
+
 # 1.2.0
 
 FEATURES
@@ -11,6 +17,11 @@ FEATURES
 IMPROVEMENTS
 
 * Extend the existing HTTP-layer `OrganizationAllowlistMiddleware` with a new MCP tool-layer `OrganizationAllowlistToolMiddleware` that rejects tool calls whose `terraform_org_name` argument is not in the allowlist configured via `MCP_ORGANIZATION_ALLOWLIST`. [430](https://github.com/hashicorp/terraform-mcp-server/pull/430)
+
+# 1.1.1
+
+IMPROVEMENTS
+
 * Add `version` field to the `/health` endpoint response to make it easier to identify which version is deployed at a glance. [410](https://github.com/hashicorp/terraform-mcp-server/pull/410)
 * Add optional Instana instrumentation (metrics and HTTP request tracing) for the streamable-http server, gated behind `INSTANA_ENABLED` [411](https://github.com/hashicorp/terraform-mcp-server/pull/411)
 * Add `TF_MCP_SHARED_SECRET` to send an `X-Tf-Mcp-Secret` header on requests to HCP Terraform / TFE, allowing the backend to identify requests from a trusted MCP deployment [392](https://github.com/hashicorp/terraform-mcp-server/pull/392)

--- a/pkg/tools/dynamic_tool.go
+++ b/pkg/tools/dynamic_tool.go
@@ -345,6 +345,12 @@ func (r *DynamicToolRegistry) registerTFETools() {
 		r.mcpServer.AddTool(tool.Tool, tool.Handler)
 	}
 
+	// Terraform Access Toolset - Access Levels
+	if toolsets.IsToolEnabled("grant_team_access", r.enabledToolsets) {
+		tool := r.createDynamicTFETool("grant_team_access", tfeTools.GrantTeamAccess)
+		r.mcpServer.AddTool(tool.Tool, tool.Handler)
+	}
+
 	r.tfeToolsRegistered = true
 }
 

--- a/pkg/tools/dynamic_tool.go
+++ b/pkg/tools/dynamic_tool.go
@@ -160,6 +160,12 @@ func (r *DynamicToolRegistry) registerTFETools() {
 		r.mcpServer.AddTool(tool.Tool, tool.Handler)
 	}
 
+	// Only register grant_team_access if TF operations are enabled AND toolset is enabled
+	if isTerraformOperationsEnabled() && toolsets.IsToolEnabled("grant_team_access", r.enabledToolsets) {
+		tool := r.createDynamicTFETool("grant_team_access", tfeTools.GrantTeamAccess)
+		r.mcpServer.AddTool(tool.Tool, tool.Handler)
+	}
+
 	// Registry-private toolset - Private provider tools
 	if toolsets.IsToolEnabled("search_private_providers", r.enabledToolsets) {
 		tool := r.createDynamicTFETool("search_private_providers", tfeTools.SearchPrivateProviders)
@@ -342,12 +348,6 @@ func (r *DynamicToolRegistry) registerTFETools() {
 	// Terraform Toolset - Comments
 	if toolsets.IsToolEnabled("get_run_comments", r.enabledToolsets) {
 		tool := r.createDynamicTFETool("get_run_comments", tfeTools.GetRunComments)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	// Terraform Access Toolset - Access Levels
-	if toolsets.IsToolEnabled("grant_team_access", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("grant_team_access", tfeTools.GrantTeamAccess)
 		r.mcpServer.AddTool(tool.Tool, tool.Handler)
 	}
 

--- a/pkg/tools/dynamic_tool.go
+++ b/pkg/tools/dynamic_tool.go
@@ -160,12 +160,6 @@ func (r *DynamicToolRegistry) registerTFETools() {
 		r.mcpServer.AddTool(tool.Tool, tool.Handler)
 	}
 
-	// Only register grant_team_access if TF operations are enabled AND toolset is enabled
-	if isTerraformOperationsEnabled() && toolsets.IsToolEnabled("grant_team_access", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("grant_team_access", tfeTools.GrantTeamAccess)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
 	// Registry-private toolset - Private provider tools
 	if toolsets.IsToolEnabled("search_private_providers", r.enabledToolsets) {
 		tool := r.createDynamicTFETool("search_private_providers", tfeTools.SearchPrivateProviders)
@@ -348,6 +342,12 @@ func (r *DynamicToolRegistry) registerTFETools() {
 	// Terraform Toolset - Comments
 	if toolsets.IsToolEnabled("get_run_comments", r.enabledToolsets) {
 		tool := r.createDynamicTFETool("get_run_comments", tfeTools.GetRunComments)
+		r.mcpServer.AddTool(tool.Tool, tool.Handler)
+	}
+
+	// Terraform Toolset - Teams
+	if toolsets.IsToolEnabled("grant_team_access", r.enabledToolsets) {
+		tool := r.createDynamicTFETool("grant_team_access", tfeTools.GrantTeamAccess)
 		r.mcpServer.AddTool(tool.Tool, tool.Handler)
 	}
 

--- a/pkg/tools/tfe/grant_team_access.go
+++ b/pkg/tools/tfe/grant_team_access.go
@@ -70,7 +70,7 @@ func grantTeamAccessHandler(ctx context.Context, request mcp.CallToolRequest, lo
 	workspaceID := request.GetString("workspace_id", "")
 	projectID := request.GetString("project_id", "")
 
-	teamID = strings.TrimLeft(strings.TrimSpace(teamID), "/")
+	teamID = strings.TrimSpace(teamID)
 	workspaceID = strings.TrimSpace(workspaceID)
 	projectID = strings.TrimSpace(projectID)
 	accessLevel = strings.ToLower(strings.TrimSpace(accessLevel))

--- a/pkg/tools/tfe/grant_team_access.go
+++ b/pkg/tools/tfe/grant_team_access.go
@@ -97,14 +97,9 @@ func grantTeamAccessHandler(ctx context.Context, request mcp.CallToolRequest, lo
 			return ToolErrorf(logger, "Invalid Team access level %q - must be one of: %s", accessLevel, validTeamAccessLevelsStr)
 		}
 
-		workspace, err := tfeClient.Workspaces.ReadByID(ctx, workspaceID)
-		if err != nil {
-			return ToolErrorf(logger, "Workspace %q not found: %v", workspaceID, err)
-		}
-
 		ta, err := tfeClient.TeamAccess.Add(ctx, tfe.TeamAccessAddOptions{
 			Access:    tfe.Access(tfe.AccessType(accessLevel)),
-			Workspace: workspace,
+			Workspace: &tfe.Workspace{ID: workspaceID},
 			Team:      &tfe.Team{ID: teamID},
 		})
 		if err != nil {
@@ -128,14 +123,9 @@ func grantTeamAccessHandler(ctx context.Context, request mcp.CallToolRequest, lo
 		return ToolErrorf(logger, "Invalid Team Project access level %q - must be one of: %s", accessLevel, validTeamProjectAccessLevelsStr)
 	}
 
-	project, err := tfeClient.Projects.Read(ctx, projectID)
-	if err != nil {
-		return ToolErrorf(logger, "Project %q not found: %v", projectID, err)
-	}
-
 	tpa, err := tfeClient.TeamProjectAccess.Add(ctx, tfe.TeamProjectAccessAddOptions{
 		Access:  tfe.TeamProjectAccessType(accessLevel),
-		Project: project,
+		Project: &tfe.Project{ID: projectID},
 		Team:    &tfe.Team{ID: teamID},
 	})
 	if err != nil {

--- a/pkg/tools/tfe/grant_team_access.go
+++ b/pkg/tools/tfe/grant_team_access.go
@@ -21,24 +21,28 @@ func GrantTeamAccess(logger *log.Logger) server.ServerTool {
 	return server.ServerTool{
 		Tool: mcp.NewTool(
 			"grant_team_access",
-			mcp.WithDescription("Grant a team access to a workspace or project"),
-			mcp.WithTitleAnnotation("Grant team access"),
+			mcp.WithDescription(`Grants a team permission to access a workspace or a project in Terraform Cloud/Enterprise.
+			Provide either workspace_id (for workspace-level access) or project_id (for project-level access) — not both.
+			Returns the created access grant including its ID, team ID, target resource ID, and access level.`),
+			mcp.WithTitleAnnotation("Grant team access to a workspace or project"),
 			mcp.WithOpenWorldHintAnnotation(true),
 			mcp.WithReadOnlyHintAnnotation(false),
 			mcp.WithDestructiveHintAnnotation(false),
 			mcp.WithString("team_id",
 				mcp.Required(),
-				mcp.Description(`The ID of the Terraform Cloud/Enterprise team to grant access to (e.g., 'team-abc123def456')`),
+				mcp.Description(`The ID of the team to grant access. Team IDs begin with 'team-' (e.g., 'team-abc123def456').`),
 			),
 			mcp.WithString("access_level",
 				mcp.Required(),
-				mcp.Description(`The access level to grant access for (e.g. "admin", "read", "write", "plan", "custom")`),
+				mcp.Description(`The permission level to grant the team.
+				For workspace access (workspace_id): "read" (view only), "plan" (can queue plans), "write" (apply runs), "admin" (full control), "custom" (fine-grained permissions).
+				For project access (project_id): "read", "write", "maintain" (manage workspaces), "admin" (full control), "custom". Note: "plan" is only valid for workspaces; "maintain" is only valid for projects.`),
 			),
 			mcp.WithString("workspace_id",
-				mcp.Description(`The ID of the Terraform Cloud/Enterprise workspace to grant access to (e.g., "ws-abc123def456")`),
+				mcp.Description(`The ID of the workspace to grant the team access to. Workspace IDs begin with 'ws-' (e.g., 'ws-abc123def456'). Mutually exclusive with project_id — provide one or the other, not both.`),
 			),
 			mcp.WithString("project_id",
-				mcp.Description(`The ID of the Terraform Cloud/Enterprise project to grant access to (e.g., "prj-abc123def456")`),
+				mcp.Description(`The ID of the project to grant the team access to. Project IDs begin with 'prj-' (e.g., 'prj-abc123def456'). Mutually exclusive with workspace_id — provide one or the other, not both.`),
 			),
 		),
 		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -71,12 +75,10 @@ func grantTeamAccessHandler(ctx context.Context, request mcp.CallToolRequest, lo
 	projectID = strings.TrimSpace(projectID)
 	accessLevel = strings.ToLower(strings.TrimSpace(accessLevel))
 
-	// At least one must be provided, not neither
 	if workspaceID == "" && projectID == "" {
 		return ToolError(logger, "One of workspace_id or project_id must be provided", nil)
 	}
 
-	// Only one must be provided, not both
 	if workspaceID != "" && projectID != "" {
 		return ToolError(logger, "Only one of workspace_id or project_id may be provided, not both", nil)
 	}
@@ -137,7 +139,7 @@ func grantTeamAccessHandler(ctx context.Context, request mcp.CallToolRequest, lo
 		Team:    &tfe.Team{ID: teamID},
 	})
 	if err != nil {
-		return ToolErrorf(logger, "Failed to grant team project access to project %q: %v", workspaceID, err)
+		return ToolErrorf(logger, "Failed to grant team project access to project %q: %v", projectID, err)
 	}
 
 	summaryJSON, err := json.Marshal(TeamProjectAccessSummary{

--- a/pkg/tools/tfe/grant_team_access.go
+++ b/pkg/tools/tfe/grant_team_access.go
@@ -1,0 +1,170 @@
+// Copyright IBM Corp. 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"slices"
+	"strings"
+
+	"github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-mcp-server/pkg/client"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	log "github.com/sirupsen/logrus"
+)
+
+// GrantTeamAccess creates a tool to grant team access to a given workspace or project.
+func GrantTeamAccess(logger *log.Logger) server.ServerTool {
+	return server.ServerTool{
+		Tool: mcp.NewTool(
+			"grant_team_access",
+			mcp.WithDescription("Grant a team access to a workspace or project"),
+			mcp.WithTitleAnnotation("Grant team access"),
+			mcp.WithOpenWorldHintAnnotation(true),
+			mcp.WithReadOnlyHintAnnotation(false),
+			mcp.WithDestructiveHintAnnotation(false),
+			mcp.WithString("team_id",
+				mcp.Required(),
+				mcp.Description(`The ID of the Terraform Cloud/Enterprise team to grant access to (e.g., 'team-abc123def456')`),
+			),
+			mcp.WithString("access_level",
+				mcp.Required(),
+				mcp.Description(`The access level to grant access for (e.g. "admin", "read", "write", "plan", "custom")`),
+			),
+			mcp.WithString("workspace_id",
+				mcp.Description(`The ID of the Terraform Cloud/Enterprise workspace to grant access to (e.g., "ws-abc123def456")`),
+			),
+			mcp.WithString("project_id",
+				mcp.Description(`The ID of the Terraform Cloud/Enterprise project to grant access to (e.g., "prj-abc123def456")`),
+			),
+		),
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return grantTeamAccessHandler(ctx, request, logger)
+		},
+	}
+}
+
+var validTeamAccessLevels = []string{"admin", "read", "write", "plan", "custom"}
+var validTeamAccessLevelsStr = strings.Join(validTeamAccessLevels, ", ")
+var validTeamProjectAccessLevels = []string{"admin", "read", "write", "maintain", "custom"}
+var validTeamProjectAccessLevelsStr = strings.Join(validTeamProjectAccessLevels, ", ")
+
+// grantTeamAccessHandler handles tool logics and functionality
+func grantTeamAccessHandler(ctx context.Context, request mcp.CallToolRequest, logger *log.Logger) (*mcp.CallToolResult, error) {
+
+	teamID, err := request.RequireString("team_id")
+	if err != nil {
+		return ToolError(logger, "Missing required input: team_id", err)
+	}
+	accessLevel, err := request.RequireString("access_level")
+	if err != nil {
+		return ToolError(logger, "Missing required input: access_level", err)
+	}
+	workspaceID := request.GetString("workspace_id", "")
+	projectID := request.GetString("project_id", "")
+
+	teamID = strings.TrimLeft(strings.TrimSpace(teamID), "/")
+	workspaceID = strings.TrimSpace(workspaceID)
+	projectID = strings.TrimSpace(projectID)
+	accessLevel = strings.ToLower(strings.TrimSpace(accessLevel))
+
+	// At least one must be provided, not neither
+	if workspaceID == "" && projectID == "" {
+		return ToolError(logger, "One of workspace_id or project_id must be provided", nil)
+	}
+
+	// Only one must be provided, not both
+	if workspaceID != "" && projectID != "" {
+		return ToolError(logger, "Only one of workspace_id or project_id may be provided, not both", nil)
+	}
+
+	tfeClient, err := client.GetTfeClientFromContext(ctx, logger)
+	if err != nil {
+		return ToolError(logger, "Failed to get Terraform client", err)
+	}
+	if tfeClient == nil {
+		return ToolError(logger, "Failed to get Terraform client - ensure TFE_TOKEN and TFE_ADDRESS are configured", nil)
+	}
+
+	if workspaceID != "" {
+
+		if !slices.Contains(validTeamAccessLevels, accessLevel) {
+			return ToolErrorf(logger, "Invalid Team access level %q - must be one of: %s", accessLevel, validTeamAccessLevelsStr)
+		}
+
+		workspace, err := tfeClient.Workspaces.ReadByID(ctx, workspaceID)
+		if err != nil {
+			return ToolErrorf(logger, "Workspace %q not found: %v", workspaceID, err)
+		}
+
+		ta, err := tfeClient.TeamAccess.Add(ctx, tfe.TeamAccessAddOptions{
+			Access:    tfe.Access(tfe.AccessType(accessLevel)),
+			Workspace: workspace,
+			Team:      &tfe.Team{ID: teamID},
+		})
+		if err != nil {
+			return ToolErrorf(logger, "Failed to grant team access to workspace %q: %v", workspaceID, err)
+		}
+
+		summaryJSON, err := json.Marshal(TeamAccessSummary{
+			ID:          ta.ID,
+			TeamID:      ta.Team.ID,
+			WorkspaceID: ta.Workspace.ID,
+			Access:      string(ta.Access),
+		})
+		if err != nil {
+			return ToolError(logger, "failed to serialize summary", err)
+		}
+
+		return mcp.NewToolResultText(string(summaryJSON)), nil
+	}
+
+	if !slices.Contains(validTeamProjectAccessLevels, accessLevel) {
+		return ToolErrorf(logger, "Invalid Team Project access level %q - must be one of: %s", accessLevel, validTeamProjectAccessLevelsStr)
+	}
+
+	project, err := tfeClient.Projects.Read(ctx, projectID)
+	if err != nil {
+		return ToolErrorf(logger, "Project %q not found: %v", projectID, err)
+	}
+
+	tpa, err := tfeClient.TeamProjectAccess.Add(ctx, tfe.TeamProjectAccessAddOptions{
+		Access:  tfe.TeamProjectAccessType(accessLevel),
+		Project: project,
+		Team:    &tfe.Team{ID: teamID},
+	})
+	if err != nil {
+		return ToolErrorf(logger, "Failed to grant team project access to project %q: %v", workspaceID, err)
+	}
+
+	summaryJSON, err := json.Marshal(TeamProjectAccessSummary{
+		ID:        tpa.ID,
+		TeamID:    tpa.Team.ID,
+		ProjectID: tpa.Project.ID,
+		Access:    string(tpa.Access),
+	})
+	if err != nil {
+		return ToolError(logger, "failed to serialize summary", err)
+	}
+
+	return mcp.NewToolResultText(string(summaryJSON)), nil
+}
+
+// TeamAccessSummary is the response summary for a granted workspace team access
+type TeamAccessSummary struct {
+	ID          string `json:"id"`
+	TeamID      string `json:"team_id"`
+	WorkspaceID string `json:"workspace_id"`
+	Access      string `json:"access"`
+}
+
+// TeamProjectAccessSummary is the response summary for a granted project team access
+type TeamProjectAccessSummary struct {
+	ID        string `json:"id"`
+	TeamID    string `json:"team_id"`
+	ProjectID string `json:"project_id"`
+	Access    string `json:"access"`
+}

--- a/pkg/tools/tfe/grant_team_access_test.go
+++ b/pkg/tools/tfe/grant_team_access_test.go
@@ -1,0 +1,199 @@
+// Copyright IBM Corp. 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package tools
+
+import (
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGrantTeamAccess(t *testing.T) {
+	logger := log.New()
+	logger.SetLevel(log.ErrorLevel)
+
+	t.Run("tool creation", func(t *testing.T) {
+		tool := GrantTeamAccess(logger)
+
+		assert.Equal(t, "grant_team_access", tool.Tool.Name)
+		assert.Contains(t, tool.Tool.Description, "Grants a team permission to access a workspace or a project")
+		assert.NotNil(t, tool.Handler)
+
+		// Check annotations
+		assert.NotNil(t, tool.Tool.Annotations.ReadOnlyHint)
+		assert.False(t, *tool.Tool.Annotations.ReadOnlyHint)
+		assert.NotNil(t, tool.Tool.Annotations.DestructiveHint)
+		assert.False(t, *tool.Tool.Annotations.DestructiveHint)
+
+		// Check required parameters
+		assert.Contains(t, tool.Tool.InputSchema.Required, "team_id")
+		assert.Contains(t, tool.Tool.InputSchema.Required, "access_level")
+
+		// Check optional parameters exist in schema
+		assert.NotNil(t, tool.Tool.InputSchema.Properties["workspace_id"])
+		assert.NotNil(t, tool.Tool.InputSchema.Properties["project_id"])
+	})
+}
+
+func TestGrantTeamAccessHandler_InputValidation(t *testing.T) {
+	logger := log.New()
+	logger.SetLevel(log.ErrorLevel)
+	_ = logger
+
+	t.Run("missing team_id", func(t *testing.T) {
+		request := &MockCallToolRequest{
+			params: map[string]interface{}{
+				// team_id intentionally omitted
+				"access_level": "read",
+				"workspace_id": "ws-abc123",
+			},
+		}
+
+		_, err := request.RequireString("team_id")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "missing required parameter")
+	})
+
+	t.Run("missing access_level", func(t *testing.T) {
+		request := &MockCallToolRequest{
+			params: map[string]interface{}{
+				"team_id":      "team-abc123",
+				"workspace_id": "ws-abc123",
+				// access_level intentionally omitted
+			},
+		}
+
+		_, err := request.RequireString("access_level")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "missing required parameter")
+	})
+
+	t.Run("neither workspace_id nor project_id provided", func(t *testing.T) {
+		request := &MockCallToolRequest{
+			params: map[string]interface{}{
+				"team_id":      "team-abc123",
+				"access_level": "read",
+				// neither workspace_id nor project_id provided
+			},
+		}
+
+		workspaceID := request.GetString("workspace_id", "")
+		projectID := request.GetString("project_id", "")
+
+		assert.Empty(t, workspaceID)
+		assert.Empty(t, projectID)
+	})
+
+	t.Run("both workspace_id and project_id provided", func(t *testing.T) {
+		request := &MockCallToolRequest{
+			params: map[string]interface{}{
+				"team_id":      "team-abc123",
+				"access_level": "read",
+				"workspace_id": "ws-abc123",
+				"project_id":   "prj-abc123",
+			},
+		}
+
+		workspaceID := request.GetString("workspace_id", "")
+		projectID := request.GetString("project_id", "")
+
+		assert.NotEmpty(t, workspaceID)
+		assert.NotEmpty(t, projectID)
+	})
+
+	t.Run("parameter parsing", func(t *testing.T) {
+		request := &MockCallToolRequest{
+			params: map[string]interface{}{
+				"team_id":      "team-abc123",
+				"access_level": "admin",
+				"workspace_id": "ws-abc123",
+			},
+		}
+
+		teamID, err := request.RequireString("team_id")
+		assert.NoError(t, err)
+		assert.Equal(t, "team-abc123", teamID)
+
+		accessLevel, err := request.RequireString("access_level")
+		assert.NoError(t, err)
+		assert.Equal(t, "admin", accessLevel)
+
+		workspaceID := request.GetString("workspace_id", "")
+		assert.Equal(t, "ws-abc123", workspaceID)
+
+		projectID := request.GetString("project_id", "")
+		assert.Empty(t, projectID)
+	})
+}
+
+func TestGrantTeamAccessHandler_AccessLevelValidation(t *testing.T) {
+	t.Run("valid workspace access levels", func(t *testing.T) {
+		validLevels := []string{"admin", "read", "write", "plan", "custom"}
+		for _, level := range validLevels {
+			found := false
+			for _, v := range validTeamAccessLevels {
+				if v == level {
+					found = true
+					break
+				}
+			}
+			assert.True(t, found, "expected %q to be a valid workspace access level", level)
+		}
+	})
+
+	t.Run("valid project access levels", func(t *testing.T) {
+		validLevels := []string{"admin", "read", "write", "maintain", "custom"}
+		for _, level := range validLevels {
+			found := false
+			for _, v := range validTeamProjectAccessLevels {
+				if v == level {
+					found = true
+					break
+				}
+			}
+			assert.True(t, found, "expected %q to be a valid project access level", level)
+		}
+	})
+
+	t.Run("plan is invalid for project access", func(t *testing.T) {
+		found := false
+		for _, v := range validTeamProjectAccessLevels {
+			if v == "plan" {
+				found = true
+				break
+			}
+		}
+		assert.False(t, found, `"plan" must not be a valid project access level`)
+	})
+
+	t.Run("maintain is invalid for workspace access", func(t *testing.T) {
+		found := false
+		for _, v := range validTeamAccessLevels {
+			if v == "maintain" {
+				found = true
+				break
+			}
+		}
+		assert.False(t, found, `"maintain" must not be a valid workspace access level`)
+	})
+
+	t.Run("invalid access level is not in either list", func(t *testing.T) {
+		invalidLevel := "superadmin"
+		foundInWorkspace := false
+		foundInProject := false
+		for _, v := range validTeamAccessLevels {
+			if v == invalidLevel {
+				foundInWorkspace = true
+			}
+		}
+		for _, v := range validTeamProjectAccessLevels {
+			if v == invalidLevel {
+				foundInProject = true
+			}
+		}
+		assert.False(t, foundInWorkspace)
+		assert.False(t, foundInProject)
+	})
+}

--- a/pkg/tools/tfe/grant_team_access_test.go
+++ b/pkg/tools/tfe/grant_team_access_test.go
@@ -69,63 +69,6 @@ func TestGrantTeamAccessHandler_InputValidation(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "missing required parameter")
 	})
-
-	t.Run("neither workspace_id nor project_id provided", func(t *testing.T) {
-		request := &MockCallToolRequest{
-			params: map[string]interface{}{
-				"team_id":      "team-abc123",
-				"access_level": "read",
-				// neither workspace_id nor project_id provided
-			},
-		}
-
-		workspaceID := request.GetString("workspace_id", "")
-		projectID := request.GetString("project_id", "")
-
-		assert.Empty(t, workspaceID)
-		assert.Empty(t, projectID)
-	})
-
-	t.Run("both workspace_id and project_id provided", func(t *testing.T) {
-		request := &MockCallToolRequest{
-			params: map[string]interface{}{
-				"team_id":      "team-abc123",
-				"access_level": "read",
-				"workspace_id": "ws-abc123",
-				"project_id":   "prj-abc123",
-			},
-		}
-
-		workspaceID := request.GetString("workspace_id", "")
-		projectID := request.GetString("project_id", "")
-
-		assert.NotEmpty(t, workspaceID)
-		assert.NotEmpty(t, projectID)
-	})
-
-	t.Run("parameter parsing", func(t *testing.T) {
-		request := &MockCallToolRequest{
-			params: map[string]interface{}{
-				"team_id":      "team-abc123",
-				"access_level": "admin",
-				"workspace_id": "ws-abc123",
-			},
-		}
-
-		teamID, err := request.RequireString("team_id")
-		assert.NoError(t, err)
-		assert.Equal(t, "team-abc123", teamID)
-
-		accessLevel, err := request.RequireString("access_level")
-		assert.NoError(t, err)
-		assert.Equal(t, "admin", accessLevel)
-
-		workspaceID := request.GetString("workspace_id", "")
-		assert.Equal(t, "ws-abc123", workspaceID)
-
-		projectID := request.GetString("project_id", "")
-		assert.Empty(t, projectID)
-	})
 }
 
 func TestGrantTeamAccessHandler_AccessLevelValidation(t *testing.T) {
@@ -166,34 +109,5 @@ func TestGrantTeamAccessHandler_AccessLevelValidation(t *testing.T) {
 			}
 		}
 		assert.False(t, found, `"plan" must not be a valid project access level`)
-	})
-
-	t.Run("maintain is invalid for workspace access", func(t *testing.T) {
-		found := false
-		for _, v := range validTeamAccessLevels {
-			if v == "maintain" {
-				found = true
-				break
-			}
-		}
-		assert.False(t, found, `"maintain" must not be a valid workspace access level`)
-	})
-
-	t.Run("invalid access level is not in either list", func(t *testing.T) {
-		invalidLevel := "superadmin"
-		foundInWorkspace := false
-		foundInProject := false
-		for _, v := range validTeamAccessLevels {
-			if v == invalidLevel {
-				foundInWorkspace = true
-			}
-		}
-		for _, v := range validTeamProjectAccessLevels {
-			if v == invalidLevel {
-				foundInProject = true
-			}
-		}
-		assert.False(t, foundInWorkspace)
-		assert.False(t, foundInProject)
 	})
 }

--- a/pkg/toolsets/mapping.go
+++ b/pkg/toolsets/mapping.go
@@ -64,6 +64,7 @@ var ToolToToolset = map[string]string{
 	"list_state_versions":                 Terraform,
 	"get_state_version":                   Terraform,
 	"get_run_comments":                    Terraform,
+	"grant_team_access":                   Terraform,
 }
 
 // GetToolsetForTool returns the toolset name for a given tool name


### PR DESCRIPTION
## New Tool: `grant_team_access`

Adds the `grant_team_access` MCP tool to the terraform toolset.

### What it does

Grants a team permission to access a **workspace** or a **project** in Terraform Cloud/Enterprise (**write operation**).
The tool dispatches to one of two TFE API endpoints depending on the target resource:

- **Workspace-level**: `POST /team-workspaces` via `tfeClient.TeamAccess.Add(...)`
- **Project-level**: `POST /team-projects` via `tfeClient.TeamProjectAccess.Add(...)`

`workspace_id` and `project_id` are mutually exclusive — exactly one must be provided per call.

### What changed

- `pkg/tools/tfe/grant_team_access.go` — tool definition, handler, and response structs (`TeamAccessSummary`, `TeamProjectAccessSummary`)
- `pkg/tools/tfe/grant_team_access_test.go` — unit tests.
- `pkg/tools/dynamic_tool.go` — registers `grant_team_access` 
- `pkg/toolsets/mapping.go` — adds `grant_team_access` to the `terraform` toolset
- `CHANGELOG.md` — entry added under `1.2.0` FEATURES

### Inputs / Output

| Parameter | Required | Description |
|---|---|---|
| `team_id` | Yes | Team ID (e.g. `team-abc123`) |
| `access_level` | Yes | Permission level to grant (see valid values below) |
| `workspace_id` | One of | Target workspace ID (e.g. `ws-abc123`). Mutually exclusive with `project_id` |
| `project_id` | One of | Target project ID (e.g. `prj-abc123`). Mutually exclusive with `workspace_id` |

**Valid access levels:**
- Workspace: `read`, `plan`, `write`, `admin`, `custom`
- Project: `read`, `write`, `maintain`, `admin`, `custom`
- Note: `plan` is workspace-only; `maintain` is project-only

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
