### PR TITLE
Add per-tool-call Instana tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ FEATURES
 * [New Tool] `grant_team_access` Grants a team access to a workspace or project by ID. Requires `team_id`, `access_level`, and either `workspace_id` or `project_id` (mutually exclusive). Valid access levels for workspaces: `admin`, `read`, `write`, `plan`, `custom`. Valid access levels for projects: `admin`, `read`, `write`, `maintain`, `custom`.
 * [New Tool] `delete_team` Permanently deletes a Terraform team by its `team_id`. Requires `team_id` (e.g. `team-abc123def456`). This is a destructive operation and must set `ENABLE_TF_OPERATIONS=true`.
 
+IMPROVEMENTS
+
+* Add per-tool-call Instana tracing so individual MCP tool calls appear as traces, not just the HTTP request [436](https://github.com/hashicorp/terraform-mcp-server/pull/436)
+
 FIXES
 
 * `get_apply_logs` now checks the apply status before attempting to stream logs. If the apply is not yet in a terminal state (`finished`, `errored`, `canceled`), the tool returns an informative message instead of timing out. [468](https://github.com/hashicorp/terraform-mcp-server/pull/468)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ FEATURES
 * [New Tool] `create_project` Creates a new Terraform project in the specified organization. Requires `terraform_org_name` and `project_name`.
 * [New Tool] `delete_project` Deletes a Terraform project by ID. Requires `project_id`. TFC/TFE will refuse to delete a project that still contains workspaces or stacks.
 
+IMPROVEMENTS
+* Add per-tool-call Instana tracing so individual MCP tool calls appear as traces, not just the HTTP request [436](https://github.com/hashicorp/terraform-mcp-server/pull/436)
+
 # 1.1.1
 
 IMPROVEMENTS

--- a/cmd/terraform-mcp-server/init.go
+++ b/cmd/terraform-mcp-server/init.go
@@ -294,13 +294,9 @@ func setupInstana(logger *log.Logger) instana.TracerLogger {
 	})
 }
 
-func streamableHTTPServerInit(ctx context.Context, hcServer *server.MCPServer, logger *log.Logger, host string, port string, endpointPath string, heartbeatInterval time.Duration, organizationAllowlist []string) error {
-	// Ensure endpoint path starts with /
+func streamableHTTPServerInit(ctx context.Context, hcServer *server.MCPServer, logger *log.Logger, host string, port string, endpointPath string, heartbeatInterval time.Duration, organizationAllowlist []string, instanaCollector instana.TracerLogger) error {
 	endpointPath = path.Join("/", endpointPath)
 	var handler http.Handler
-
-	// Initialize the Instana collector if enabled (nil when disabled).
-	instanaCollector := setupInstana(logger)
 
 	// Create StreamableHTTP server which implements the new streamable-http transport
 	// This is the modern MCP transport that supports both direct HTTP responses and SSE streams

--- a/cmd/terraform-mcp-server/init.go
+++ b/cmd/terraform-mcp-server/init.go
@@ -300,13 +300,10 @@ func setupInstana(logger *log.Logger) instana.TracerLogger {
 	})
 }
 
-func streamableHTTPServerInit(ctx context.Context, hcServer *server.MCPServer, logger *log.Logger, host string, port string, endpointPath string, heartbeatInterval time.Duration, organizationAllowlist []string, enabledToolsets []string) error {
+func streamableHTTPServerInit(ctx context.Context, hcServer *server.MCPServer, logger *log.Logger, host string, port string, endpointPath string, heartbeatInterval time.Duration, organizationAllowlist []string, enabledToolsets []string, instanaCollector instana.TracerLogger) error {
 	// Ensure endpoint path starts with /
 	endpointPath = path.Join("/", endpointPath)
 	var handler http.Handler
-
-	// Initialize the Instana collector if enabled (nil when disabled).
-	instanaCollector := setupInstana(logger)
 
 	// Create StreamableHTTP server which implements the new streamable-http transport
 	// This is the modern MCP transport that supports both direct HTTP responses and SSE streams

--- a/cmd/terraform-mcp-server/main.go
+++ b/cmd/terraform-mcp-server/main.go
@@ -18,6 +18,8 @@ import (
 	"github.com/hashicorp/terraform-mcp-server/pkg/client"
 	"github.com/hashicorp/terraform-mcp-server/pkg/toolsets"
 	"github.com/hashicorp/terraform-mcp-server/version"
+	instana "github.com/instana/go-sensor"
+	ot "github.com/opentracing/opentracing-go"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
@@ -39,6 +41,10 @@ var sessionClientInfo sync.Map // map[string]client.ClientInfo
 func runHTTPServer(logger *log.Logger, host string, port string, endpointPath string, heartbeatInterval time.Duration, enabledToolsets []string, metricsConfig client.MetricsConfig, organizationAllowlist []string) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
+
+	// Initialize the Instana collector once (nil when disabled) so it can be
+	// shared by the tool-call tracing hooks and the HTTP handler wrap.
+	instanaCollector := setupInstana(logger)
 
 	// Create hooks for session management
 	hooks := &server.Hooks{}
@@ -88,8 +94,49 @@ func runHTTPServer(logger *log.Logger, host string, port string, endpointPath st
 		}
 	})
 	attachMetricsHooks(hooks, metricsConfig, logger)
+	attachInstanaTracingHooks(hooks, instanaCollector)
 
-	return streamableHTTPServerInit(ctx, hcServer, logger, host, port, endpointPath, heartbeatInterval, organizationAllowlist, enabledToolsets)
+	return streamableHTTPServerInit(ctx, hcServer, logger, host, port, endpointPath, heartbeatInterval, organizationAllowlist, enabledToolsets, instanaCollector)
+}
+
+// attachInstanaTracingHooks adds a span for each tool call. The http handler is
+// already traced but with streamable-http the tool calls all go over one long
+// lived connection, so we don't actually get a span per call that way. So we add
+// them here at the mcp layer using the hooks instead.
+func attachInstanaTracingHooks(hooks *server.Hooks, collector instana.TracerLogger) {
+	if collector == nil {
+		return
+	}
+
+	// keep the spans here by request id so we can start one in Before and
+	// close the same one out in After
+	var toolCallSpans sync.Map
+
+	hooks.AddBeforeCallTool(func(ctx context.Context, id any, message *mcp.CallToolRequest) {
+		opts := []ot.StartSpanOption{
+			ot.Tags{
+				"span.kind": "server",
+				"mcp.tool":  message.Params.Name,
+			},
+		}
+		if parent, ok := instana.SpanFromContext(ctx); ok {
+			opts = append(opts, ot.ChildOf(parent.Context()))
+		}
+		span := collector.StartSpan("mcp.tool_call", opts...)
+		toolCallSpans.Store(fmt.Sprintf("%v", id), span)
+	})
+
+	hooks.AddAfterCallTool(func(ctx context.Context, id any, message *mcp.CallToolRequest, result any) {
+		v, ok := toolCallSpans.LoadAndDelete(fmt.Sprintf("%v", id))
+		if !ok {
+			return
+		}
+		span := v.(ot.Span)
+		if r, ok := result.(*mcp.CallToolResult); ok && r.IsError {
+			span.SetTag("error", true)
+		}
+		span.Finish()
+	})
 }
 
 func attachMetricsHooks(hooks *server.Hooks, metricsConfig client.MetricsConfig, logger *log.Logger) {

--- a/cmd/terraform-mcp-server/main.go
+++ b/cmd/terraform-mcp-server/main.go
@@ -18,6 +18,8 @@ import (
 	"github.com/hashicorp/terraform-mcp-server/pkg/client"
 	"github.com/hashicorp/terraform-mcp-server/pkg/toolsets"
 	"github.com/hashicorp/terraform-mcp-server/version"
+	instana "github.com/instana/go-sensor"
+	ot "github.com/opentracing/opentracing-go"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
@@ -39,6 +41,10 @@ var sessionClientInfo sync.Map // map[string]client.ClientInfo
 func runHTTPServer(logger *log.Logger, host string, port string, endpointPath string, heartbeatInterval time.Duration, enabledToolsets []string, metricsConfig client.MetricsConfig, organizationAllowlist []string) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
+
+	// Initialize the Instana collector once (nil when disabled) so it can be
+	// shared by the tool-call tracing hooks and the HTTP handler wrap.
+	instanaCollector := setupInstana(logger)
 
 	// Create hooks for session management
 	hooks := &server.Hooks{}
@@ -71,8 +77,50 @@ func runHTTPServer(logger *log.Logger, host string, port string, endpointPath st
 		}
 	})
 	attachMetricsHooks(hooks, metricsConfig, logger)
+	attachInstanaTracingHooks(hooks, instanaCollector)
 
-	return streamableHTTPServerInit(ctx, hcServer, logger, host, port, endpointPath, heartbeatInterval, organizationAllowlist)
+	return streamableHTTPServerInit(ctx, hcServer, logger, host, port, endpointPath, heartbeatInterval, organizationAllowlist, instanaCollector)
+
+}
+
+// toolCallSpans tracks in-flight spans by request id so we can start one in
+// BeforeCallTool and close out the matching span in AfterCallTool.
+var toolCallSpans sync.Map
+
+// attachInstanaTracingHooks adds a span for each tool call. The http handler is
+// already traced but with streamable-http the tool calls all go over one long
+// lived connection, so we don't actually get a span per call that way. So we add
+// them here at the mcp layer using the hooks instead.
+func attachInstanaTracingHooks(hooks *server.Hooks, collector instana.TracerLogger) {
+	if collector == nil {
+		return
+	}
+
+	hooks.AddBeforeCallTool(func(ctx context.Context, id any, message *mcp.CallToolRequest) {
+		opts := []ot.StartSpanOption{
+			ot.Tags{
+				"span.kind": "server",
+				"mcp.tool":  message.Params.Name,
+			},
+		}
+		if parent, ok := instana.SpanFromContext(ctx); ok {
+			opts = append(opts, ot.ChildOf(parent.Context()))
+		}
+		span := collector.StartSpan("mcp.tool_call", opts...)
+		toolCallSpans.Store(fmt.Sprintf("%v", id), span)
+	})
+
+	hooks.AddAfterCallTool(func(ctx context.Context, id any, message *mcp.CallToolRequest, result any) {
+		v, ok := toolCallSpans.LoadAndDelete(fmt.Sprintf("%v", id))
+		if !ok {
+			return
+		}
+		span := v.(ot.Span)
+		if r, ok := result.(*mcp.CallToolResult); ok && r.IsError {
+			span.SetTag("error", true)
+		}
+		span.Finish()
+	})
 }
 
 func attachMetricsHooks(hooks *server.Hooks, metricsConfig client.MetricsConfig, logger *log.Logger) {

--- a/cmd/terraform-mcp-server/main.go
+++ b/cmd/terraform-mcp-server/main.go
@@ -83,10 +83,6 @@ func runHTTPServer(logger *log.Logger, host string, port string, endpointPath st
 
 }
 
-// toolCallSpans tracks in-flight spans by request id so we can start one in
-// BeforeCallTool and close out the matching span in AfterCallTool.
-var toolCallSpans sync.Map
-
 // attachInstanaTracingHooks adds a span for each tool call. The http handler is
 // already traced but with streamable-http the tool calls all go over one long
 // lived connection, so we don't actually get a span per call that way. So we add
@@ -95,6 +91,10 @@ func attachInstanaTracingHooks(hooks *server.Hooks, collector instana.TracerLogg
 	if collector == nil {
 		return
 	}
+
+	// keep the spans here by request id so we can start one in Before and
+	// close the same one out in After
+	var toolCallSpans sync.Map
 
 	hooks.AddBeforeCallTool(func(ctx context.Context, id any, message *mcp.CallToolRequest) {
 		opts := []ot.StartSpanOption{


### PR DESCRIPTION
## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

This PR adds a span for each MCP tool call so we actually get traces for them in Instana.

currently the http handler is already wrapped with Instana's TracingHandlerFunc, but that
only traces at the http request level. With streamable-http the tool calls all go
over one long lived connection, so it's only really seeing the connection and not
the individual tool calls happening inside it. I believe that's why the service shows up but
there's no actual trace data for the tools.

in regards to testing > 

I tested locally and confirmed the hooks fire and a span gets created + finished for
each tool call. But I couldn't fully confirm the spans actually landing in Instana from my
local setup though unfortunately. ran into some issues with the  go-sensor announce handshake to my local dockerized agent kept failing due to weird networking issues, which I know its always a pain with docker on mac

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
