### PR TITLE
Fix failing HCPT tests

### DIFF
--- a/.github/workflows/hcpt_test.yml
+++ b/.github/workflows/hcpt_test.yml
@@ -28,6 +28,8 @@ jobs:
           make build
 
       - name: Start server
+        env:
+          ENABLE_TF_OPERATIONS: true
         run: |
           nohup ./bin/terraform-mcp-server streamable-http --transport-host 0.0.0.0 --transport-port 8080 2>&1 &
 


### PR DESCRIPTION
This PR contains a fix to the failing HCPT test workflow. It sets `ENABLED_TF_OPERATIONS` to true when starting the server so tests containing tools gated behind that flag does not fail.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
