### PR TITLE
set service.instance.id and k8s.pod.uid on OTel metrics resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ FEATURES
 * [New Tool] `list_teams` Lists all teams within a given Terraform Cloud organization. Requires `terraform_org_name`. Optionally filter by exact team names (`team_names`), or substring search (`search_query`). Supports pagination.
 * [New Tool] `get_team` Fetches full details for a single team by ID, including members, organization access permissions, and SSO settings. Requires `team_id`. [441](https://github.com/hashicorp/terraform-mcp-server/pull/441)
 
+IMPROVEMENTS
+
+* Set `service.instance.id` on the OTel metrics resource, plus `k8s.pod.uid` when running in K8s, so telemetry from separate instances is no longer attributed to a single entity [448](https://github.com/hashicorp/terraform-mcp-server/pull/448)
+
 # 1.2.0
 
 FEATURES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.2.1
+
+IMPROVEMENTS
+
+* Set `service.instance.id` on the OTel metrics resource, plus `k8s.pod.uid` when running in K8s, so telemetry from separate instances is no longer attributed to a single entity attributed to a single entity [448](https://github.com/hashicorp/terraform-mcp-server/pull/448)
+
 # 1.2.0
 
 FEATURES

--- a/cmd/terraform-mcp-server/main.go
+++ b/cmd/terraform-mcp-server/main.go
@@ -445,10 +445,19 @@ func initMetrics(ctx context.Context, config *client.MetricsConfig, logger *log.
 	}
 	// Create the MeterProvider with a PeriodicReader
 	// The reader flushes metrics to the exporter periodically
-	resourceAttrs := resource.NewSchemaless(
+
+	// without service.instance.id every replica sends the exact same resource and
+	// the backend folds them into one entity. k8s.pod.uid is the separate attribute
+	// that links that entity back to the pod, only added when we're in k8s.
+	resourceOpts := []attribute.KeyValue{
 		attribute.String("service.name", config.ServiceName),
 		attribute.String("service.version", config.ServiceVersion),
-	)
+		attribute.String("service.instance.id", config.ServiceInstanceID),
+	}
+	if config.K8sPodUID != "" {
+		resourceOpts = append(resourceOpts, attribute.String("k8s.pod.uid", config.K8sPodUID))
+	}
+	resourceAttrs := resource.NewSchemaless(resourceOpts...)
 	config.MeterProvider = sdkmetric.NewMeterProvider(
 		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(exporter, sdkmetric.WithInterval(config.ExportInterval))),
 		sdkmetric.WithResource(resourceAttrs),

--- a/cmd/terraform-mcp-server/main.go
+++ b/cmd/terraform-mcp-server/main.go
@@ -448,14 +448,15 @@ func initMetrics(ctx context.Context, config *client.MetricsConfig, logger *log.
 
 	// without service.instance.id every replica sends the exact same resource and
 	// the backend folds them into one entity. k8s.pod.uid is the separate attribute
-	// that links that entity back to the pod, only added when we're in k8s.
+	// that links that entity back to the pod, only set when we're in k8s and the id
+	// was handed to us, so we know it's a real pod uid and not a hostname.
 	resourceOpts := []attribute.KeyValue{
 		attribute.String("service.name", config.ServiceName),
 		attribute.String("service.version", config.ServiceVersion),
 		attribute.String("service.instance.id", config.ServiceInstanceID),
 	}
-	if config.K8sPodUID != "" {
-		resourceOpts = append(resourceOpts, attribute.String("k8s.pod.uid", config.K8sPodUID))
+	if config.InstanceIDIsPodUID {
+		resourceOpts = append(resourceOpts, attribute.String("k8s.pod.uid", config.ServiceInstanceID))
 	}
 	resourceAttrs := resource.NewSchemaless(resourceOpts...)
 	config.MeterProvider = sdkmetric.NewMeterProvider(

--- a/pkg/client/metrics.go
+++ b/pkg/client/metrics.go
@@ -19,6 +19,8 @@ type MetricsConfig struct {
 	ExportInterval        time.Duration            // Controls the frequency of metric flushes
 	ServiceName           string                   // ServiceName identifies the source of the metrics (e.g., "terraform-mcp-server")
 	ServiceVersion        string                   // ServiceVersion helps track metrics across different deployments
+	ServiceInstanceID     string                   // ServiceInstanceID uniquely identifies this running instance, so replicas don't collapse into one entity
+	K8sPodUID             string                   // K8sPodUID links the instance to its Kubernetes pod. Empty when not running in Kubernetes
 	MeterProvider         *sdkmetric.MeterProvider // MeterProvider is the OTel provider used to create instruments
 	Attributes            []attribute.KeyValue     // Attributes are global labels applied to every metric emitted
 	EnableRuntimeMetrics  bool                     // EnableRuntimeMetrics toggles the collection of Go runtime stats (GC, Memory)
@@ -35,6 +37,15 @@ type ClientInfo struct {
 	Description string
 }
 
+// defaultServiceInstanceID falls back to the hostname so stdio and local runs still
+// get a distinct id when nothing is set in the environment.
+func defaultServiceInstanceID() string {
+	if hostname, err := os.Hostname(); err == nil && hostname != "" {
+		return hostname
+	}
+	return "unknown"
+}
+
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
 		Enabled:              false,
@@ -42,6 +53,8 @@ func DefaultMetricsConfig() MetricsConfig {
 		ExportInterval:       2 * time.Second,
 		ServiceName:          "terraform-mcp-server",
 		ServiceVersion:       version.GetHumanVersion(),
+		ServiceInstanceID:    defaultServiceInstanceID(),
+		K8sPodUID:            "",
 		MeterProvider:        nil,
 		Attributes:           []attribute.KeyValue{},
 		EnableRuntimeMetrics: true,
@@ -78,6 +91,20 @@ func LoadMetricsConfigFromEnv(logger *log.Logger) MetricsConfig {
 		logger.Infof("Using env value for OTEL_METRICS_SERVICE_VERSION: %s", serviceVersion)
 	} else {
 		logger.Infof("OTEL_METRICS_SERVICE_VERSION not set in env, using default: %s", config.ServiceVersion)
+	}
+	if instanceID := os.Getenv("OTEL_SERVICE_INSTANCE_ID"); instanceID != "" {
+		config.ServiceInstanceID = instanceID
+		logger.Infof("Using env value for OTEL_SERVICE_INSTANCE_ID: %s", instanceID)
+	} else {
+		logger.Infof("OTEL_SERVICE_INSTANCE_ID not set in env, using default: %s", config.ServiceInstanceID)
+	}
+	// only set in k8s. left empty everywhere else so we're not sticking a
+	// k8s.pod.uid on a process that isn't in a pod.
+	if podUID := os.Getenv("OTEL_K8S_POD_UID"); podUID != "" {
+		config.K8sPodUID = podUID
+		logger.Infof("Using env value for OTEL_K8S_POD_UID: %s", podUID)
+	} else {
+		logger.Infof("OTEL_K8S_POD_UID not set in env, k8s.pod.uid will be omitted")
 	}
 	if enabled := os.Getenv("OTEL_METRICS_ENABLED"); enabled == "true" {
 		config.Enabled = true

--- a/pkg/client/metrics.go
+++ b/pkg/client/metrics.go
@@ -18,6 +18,8 @@ type MetricsConfig struct {
 	ExportInterval        time.Duration            // Controls the frequency of metric flushes
 	ServiceName           string                   // ServiceName identifies the source of the metrics (e.g., "terraform-mcp-server")
 	ServiceVersion        string                   // ServiceVersion helps track metrics across different deployments
+	ServiceInstanceID     string                   // ServiceInstanceID uniquely identifies this running instance, so replicas don't collapse into one entity
+	K8sPodUID             string                   // K8sPodUID links the instance to its Kubernetes pod. Empty when not running in Kubernetes
 	MeterProvider         *sdkmetric.MeterProvider // MeterProvider is the OTel provider used to create instruments
 	Attributes            []attribute.KeyValue     // Attributes are global labels applied to every metric emitted
 	EnableRuntimeMetrics  bool                     // EnableRuntimeMetrics toggles the collection of Go runtime stats (GC, Memory)
@@ -34,6 +36,15 @@ type ClientInfo struct {
 	Description string
 }
 
+// defaultServiceInstanceID falls back to the hostname so stdio and local runs still
+// get a distinct id when nothing is set in the environment.
+func defaultServiceInstanceID() string {
+	if hostname, err := os.Hostname(); err == nil && hostname != "" {
+		return hostname
+	}
+	return "unknown"
+}
+
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
 		Enabled:              false,
@@ -41,6 +52,8 @@ func DefaultMetricsConfig() MetricsConfig {
 		ExportInterval:       2 * time.Second,
 		ServiceName:          "terraform-mcp-server",
 		ServiceVersion:       "latest",
+		ServiceInstanceID:    defaultServiceInstanceID(),
+		K8sPodUID:            "",
 		MeterProvider:        nil,
 		Attributes:           []attribute.KeyValue{},
 		EnableRuntimeMetrics: true,
@@ -77,6 +90,20 @@ func LoadMetricsConfigFromEnv(logger *log.Logger) MetricsConfig {
 		logger.Infof("Using env value for OTEL_METRICS_SERVICE_VERSION: %s", serviceVersion)
 	} else {
 		logger.Infof("OTEL_METRICS_SERVICE_VERSION not set in env, using default: %s", config.ServiceVersion)
+	}
+	if instanceID := os.Getenv("OTEL_SERVICE_INSTANCE_ID"); instanceID != "" {
+		config.ServiceInstanceID = instanceID
+		logger.Infof("Using env value for OTEL_SERVICE_INSTANCE_ID: %s", instanceID)
+	} else {
+		logger.Infof("OTEL_SERVICE_INSTANCE_ID not set in env, using default: %s", config.ServiceInstanceID)
+	}
+	// only set in k8s. left empty everywhere else so we're not sticking a
+	// k8s.pod.uid on a process that isn't in a pod.
+	if podUID := os.Getenv("OTEL_K8S_POD_UID"); podUID != "" {
+		config.K8sPodUID = podUID
+		logger.Infof("Using env value for OTEL_K8S_POD_UID: %s", podUID)
+	} else {
+		logger.Infof("OTEL_K8S_POD_UID not set in env, k8s.pod.uid will be omitted")
 	}
 	if enabled := os.Getenv("OTEL_METRICS_ENABLED"); enabled == "true" {
 		config.Enabled = true

--- a/pkg/client/metrics.go
+++ b/pkg/client/metrics.go
@@ -18,8 +18,8 @@ type MetricsConfig struct {
 	ExportInterval        time.Duration            // Controls the frequency of metric flushes
 	ServiceName           string                   // ServiceName identifies the source of the metrics (e.g., "terraform-mcp-server")
 	ServiceVersion        string                   // ServiceVersion helps track metrics across different deployments
-	ServiceInstanceID     string                   // ServiceInstanceID uniquely identifies this running instance, so replicas don't collapse into one entity
-	K8sPodUID             string                   // K8sPodUID links the instance to its Kubernetes pod. Empty when not running in Kubernetes
+	ServiceInstanceID     string                   // ServiceInstanceID uniquely identifies this replica, so they don't collapse into one entity
+	InstanceIDIsPodUID    bool                     // InstanceIDIsPodUID is true when we're in k8s and the id came from the env, so it's a real pod UID
 	MeterProvider         *sdkmetric.MeterProvider // MeterProvider is the OTel provider used to create instruments
 	Attributes            []attribute.KeyValue     // Attributes are global labels applied to every metric emitted
 	EnableRuntimeMetrics  bool                     // EnableRuntimeMetrics toggles the collection of Go runtime stats (GC, Memory)
@@ -37,12 +37,17 @@ type ClientInfo struct {
 }
 
 // defaultServiceInstanceID falls back to the hostname so stdio and local runs still
-// get a distinct id when nothing is set in the environment.
+// get a distinct id when nothing's set in the env.
 func defaultServiceInstanceID() string {
 	if hostname, err := os.Hostname(); err == nil && hostname != "" {
 		return hostname
 	}
 	return "unknown"
+}
+
+// runningInKubernetes tells us if we're in a pod. kube sets this in every pod.
+func runningInKubernetes() bool {
+	return os.Getenv("KUBERNETES_SERVICE_HOST") != ""
 }
 
 func DefaultMetricsConfig() MetricsConfig {
@@ -53,7 +58,7 @@ func DefaultMetricsConfig() MetricsConfig {
 		ServiceName:          "terraform-mcp-server",
 		ServiceVersion:       "latest",
 		ServiceInstanceID:    defaultServiceInstanceID(),
-		K8sPodUID:            "",
+		InstanceIDIsPodUID:   false,
 		MeterProvider:        nil,
 		Attributes:           []attribute.KeyValue{},
 		EnableRuntimeMetrics: true,
@@ -91,19 +96,14 @@ func LoadMetricsConfigFromEnv(logger *log.Logger) MetricsConfig {
 	} else {
 		logger.Infof("OTEL_METRICS_SERVICE_VERSION not set in env, using default: %s", config.ServiceVersion)
 	}
-	if instanceID := os.Getenv("OTEL_SERVICE_INSTANCE_ID"); instanceID != "" {
+	if instanceID := os.Getenv("OTEL_INSTANCE_ID"); instanceID != "" {
 		config.ServiceInstanceID = instanceID
-		logger.Infof("Using env value for OTEL_SERVICE_INSTANCE_ID: %s", instanceID)
+		// only a real pod uid if we're in a pod and something explicitly handed us
+		// the id. the hostname fallback is a pod name, not a uid.
+		config.InstanceIDIsPodUID = runningInKubernetes()
+		logger.Infof("Using env value for OTEL_INSTANCE_ID: %s", instanceID)
 	} else {
-		logger.Infof("OTEL_SERVICE_INSTANCE_ID not set in env, using default: %s", config.ServiceInstanceID)
-	}
-	// only set in k8s. left empty everywhere else so we're not sticking a
-	// k8s.pod.uid on a process that isn't in a pod.
-	if podUID := os.Getenv("OTEL_K8S_POD_UID"); podUID != "" {
-		config.K8sPodUID = podUID
-		logger.Infof("Using env value for OTEL_K8S_POD_UID: %s", podUID)
-	} else {
-		logger.Infof("OTEL_K8S_POD_UID not set in env, k8s.pod.uid will be omitted")
+		logger.Infof("OTEL_INSTANCE_ID not set in env, using default: %s", config.ServiceInstanceID)
 	}
 	if enabled := os.Getenv("OTEL_METRICS_ENABLED"); enabled == "true" {
 		config.Enabled = true

--- a/pkg/client/metrics.go
+++ b/pkg/client/metrics.go
@@ -19,8 +19,8 @@ type MetricsConfig struct {
 	ExportInterval        time.Duration            // Controls the frequency of metric flushes
 	ServiceName           string                   // ServiceName identifies the source of the metrics (e.g., "terraform-mcp-server")
 	ServiceVersion        string                   // ServiceVersion helps track metrics across different deployments
-	ServiceInstanceID     string                   // ServiceInstanceID uniquely identifies this running instance, so replicas don't collapse into one entity
-	K8sPodUID             string                   // K8sPodUID links the instance to its Kubernetes pod. Empty when not running in Kubernetes
+	ServiceInstanceID     string                   // ServiceInstanceID uniquely identifies this replica, so they don't collapse into one entity
+	InstanceIDIsPodUID    bool                     // InstanceIDIsPodUID is true when we're in k8s and the id came from the env, so it's a real pod UID
 	MeterProvider         *sdkmetric.MeterProvider // MeterProvider is the OTel provider used to create instruments
 	Attributes            []attribute.KeyValue     // Attributes are global labels applied to every metric emitted
 	EnableRuntimeMetrics  bool                     // EnableRuntimeMetrics toggles the collection of Go runtime stats (GC, Memory)
@@ -38,12 +38,17 @@ type ClientInfo struct {
 }
 
 // defaultServiceInstanceID falls back to the hostname so stdio and local runs still
-// get a distinct id when nothing is set in the environment.
+// get a distinct id when nothing's set in the env.
 func defaultServiceInstanceID() string {
 	if hostname, err := os.Hostname(); err == nil && hostname != "" {
 		return hostname
 	}
 	return "unknown"
+}
+
+// runningInKubernetes tells us if we're in a pod. kube sets this in every pod.
+func runningInKubernetes() bool {
+	return os.Getenv("KUBERNETES_SERVICE_HOST") != ""
 }
 
 func DefaultMetricsConfig() MetricsConfig {
@@ -54,7 +59,7 @@ func DefaultMetricsConfig() MetricsConfig {
 		ServiceName:          "terraform-mcp-server",
 		ServiceVersion:       version.GetHumanVersion(),
 		ServiceInstanceID:    defaultServiceInstanceID(),
-		K8sPodUID:            "",
+		InstanceIDIsPodUID:   false,
 		MeterProvider:        nil,
 		Attributes:           []attribute.KeyValue{},
 		EnableRuntimeMetrics: true,
@@ -92,19 +97,14 @@ func LoadMetricsConfigFromEnv(logger *log.Logger) MetricsConfig {
 	} else {
 		logger.Infof("OTEL_METRICS_SERVICE_VERSION not set in env, using default: %s", config.ServiceVersion)
 	}
-	if instanceID := os.Getenv("OTEL_SERVICE_INSTANCE_ID"); instanceID != "" {
+	if instanceID := os.Getenv("OTEL_INSTANCE_ID"); instanceID != "" {
 		config.ServiceInstanceID = instanceID
-		logger.Infof("Using env value for OTEL_SERVICE_INSTANCE_ID: %s", instanceID)
+		// only a real pod uid if we're in a pod and something explicitly handed us
+		// the id. the hostname fallback is a pod name, not a uid.
+		config.InstanceIDIsPodUID = runningInKubernetes()
+		logger.Infof("Using env value for OTEL_INSTANCE_ID: %s", instanceID)
 	} else {
-		logger.Infof("OTEL_SERVICE_INSTANCE_ID not set in env, using default: %s", config.ServiceInstanceID)
-	}
-	// only set in k8s. left empty everywhere else so we're not sticking a
-	// k8s.pod.uid on a process that isn't in a pod.
-	if podUID := os.Getenv("OTEL_K8S_POD_UID"); podUID != "" {
-		config.K8sPodUID = podUID
-		logger.Infof("Using env value for OTEL_K8S_POD_UID: %s", podUID)
-	} else {
-		logger.Infof("OTEL_K8S_POD_UID not set in env, k8s.pod.uid will be omitted")
+		logger.Infof("OTEL_INSTANCE_ID not set in env, using default: %s", config.ServiceInstanceID)
 	}
 	if enabled := os.Getenv("OTEL_METRICS_ENABLED"); enabled == "true" {
 		config.Enabled = true


### PR DESCRIPTION
## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

This PR adds `service.instance.id `to the OTel metrics resource, and `k8s.pod.uid` when we're
running in k8s. 

right now `resource.NewSchemaless` only sets `service.name` and `service.version`, so every
replica sends an identical resource and Instana collapses them into a single entity.
in prod all 6 pods show up as one entity id. we can't tell replicas apart, and the entity never links to a k8s pod,
which is why none of the `kubernetes.*` tags are available when attempting to build dashboard widgets.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
