### PR TITLE
fix: honor optional no-code module variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ IMPROVEMENTS
 
 * Extend the existing HTTP-layer `OrganizationAllowlistMiddleware` with a new MCP tool-layer `OrganizationAllowlistToolMiddleware` that rejects tool calls whose `terraform_org_name` argument is not in the allowlist configured via `MCP_ORGANIZATION_ALLOWLIST`. [430](https://github.com/hashicorp/terraform-mcp-server/pull/430)
 
+FIXES
+
+* Honor optional and defaulted module variables when eliciting inputs for `create_no_code_workspace`.
+
 # 1.1.1
 
 IMPROVEMENTS

--- a/pkg/tools/tfe/create_no_code_workspace.go
+++ b/pkg/tools/tfe/create_no_code_workspace.go
@@ -74,14 +74,14 @@ func createNoCodeWorkspaceHandler(ctx context.Context, request mcp.CallToolReque
 		return ToolError(logger, err.Error(), nil)
 	}
 
-	elicitationProperties, requestedVars := buildElicitationSchema(moduleMetadata, noCodeModule)
+	elicitationProperties, requestedVars, requiredVars := buildElicitationSchema(moduleMetadata, noCodeModule)
 
-	result, err := requestVariableValues(ctx, mcpServer, params.noCodeModuleID, elicitationProperties, requestedVars)
+	result, err := requestVariableValues(ctx, mcpServer, params.noCodeModuleID, elicitationProperties, requiredVars)
 	if err != nil {
 		return ToolError(logger, err.Error(), nil)
 	}
 
-	variables, err := processElicitationResponse(result, requestedVars, elicitationProperties)
+	variables, err := processElicitationResponse(result, requestedVars, requiredVars, elicitationProperties)
 	if err != nil {
 		return ToolError(logger, err.Error(), nil)
 	}
@@ -168,17 +168,21 @@ func fetchModuleData(ctx context.Context, tfeClient *tfe.Client, projectID, noCo
 	return project, noCodeModule, &moduleMetadata, nil
 }
 
-func buildElicitationSchema(moduleMetadata *client.ModuleMetadata, noCodeModule *tfe.RegistryNoCodeModule) (map[string]any, []string) {
+func buildElicitationSchema(moduleMetadata *client.ModuleMetadata, noCodeModule *tfe.RegistryNoCodeModule) (map[string]any, []string, []string) {
 	elicitationProperties := make(map[string]any)
 	requestedVars := make([]string, 0, len(moduleMetadata.Data.Attributes.InputVariables))
+	requiredVars := make([]string, 0, len(moduleMetadata.Data.Attributes.InputVariables))
 
 	for _, inputVar := range moduleMetadata.Data.Attributes.InputVariables {
 		property := buildPropertySchema(inputVar, noCodeModule)
 		elicitationProperties[inputVar.Name] = property
 		requestedVars = append(requestedVars, inputVar.Name)
+		if inputVar.Required {
+			requiredVars = append(requiredVars, inputVar.Name)
+		}
 	}
 
-	return elicitationProperties, requestedVars
+	return elicitationProperties, requestedVars, requiredVars
 }
 
 func buildPropertySchema(inputVar struct {
@@ -278,27 +282,44 @@ func requestVariableValues(ctx context.Context, mcpServer *server.MCPServer, mod
 	return result, nil
 }
 
-func processElicitationResponse(result *mcp.ElicitationResult, requestedVars []string, elicitationProperties map[string]any) ([]*tfe.Variable, error) {
+func processElicitationResponse(result *mcp.ElicitationResult, requestedVars, requiredVars []string, elicitationProperties map[string]any) ([]*tfe.Variable, error) {
 	switch result.Action {
 	case mcp.ElicitationResponseActionDecline:
 		return nil, fmt.Errorf("workspace creation declined by user")
 	case mcp.ElicitationResponseActionCancel:
 		return nil, fmt.Errorf("workspace creation cancelled by user")
 	case mcp.ElicitationResponseActionAccept:
-		return extractVariablesFromResponse(result.Content, requestedVars, elicitationProperties)
+		return extractVariablesFromResponse(result.Content, requestedVars, requiredVars, elicitationProperties)
 	default:
 		return nil, fmt.Errorf("unexpected elicitation response action: %s", result.Action)
 	}
 }
 
-func extractVariablesFromResponse(content any, requestedVars []string, elicitationProperties map[string]any) ([]*tfe.Variable, error) {
+func extractVariablesFromResponse(content any, requestedVars, requiredVars []string, elicitationProperties map[string]any) ([]*tfe.Variable, error) {
 	data, ok := content.(map[string]any)
 	if !ok {
 		return nil, fmt.Errorf("elicitation response content is not a map, got %T", content)
 	}
 
+	required := make(map[string]struct{}, len(requiredVars))
+	for _, varName := range requiredVars {
+		required[varName] = struct{}{}
+	}
+
 	variables := make([]*tfe.Variable, 0, len(requestedVars))
 	for _, varName := range requestedVars {
+		valueRaw, exists := data[varName]
+		_, isRequired := required[varName]
+		if !exists {
+			if isRequired {
+				return nil, fmt.Errorf("required variable '%s' is missing from response", varName)
+			}
+			continue
+		}
+		if strValue, ok := valueRaw.(string); ok && strValue == "" && !isRequired {
+			continue
+		}
+
 		variable, err := createVariable(varName, data, elicitationProperties)
 		if err != nil {
 			return nil, err

--- a/pkg/tools/tfe/create_no_code_workspace_test.go
+++ b/pkg/tools/tfe/create_no_code_workspace_test.go
@@ -4,11 +4,15 @@
 package tools
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-mcp-server/pkg/client"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateNoCodeWorkspace(t *testing.T) {
@@ -46,4 +50,98 @@ func TestCreateNoCodeWorkspace(t *testing.T) {
 		// Handler should not be nil
 		assert.NotNil(t, tool.Handler)
 	})
+}
+
+func TestBuildElicitationSchemaOnlyRequiresRequiredVariables(t *testing.T) {
+	moduleMetadata := testModuleMetadata(t)
+
+	properties, requestedVars, requiredVars := buildElicitationSchema(moduleMetadata, &tfe.RegistryNoCodeModule{})
+
+	assert.Equal(t, []string{"name", "description", "enabled", "count"}, requestedVars)
+	assert.Equal(t, []string{"name"}, requiredVars)
+	assert.Len(t, properties, 4)
+}
+
+func TestExtractVariablesFromResponseHonorsOptionalVariables(t *testing.T) {
+	moduleMetadata := testModuleMetadata(t)
+	properties, requestedVars, requiredVars := buildElicitationSchema(moduleMetadata, &tfe.RegistryNoCodeModule{})
+
+	t.Run("omitted optional variables use module defaults", func(t *testing.T) {
+		variables, err := extractVariablesFromResponse(
+			map[string]any{"name": "example"},
+			requestedVars,
+			requiredVars,
+			properties,
+		)
+
+		require.NoError(t, err)
+		require.Len(t, variables, 1)
+		assert.Equal(t, "name", variables[0].Key)
+		assert.Equal(t, "example", variables[0].Value)
+	})
+
+	t.Run("empty optional string uses module default", func(t *testing.T) {
+		variables, err := extractVariablesFromResponse(
+			map[string]any{"name": "example", "description": ""},
+			requestedVars,
+			requiredVars,
+			properties,
+		)
+
+		require.NoError(t, err)
+		require.Len(t, variables, 1)
+		assert.Equal(t, "name", variables[0].Key)
+	})
+
+	t.Run("false and zero optional values are preserved", func(t *testing.T) {
+		variables, err := extractVariablesFromResponse(
+			map[string]any{"name": "example", "enabled": false, "count": float64(0)},
+			requestedVars,
+			requiredVars,
+			properties,
+		)
+
+		require.NoError(t, err)
+		require.Len(t, variables, 3)
+		assert.Equal(t, "false", variables[1].Value)
+		assert.Equal(t, "0", variables[2].Value)
+	})
+
+	t.Run("missing required variable remains invalid", func(t *testing.T) {
+		_, err := extractVariablesFromResponse(map[string]any{}, requestedVars, requiredVars, properties)
+
+		require.EqualError(t, err, "required variable 'name' is missing from response")
+	})
+
+	t.Run("empty required string remains invalid", func(t *testing.T) {
+		_, err := extractVariablesFromResponse(
+			map[string]any{"name": ""},
+			requestedVars,
+			requiredVars,
+			properties,
+		)
+
+		require.EqualError(t, err, "variable 'name' cannot be empty")
+	})
+}
+
+func testModuleMetadata(t *testing.T) *client.ModuleMetadata {
+	t.Helper()
+
+	metadataJSON := []byte(`{
+		"data": {
+			"attributes": {
+				"input-variables": [
+					{"name": "name", "type": "string", "required": true},
+					{"name": "description", "type": "string", "required": false},
+					{"name": "enabled", "type": "bool", "required": false},
+					{"name": "count", "type": "number", "required": false}
+				]
+			}
+		}
+	}`)
+
+	var moduleMetadata client.ModuleMetadata
+	require.NoError(t, json.Unmarshal(metadataJSON, &moduleMetadata))
+	return &moduleMetadata
 }


### PR DESCRIPTION
Fixes #426

## Summary

- mark only module inputs whose metadata reports `required: true` as required in the elicitation schema
- omit absent or empty optional string inputs from workspace creation so HCP Terraform can apply the module defaults
- preserve explicitly supplied optional values such as `false` and `0`

## Root cause

`buildElicitationSchema` used the complete input-variable list as the schema's `required` array. Response processing then required and converted every input, including optional/defaulted ones. As a result, clients could neither omit optional inputs nor leave an optional string empty to use its module default.

## Verification

- `go test ./pkg/tools/tfe -run 'Test(CreateNoCodeWorkspace|BuildElicitationSchemaOnlyRequiresRequiredVariables|ExtractVariablesFromResponseHonorsOptionalVariables)$' -count=1`
- `go test ./cmd/... ./pkg/... ./version -count=1`
- `go vet ./...`
- `make build`
- `make test-hcpt` (passes with the credentialed HCPT test skipped because no local `TFE_TOKEN` is configured)
- `git diff --check`

Local Docker E2E tests did not start: the image build remained blocked for about five minutes and was terminated before any test case ran. All non-E2E packages passed.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

  Revert this pull request; the change does not require data migration or external cleanup.

- [x] If applicable, I've documented the impact of any changes to security controls.

  No security controls are changed.
