### PR TITLE
add authentication bearer token to loadtest

### DIFF
--- a/.github/workflows/loadtest.yml
+++ b/.github/workflows/loadtest.yml
@@ -35,5 +35,7 @@ jobs:
           curl -sf http://localhost:8080/health || exit 1
 
       - name: Run load test
+        env:
+          TFE_TOKEN: ${{ secrets.TFE_TOKEN }}
         run: |
           ./loadtest -workers=2 -qps=2 -duration=30s http://localhost:8080/mcp

--- a/cmd/loadtest/main.go
+++ b/cmd/loadtest/main.go
@@ -10,6 +10,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"os/signal"
 	"sync"
@@ -18,6 +19,17 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
+
+type authTransport struct {
+	token        string
+	roundtripper http.RoundTripper
+}
+
+func (t *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	req.Header.Set("Authorization", "Bearer "+t.token)
+	return t.roundtripper.RoundTrip(req)
+}
 
 var (
 	duration = flag.Duration("duration", 1*time.Minute, "duration of the load test")
@@ -59,6 +71,20 @@ func main() {
 	ctx, stop := signal.NotifyContext(ctx, os.Interrupt)
 	defer stop()
 
+	httpClient := http.DefaultClient
+
+	if tfeToken := os.Getenv("TFE_TOKEN"); tfeToken != "" {
+		httpClient = &http.Client{
+			Transport: &authTransport{
+				token:        tfeToken,
+				roundtripper: http.DefaultTransport,
+			},
+		}
+		log.Print("loadtest: using bearer authentication from TFE_TOKEN")
+	} else {
+		log.Print("loadtest: TFE_TOKEN not set; running without authentication")
+	}
+
 	var (
 		start   = time.Now()
 		success atomic.Int64
@@ -74,7 +100,7 @@ func main() {
 			defer wg.Done()
 
 			client := mcp.NewClient(&mcp.Implementation{Name: "loadtest", Version: "v1.0.0"}, nil)
-			session, err := client.Connect(ctx, &mcp.StreamableClientTransport{Endpoint: endpoint}, nil)
+			session, err := client.Connect(ctx, &mcp.StreamableClientTransport{Endpoint: endpoint, HTTPClient: httpClient}, nil)
 			if err != nil {
 				log.Printf("connect error: %v", err)
 				return


### PR DESCRIPTION
## Description
Updates the loadtest client to support authenticated MCP requests using `TFE_TOKEN`. When `TFE_TOKEN` is set, the load test configures a custom HTTP transport that adds: `Authorization: Bearer <TFE_TOKEN>` to outgoing MCP requests. If the token is not set, the loadtest continues using the default unauthenticated HTTP client.

no-changelog-needed