### PR TITLE
use build version for Otel service.version instead of hardcoded latest

### DIFF
--- a/pkg/client/metrics.go
+++ b/pkg/client/metrics.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/hashicorp/terraform-mcp-server/version"
 	"github.com/mark3labs/mcp-go/mcp"
 	log "github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel/attribute"
@@ -40,7 +41,7 @@ func DefaultMetricsConfig() MetricsConfig {
 		Endpoint:             "localhost:4318",
 		ExportInterval:       2 * time.Second,
 		ServiceName:          "terraform-mcp-server",
-		ServiceVersion:       "latest",
+		ServiceVersion:       version.GetHumanVersion(),
 		MeterProvider:        nil,
 		Attributes:           []attribute.KeyValue{},
 		EnableRuntimeMetrics: true,


### PR DESCRIPTION
## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

This PR sets service.version from version.GetHumanVersion() instead of the hardcoded "latest".

currently our metrics reports `latest` no matter what build is running. every `mcp_*` series carries `service.version=latest` and the otel entity's version field shows `latest` too. which gives us no way to tie a metric back to a release

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
