### PR TITLE
Add `get_project` tool

### DIFF
--- a/.github/workflows/hcpt_test.yml
+++ b/.github/workflows/hcpt_test.yml
@@ -36,5 +36,6 @@ jobs:
           TF_MCP_ENDPOINT: http://localhost:8080/mcp
           TFE_TOKEN: ${{ secrets.TFE_TOKEN_TESTING }}
           TFE_ORG_NAME: ${{ vars.TEST_TF_ORG_NAME }}
+          ENABLE_TF_OPERATIONS: true
         run: |
           make test-hcpt

--- a/.github/workflows/hcpt_test.yml
+++ b/.github/workflows/hcpt_test.yml
@@ -28,6 +28,8 @@ jobs:
           make build
 
       - name: Start server
+        env:
+          ENABLE_TF_OPERATIONS: true
         run: |
           nohup ./bin/terraform-mcp-server streamable-http --transport-host 0.0.0.0 --transport-port 8080 2>&1 &
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.3.0
+
+FEATURES
+
+* [New Tool] `get_project` Fetches detailed information about a Terraform project by its ID. Requires `project_id`.
+
 # 1.2.0
 
 FEATURES

--- a/pkg/tools/dynamic_tool.go
+++ b/pkg/tools/dynamic_tool.go
@@ -153,6 +153,19 @@ func (r *DynamicToolRegistry) registerTFETools() {
 		r.mcpServer.AddTool(tool.Tool, tool.Handler)
 	}
 
+	// Terraform toolset - Project management tools
+	if toolsets.IsToolEnabled("create_project", r.enabledToolsets) {
+		tool := r.createDynamicTFETool("create_project", tfeTools.CreateProject)
+		r.mcpServer.AddTool(tool.Tool, tool.Handler)
+	}
+
+	// Only register delete_project if TF operations are enabled AND toolset is enabled
+	if isTerraformOperationsEnabled() && toolsets.IsToolEnabled("delete_project", r.enabledToolsets) {
+		tool := r.createDynamicTFETool("delete_project", tfeTools.DeleteProject)
+		r.mcpServer.AddTool(tool.Tool, tool.Handler)
+	}
+
+	// Only register delete_workspace_safely if TF operations are enabled AND toolset is enabled
 	if isTerraformOperationsEnabled() && toolsets.IsToolEnabled("delete_workspace_safely", r.enabledToolsets) {
 		tool := r.createDynamicTFETool("delete_workspace_safely", tfeTools.DeleteWorkspaceSafely)
 		r.mcpServer.AddTool(tool.Tool, tool.Handler)

--- a/pkg/tools/dynamic_tool.go
+++ b/pkg/tools/dynamic_tool.go
@@ -348,6 +348,12 @@ func (r *DynamicToolRegistry) registerTFETools() {
 		r.mcpServer.AddTool(tool.Tool, tool.Handler)
 	}
 
+	// Terraform Toolset - Project
+	if toolsets.IsToolEnabled("get_project", r.enabledToolsets) {
+		tool := r.createDynamicTFETool("get_project", tfeTools.GetProject)
+		r.mcpServer.AddTool(tool.Tool, tool.Handler)
+	}
+
 	r.tfeToolsRegistered = true
 }
 

--- a/pkg/tools/tfe/get_project.go
+++ b/pkg/tools/tfe/get_project.go
@@ -41,7 +41,7 @@ func getProjectHandler(ctx context.Context, request mcp.CallToolRequest, logger 
 
 	projectID, err := request.RequireString("project_id")
 	if err != nil {
-		return ToolError(logger, "missing required input: project_id", err)
+		return ToolError(logger, "Missing required input: project_id", err)
 	}
 	projectID = strings.TrimSpace(projectID)
 
@@ -55,7 +55,7 @@ func getProjectHandler(ctx context.Context, request mcp.CallToolRequest, logger 
 
 	project, err := tfeClient.Projects.Read(ctx, projectID)
 	if err != nil {
-		return ToolErrorf(logger, "failed to read project %q: %v", projectID, err)
+		return ToolErrorf(logger, "Failed to read project %q: %v", projectID, err)
 	}
 
 	summary := &GetProjectSummary{

--- a/pkg/tools/tfe/get_project.go
+++ b/pkg/tools/tfe/get_project.go
@@ -58,7 +58,7 @@ func getProjectHandler(ctx context.Context, request mcp.CallToolRequest, logger 
 		return ToolErrorf(logger, "Failed to read project %q: %v", projectID, err)
 	}
 
-	summary := &GetProjectSummary{
+	summary := &ProjectDetails{
 		ID:                   project.ID,
 		Name:                 project.Name,
 		Description:          project.Description,
@@ -82,8 +82,8 @@ func getProjectHandler(ctx context.Context, request mcp.CallToolRequest, logger 
 	return mcp.NewToolResultText(string(projectJSON)), nil
 }
 
-// GetProjectSummary is the response shape returned by the get_project tool.
-type GetProjectSummary struct {
+// ProjectDetails is the response shape returned by the get_project tool.
+type ProjectDetails struct {
 	ID                          string `json:"project_id"`
 	Name                        string `json:"project_name"`
 	Description                 string `json:"description,omitempty"`

--- a/pkg/tools/tfe/get_project.go
+++ b/pkg/tools/tfe/get_project.go
@@ -1,0 +1,94 @@
+// Copyright IBM Corp. 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/hashicorp/terraform-mcp-server/pkg/client"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	log "github.com/sirupsen/logrus"
+)
+
+// GetProject creates a tool to fetch a Terraform project by its ID.
+func GetProject(logger *log.Logger) server.ServerTool {
+	return server.ServerTool{
+		Tool: mcp.NewTool(
+			"get_project",
+			mcp.WithDescription(`Fetches detailed information about a Terraform project by its ID. If the project ID isn't already known, call list_terraform_projects first.`),
+			mcp.WithTitleAnnotation("Get a Terraform project by ID"),
+			mcp.WithOpenWorldHintAnnotation(true),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithDestructiveHintAnnotation(false),
+			mcp.WithString("project_id",
+				mcp.Required(),
+				mcp.Description("The ID of the project to fetch (e.g., 'prj-abc123def456')"),
+			),
+		),
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return getProjectHandler(ctx, request, logger)
+		},
+	}
+
+}
+
+// getProjectHandler handles tool logics and functionality
+func getProjectHandler(ctx context.Context, request mcp.CallToolRequest, logger *log.Logger) (*mcp.CallToolResult, error) {
+
+	projectID, err := request.RequireString("project_id")
+	if err != nil {
+		return ToolError(logger, "missing required input: project_id", err)
+	}
+	projectID = strings.TrimSpace(projectID)
+
+	tfeClient, err := client.GetTfeClientFromContext(ctx, logger)
+	if err != nil {
+		return ToolError(logger, "Failed to get Terraform client", err)
+	}
+	if tfeClient == nil {
+		return ToolError(logger, "Failed to get Terraform client - ensure TFE_TOKEN and TFE_ADDRESS are configured", nil)
+	}
+
+	project, err := tfeClient.Projects.Read(ctx, projectID)
+	if err != nil {
+		return ToolErrorf(logger, "failed to read project %q: %v", projectID, err)
+	}
+
+	summary := &GetProjectSummary{
+		ID:                   project.ID,
+		Name:                 project.Name,
+		Description:          project.Description,
+		DefaultExecutionMode: project.DefaultExecutionMode,
+		IsUnified:            project.IsUnified,
+	}
+	if project.Organization != nil {
+		summary.OrganizationName = project.Organization.Name
+	}
+	if project.AutoDestroyActivityDuration.IsSpecified() && !project.AutoDestroyActivityDuration.IsNull() {
+		if v, err := project.AutoDestroyActivityDuration.Get(); err == nil {
+			summary.AutoDestroyActivityDuration = v
+		}
+	}
+
+	projectJSON, err := json.Marshal(summary)
+	if err != nil {
+		return ToolError(logger, "Failed to serialize project", err)
+	}
+
+	return mcp.NewToolResultText(string(projectJSON)), nil
+}
+
+// GetProjectSummary is the response shape returned by the get_project tool.
+type GetProjectSummary struct {
+	ID                          string `json:"project_id"`
+	Name                        string `json:"project_name"`
+	Description                 string `json:"description,omitempty"`
+	DefaultExecutionMode        string `json:"default_execution_mode,omitempty"`
+	IsUnified                   bool   `json:"is_unified"`
+	AutoDestroyActivityDuration string `json:"auto_destroy_activity_duration,omitempty"`
+	OrganizationName            string `json:"organization_name,omitempty"`
+}

--- a/pkg/tools/tfe/get_project_test.go
+++ b/pkg/tools/tfe/get_project_test.go
@@ -1,0 +1,73 @@
+// Copyright IBM Corp. 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package tools
+
+import (
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetProject(t *testing.T) {
+	logger := log.New()
+	logger.SetLevel(log.ErrorLevel)
+
+	t.Run("tool creation", func(t *testing.T) {
+		tool := GetProject(logger)
+
+		assert.Equal(t, "get_project", tool.Tool.Name)
+		assert.Contains(t, tool.Tool.Description, "Terraform project")
+		assert.NotNil(t, tool.Handler)
+
+		// Verify annotations: read-only, not destructive, calls external TFE API
+		assert.NotNil(t, tool.Tool.Annotations.ReadOnlyHint)
+		assert.True(t, *tool.Tool.Annotations.ReadOnlyHint)
+		assert.NotNil(t, tool.Tool.Annotations.DestructiveHint)
+		assert.False(t, *tool.Tool.Annotations.DestructiveHint)
+		assert.NotNil(t, tool.Tool.Annotations.OpenWorldHint)
+		assert.True(t, *tool.Tool.Annotations.OpenWorldHint)
+
+		// Check that project_id is the only required parameter
+		assert.Contains(t, tool.Tool.InputSchema.Required, "project_id")
+		assert.Len(t, tool.Tool.InputSchema.Required, 1)
+	})
+
+	t.Run("parameter validation", func(t *testing.T) {
+		tests := []struct {
+			name        string
+			params      map[string]interface{}
+			expectError bool
+		}{
+			{
+				name: "valid project_id",
+				params: map[string]interface{}{
+					"project_id": "prj-abc123def456",
+				},
+				expectError: false,
+			},
+			{
+				name:        "missing project_id",
+				params:      map[string]interface{}{},
+				expectError: true,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				request := &MockCallToolRequest{params: tt.params}
+
+				projectID, err := request.RequireString("project_id")
+
+				if tt.expectError {
+					assert.Error(t, err)
+					assert.Contains(t, err.Error(), "project_id")
+				} else {
+					assert.NoError(t, err)
+					assert.Equal(t, tt.params["project_id"], projectID)
+				}
+			})
+		}
+	})
+}

--- a/pkg/toolsets/mapping.go
+++ b/pkg/toolsets/mapping.go
@@ -69,6 +69,7 @@ var ToolToToolset = map[string]string{
 	"list_state_versions":                 Terraform,
 	"get_state_version":                   Terraform,
 	"get_run_comments":                    Terraform,
+	"get_project":                         Terraform,
 }
 
 // GetToolsetForTool returns the toolset name for a given tool name

--- a/test/terraform/projects_test.go
+++ b/test/terraform/projects_test.go
@@ -68,6 +68,7 @@ func TestListAndGetProject(t *testing.T) {
 }
 
 func TestCreateAndDeleteProject(t *testing.T) {
+	requireTfOperations(t)
 	s := newTestingSession(t)
 	defer s.Close()
 

--- a/test/terraform/projects_test.go
+++ b/test/terraform/projects_test.go
@@ -1,0 +1,160 @@
+package terraform
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+// deleteProject deletes a project using its own context so it can be safely
+// called from t.Cleanup, where t.Context() is already cancelled.
+func deleteProject(t *testing.T, s *mcp.ClientSession, projectID string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), toolCallTimeout)
+	defer cancel()
+	_, _ = s.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "delete_project",
+		Arguments: map[string]any{"project_id": projectID},
+	})
+}
+
+func TestListAndGetProject(t *testing.T) {
+	s := newTestingSession(t)
+	defer s.Close()
+
+	orgsResult, orgsText := callTool(t, s, "list_terraform_orgs", map[string]any{})
+	require.False(t, orgsResult.IsError, "list_terraform_orgs should not return an error")
+	require.NotEmpty(t, orgsText, "list_terraform_orgs should return a non-empty response")
+
+	orgName := gjson.Get(orgsText, "items.0.organization_name").String()
+	require.NotEmpty(t, orgName, "expected at least one organization to be available")
+
+	projectsResult, projectsText := callTool(t, s, "list_terraform_projects", map[string]any{
+		"terraform_org_name": orgName,
+	})
+	require.False(t, projectsResult.IsError, "list_terraform_projects should not return an error")
+	require.NotEmpty(t, projectsText, "list_terraform_projects should return a non-empty response")
+
+	projectID := gjson.Get(projectsText, "items.0.project_id").String()
+	require.NotEmpty(t, projectID, "expected at least one project to be available in org %q", orgName)
+
+	t.Run("returns project details for a valid project_id", func(t *testing.T) {
+		result, resultText := callTool(t, s, "get_project", map[string]any{
+			"project_id": projectID,
+		})
+
+		require.False(t, result.IsError, "Tool call result should not be an error")
+		require.NotEmpty(t, resultText, "Tool call result must not be empty")
+
+		assert.Equal(t, projectID, gjson.Get(resultText, "project_id").String(), "response should contain the requested project_id")
+		assert.NotEmpty(t, gjson.Get(resultText, "project_name").String(), "response should contain a project_name")
+		assert.True(t, gjson.Get(resultText, "is_unified").Exists(), "response should always contain the is_unified field")
+	})
+
+	t.Run("returns an error for a non-existent project_id", func(t *testing.T) {
+		result, resultText := callTool(t, s, "get_project", map[string]any{
+			"project_id": "prj-doesnotexist000",
+		})
+
+		require.True(t, result.IsError, "Tool call should return an error for an invalid project_id")
+		assert.Contains(t, resultText, "prj-doesnotexist000", "error message should reference the unknown project_id")
+	})
+}
+
+func TestCreateAndDeleteProject(t *testing.T) {
+	s := newTestingSession(t)
+	defer s.Close()
+
+	orgsResult, orgsText := callTool(t, s, "list_terraform_orgs", map[string]any{})
+	require.False(t, orgsResult.IsError, "list_terraform_orgs should not return an error")
+	require.NotEmpty(t, orgsText, "list_terraform_orgs should return a non-empty response")
+
+	orgName := gjson.Get(orgsText, "items.0.organization_name").String()
+	require.NotEmpty(t, orgName, "expected at least one organization to be available")
+
+	// Use a timestamped name to avoid collisions across concurrent or repeated runs.
+	projectName := fmt.Sprintf("mcp-test-%d", time.Now().UnixMilli())
+
+	t.Run("creates a project", func(t *testing.T) {
+		createResult, createText := callTool(t, s, "create_project", map[string]any{
+			"terraform_org_name": orgName,
+			"project_name":       projectName,
+			"description":        "Created by terraform-mcp-server integration tests",
+		})
+
+		require.False(t, createResult.IsError, "create_project should not return an error")
+		require.NotEmpty(t, createText, "create_project should return a non-empty response")
+
+		createdID := gjson.Get(createText, "project_id").String()
+		require.NotEmpty(t, createdID, "create_project response should contain a project_id")
+		assert.Equal(t, projectName, gjson.Get(createText, "project_name").String(), "create_project response should echo back the project name")
+
+		// Safety net: delete the project if any assertion below fails before the
+		// explicit delete subtest runs. Uses a standalone context because
+		// t.Context() is already cancelled when Cleanup fires.
+		t.Cleanup(func() { deleteProject(t, s, createdID) })
+
+		t.Run("get_project returns the newly created project", func(t *testing.T) {
+			getResult, getText := callTool(t, s, "get_project", map[string]any{
+				"project_id": createdID,
+			})
+
+			require.False(t, getResult.IsError, "get_project should not return an error for the newly created project")
+			assert.Equal(t, createdID, gjson.Get(getText, "project_id").String(), "get_project should return the correct project_id")
+			assert.Equal(t, projectName, gjson.Get(getText, "project_name").String(), "get_project should return the correct project_name")
+			assert.Equal(t, "Created by terraform-mcp-server integration tests", gjson.Get(getText, "description").String(), "get_project should return the correct description")
+		})
+
+		t.Run("deletes the project", func(t *testing.T) {
+			deleteResult, deleteText := callTool(t, s, "delete_project", map[string]any{
+				"project_id": createdID,
+			})
+
+			require.False(t, deleteResult.IsError, "delete_project should not return an error for an empty project")
+			assert.Contains(t, deleteText, createdID, "delete_project response should reference the deleted project_id")
+		})
+
+		t.Run("get_project returns an error after deletion", func(t *testing.T) {
+			getResult, _ := callTool(t, s, "get_project", map[string]any{
+				"project_id": createdID,
+			})
+
+			require.True(t, getResult.IsError, "get_project should return an error for a deleted project")
+		})
+	})
+
+	t.Run("returns an error for a duplicate project name", func(t *testing.T) {
+		dupName := projectName + "-dup"
+
+		firstResult, firstText := callTool(t, s, "create_project", map[string]any{
+			"terraform_org_name": orgName,
+			"project_name":       dupName,
+		})
+		require.False(t, firstResult.IsError, "first create_project should succeed")
+
+		firstID := gjson.Get(firstText, "project_id").String()
+		t.Cleanup(func() { deleteProject(t, s, firstID) })
+
+		// A second project with the same name in the same org should be rejected.
+		dupResult, _ := callTool(t, s, "create_project", map[string]any{
+			"terraform_org_name": orgName,
+			"project_name":       dupName,
+		})
+		assert.True(t, dupResult.IsError, "create_project should return an error when a project with the same name already exists")
+	})
+
+	t.Run("returns an error when deleting a non-existent project_id", func(t *testing.T) {
+		result, resultText := callTool(t, s, "delete_project", map[string]any{
+			"project_id": "prj-doesnotexist000",
+		})
+
+		require.True(t, result.IsError, "delete_project should return an error for a non-existent project_id")
+		assert.Contains(t, resultText, "prj-doesnotexist000", "error message should reference the unknown project_id")
+	})
+}

--- a/test/terraform/terraform_test.go
+++ b/test/terraform/terraform_test.go
@@ -25,7 +25,8 @@ var (
 	tfeAddress  string
 	tfeOrgName  string
 
-	testingClient *mcp.Client
+	testingClient      *mcp.Client
+	enableTfOperations string
 )
 
 type authTransport struct {
@@ -53,6 +54,7 @@ func init() {
 	tfeToken = os.Getenv("TFE_TOKEN")
 	tfeAddress = os.Getenv("TFE_ADDRESS")
 	tfeOrgName = os.Getenv("TFE_ORG_NAME")
+	enableTfOperations = os.Getenv("ENABLE_TF_OPERATIONS")
 
 	testingClient = mcp.NewClient(&mcp.Implementation{
 		Name:    "terraform-mcp-server-test-harness",
@@ -113,6 +115,12 @@ func tfeClient(t *testing.T) *tfe.Client {
 		t.Fatalf("Failed to create direct TFE client: %v", err)
 	}
 	return client
+	
+func requireTfOperations(t *testing.T) {
+	t.Helper()
+	if enableTfOperations != "true" {
+		t.Skip("skipping: ENABLE_TF_OPERATIONS is not set to true")
+	}
 }
 
 func getTextContent(result *mcp.CallToolResult) string {


### PR DESCRIPTION
## New Tool: `get_project`

Adds the `get_project` MCP tool to the terraform toolset. Fetches detailed information about a single Terraform project by its ID. Useful when you already have a `project_id` (e.g. from `list_terraform_projects`) and need the full details of that project.

### What changed

- `pkg/tools/tfe/get_project.go` — tool definition, handler, and `ProjectDetails` response struct
- `pkg/tools/tfe/get_project_test.go` — unit tests.
- `pkg/tools/dynamic_tool.go` — registers `get_project` in the terraform toolset.
- `pkg/toolsets/mapping.go` — adds `get_project` to the terraform toolset
- `CHANGELOG.md` — adds entry under `1.2.0`

### Inputs / Output

**Required:** `project_id` (e.g. `prj-abc123def456`)

**Returns:**
```json
{
  "project_id": "prj-abc123def456",
  "project_name": "my-project",
  "description": "...",
  "default_execution_mode": "remote",
  "is_unified": false,
  "auto_destroy_activity_duration": "14d",
  "organization_name": "my-org"
}
```


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
