### PR TITLE
automate deployment to remote dev

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,46 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+name: deploy
+
+on:
+  workflow_run:
+    workflows: [build]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch_dev:
+    name: deploy build to remote dev
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push'
+    runs-on: ubuntu-latest
+
+    env:
+      IMAGE_REPOSITORY: hashicorppreview/terraform-mcp-server
+      COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
+
+    steps:
+      - name: Check out built commit
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          ref: ${{ env.COMMIT_SHA }}
+
+      - name: Determine product version
+        id: version
+        uses: hashicorp/actions-set-product-version@v2
+        with:
+          checkout: false
+
+      - name: Send deploy-dev event
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
+        with: 
+          token: ${{ secrets.REMOTE_DEPLOY_TOKEN }} 
+          repository: hashicorp/terraform-mcp-server-remote 
+          event-type: deploy-dev 
+          client-payload: {
+              "image_repository": "${{ env.IMAGE_REPOSITORY }}",
+              "image_tag": "${{ steps.version.outputs.product-version }}-${{ env.COMMIT_SHA }}"
+            }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,8 @@ jobs:
           token: ${{ secrets.REMOTE_DEPLOY_TOKEN }} 
           repository: hashicorp/terraform-mcp-server-remote 
           event-type: deploy-dev 
-          client-payload: {
-              "image_repository": "${{ env.IMAGE_REPOSITORY }}",
-              "image_tag": "${{ steps.version.outputs.product-version }}-${{ env.COMMIT_SHA }}"
-            }
+          client-payload: >-
+                {
+                  "image_repository": "${{ env.IMAGE_REPOSITORY }}",
+                  "image_tag": "${{ steps.version.outputs.product-version }}-${{ env.COMMIT_SHA }}"
+                }


### PR DESCRIPTION
## Summary
Adds a deployment workflow that runs after a successful build workflow triggered by a push to main, including PR merges.

The workflow identifies the image built for the exact commit and sends a deploy-dev repository dispatch event to terraform-mcp-server-remote. This PR currently covers deployment to the remote development environment only.

## Scope

The receiving workflow in terraform-mcp-server-remote remains responsible for:

- Waiting for the image tag to become available in the registry before deployment.
- Managing deployment concurrency. Concurrency does not need to be handled in this repository because each merge to main should run its own independent build and produce an immutable image. Since the actual deployment occurs in terraform-mcp-server-remote, that workflow is the appropriate place to queue overlapping deployment requests and prevent older images from being deployed after newer ones.

## Notes

Uses third party action for repository dispatch: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 (v4.0.1). The same action is also used in HashiCorp [Vault workflows](https://github.com/hashicorp/vault/blob/b261d60b6b0b221df8d1ce712dc74726fb516053/.github/workflows/copy-external-contributor-pull-request-ce.yml#L60). Let me know if using the GitHub CLI would be preferred over this third-party action.