### PR TITLE
Add `grant_team_access` tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ FIXES
 
 * `get_apply_logs` now checks the apply status before attempting to stream logs. If the apply is not yet in a terminal state (`finished`, `errored`, `canceled`), the tool returns an informative message instead of timing out.
 * [New Tool] `grant_team_access` Grants a team access to a workspace or project by ID. Requires `team_id`, `access_level`, and either `workspace_id` or `project_id` (mutually exclusive). Valid access levels for workspaces: `admin`, `read`, `write`, `plan`, `custom`. Valid access levels for projects: `admin`, `read`, `write`, `maintain`, `custom`.
-* [New Tool] `create_team` Creates a new team in a Terraform Cloud/Enterprise organization. Requires `terraform_org_name` and `team_name`; optional `visibility` ("secret" or "organization"). [427](https://github.com/hashicorp/terraform-mcp-server/pull/427)
 
 # 1.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,6 @@ FEATURES
 IMPROVEMENTS
 
 * Extend the existing HTTP-layer `OrganizationAllowlistMiddleware` with a new MCP tool-layer `OrganizationAllowlistToolMiddleware` that rejects tool calls whose `terraform_org_name` argument is not in the allowlist configured via `MCP_ORGANIZATION_ALLOWLIST`. [430](https://github.com/hashicorp/terraform-mcp-server/pull/430)
-
-# 1.1.1
-
-IMPROVEMENTS
-
 * Add `version` field to the `/health` endpoint response to make it easier to identify which version is deployed at a glance. [410](https://github.com/hashicorp/terraform-mcp-server/pull/410)
 * Add optional Instana instrumentation (metrics and HTTP request tracing) for the streamable-http server, gated behind `INSTANA_ENABLED` [411](https://github.com/hashicorp/terraform-mcp-server/pull/411)
 * Add `TF_MCP_SHARED_SECRET` to send an `X-Tf-Mcp-Secret` header on requests to HCP Terraform / TFE, allowing the backend to identify requests from a trusted MCP deployment [392](https://github.com/hashicorp/terraform-mcp-server/pull/392)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ FEATURES
 * [New Tool] `get_project` Fetches detailed information about a Terraform project by its ID. Requires `project_id`.
 * [New Tool] `create_team` Creates a new team in a Terraform Cloud/Enterprise organization. Requires `terraform_org_name` and `team_name`; optional `visibility` ("secret" or "organization"). [427](https://github.com/hashicorp/terraform-mcp-server/pull/427)
 * [New Tool] `add_team_member` Adds a single member to a Terraform Cloud/Enterprise team. Requires `team_id`; accepts either `username` (accepted-invite users only) or `organization_membership_id` (works for pending and accepted invites). Exactly one must be provided.
+* [New Tool] `grant_team_access` Grants a team access to a workspace or project by ID. Requires `team_id`, `access_level`, and either `workspace_id` or `project_id` (mutually exclusive). Valid access levels for workspaces: `admin`, `read`, `write`, `plan`, `custom`. Valid access levels for projects: `admin`, `read`, `write`, `maintain`, `custom`.
 
 FIXES
 
 * `get_apply_logs` now checks the apply status before attempting to stream logs. If the apply is not yet in a terminal state (`finished`, `errored`, `canceled`), the tool returns an informative message instead of timing out.
-* [New Tool] `grant_team_access` Grants a team access to a workspace or project by ID. Requires `team_id`, `access_level`, and either `workspace_id` or `project_id` (mutually exclusive). Valid access levels for workspaces: `admin`, `read`, `write`, `plan`, `custom`. Valid access levels for projects: `admin`, `read`, `write`, `maintain`, `custom`.
 
 # 1.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ FEATURES
 FIXES
 
 * `get_apply_logs` now checks the apply status before attempting to stream logs. If the apply is not yet in a terminal state (`finished`, `errored`, `canceled`), the tool returns an informative message instead of timing out.
+* [New Tool] `grant_team_access` Grants a team access to a workspace or project by ID. Requires `team_id`, `access_level`, and either `workspace_id` or `project_id` (mutually exclusive). Valid access levels for workspaces: `admin`, `read`, `write`, `plan`, `custom`. Valid access levels for projects: `admin`, `read`, `write`, `maintain`, `custom`.
 
 # 1.2.0
 
@@ -26,6 +27,11 @@ FEATURES
 IMPROVEMENTS
 
 * Extend the existing HTTP-layer `OrganizationAllowlistMiddleware` with a new MCP tool-layer `OrganizationAllowlistToolMiddleware` that rejects tool calls whose `terraform_org_name` argument is not in the allowlist configured via `MCP_ORGANIZATION_ALLOWLIST`. [430](https://github.com/hashicorp/terraform-mcp-server/pull/430)
+
+# 1.1.1
+
+IMPROVEMENTS
+
 * Add `version` field to the `/health` endpoint response to make it easier to identify which version is deployed at a glance. [410](https://github.com/hashicorp/terraform-mcp-server/pull/410)
 * Add optional Instana instrumentation (metrics and HTTP request tracing) for the streamable-http server, gated behind `INSTANA_ENABLED` [411](https://github.com/hashicorp/terraform-mcp-server/pull/411)
 * Add `TF_MCP_SHARED_SECRET` to send an `X-Tf-Mcp-Secret` header on requests to HCP Terraform / TFE, allowing the backend to identify requests from a trusted MCP deployment [392](https://github.com/hashicorp/terraform-mcp-server/pull/392)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ FIXES
 
 * `get_apply_logs` now checks the apply status before attempting to stream logs. If the apply is not yet in a terminal state (`finished`, `errored`, `canceled`), the tool returns an informative message instead of timing out.
 * [New Tool] `grant_team_access` Grants a team access to a workspace or project by ID. Requires `team_id`, `access_level`, and either `workspace_id` or `project_id` (mutually exclusive). Valid access levels for workspaces: `admin`, `read`, `write`, `plan`, `custom`. Valid access levels for projects: `admin`, `read`, `write`, `maintain`, `custom`.
+* [New Tool] `create_team` Creates a new team in a Terraform Cloud/Enterprise organization. Requires `terraform_org_name` and `team_name`; optional `visibility` ("secret" or "organization"). [427](https://github.com/hashicorp/terraform-mcp-server/pull/427)
 
 # 1.2.0
 

--- a/pkg/tools/dynamic_tool.go
+++ b/pkg/tools/dynamic_tool.go
@@ -137,6 +137,11 @@ func (r *DynamicToolRegistry) registerTFETools() {
 		r.mcpServer.AddTool(tool.Tool, tool.Handler)
 	}
 
+	if toolsets.IsToolEnabled("grant_team_access", r.enabledToolsets) {
+		tool := r.createDynamicTFETool("grant_team_access", tfeTools.GrantTeamAccess)
+		r.mcpServer.AddTool(tool.Tool, tool.Handler)
+	}
+
 	// Terraform toolset - Workspace management tools
 	if toolsets.IsToolEnabled("list_workspaces", r.enabledToolsets) {
 		tool := r.createDynamicTFETool("list_workspaces", tfeTools.ListWorkspaces)
@@ -375,13 +380,6 @@ func (r *DynamicToolRegistry) registerTFETools() {
 		tool := r.createDynamicTFETool("get_run_comments", tfeTools.GetRunComments)
 		r.mcpServer.AddTool(tool.Tool, tool.Handler)
 	}
-
-	// Terraform Toolset - Teams
-	if toolsets.IsToolEnabled("grant_team_access", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("grant_team_access", tfeTools.GrantTeamAccess)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
 	r.tfeToolsRegistered = true
 }
 

--- a/pkg/tools/dynamic_tool.go
+++ b/pkg/tools/dynamic_tool.go
@@ -375,6 +375,13 @@ func (r *DynamicToolRegistry) registerTFETools() {
 		tool := r.createDynamicTFETool("get_run_comments", tfeTools.GetRunComments)
 		r.mcpServer.AddTool(tool.Tool, tool.Handler)
 	}
+
+	// Terraform Access Toolset - Access Levels
+	if toolsets.IsToolEnabled("grant_team_access", r.enabledToolsets) {
+		tool := r.createDynamicTFETool("grant_team_access", tfeTools.GrantTeamAccess)
+		r.mcpServer.AddTool(tool.Tool, tool.Handler)
+	}
+
 	r.tfeToolsRegistered = true
 }
 

--- a/pkg/tools/dynamic_tool.go
+++ b/pkg/tools/dynamic_tool.go
@@ -191,6 +191,12 @@ func (r *DynamicToolRegistry) registerTFETools() {
 		r.mcpServer.AddTool(tool.Tool, tool.Handler)
 	}
 
+	// Only register grant_team_access if TF operations are enabled AND toolset is enabled
+	if isTerraformOperationsEnabled() && toolsets.IsToolEnabled("grant_team_access", r.enabledToolsets) {
+		tool := r.createDynamicTFETool("grant_team_access", tfeTools.GrantTeamAccess)
+		r.mcpServer.AddTool(tool.Tool, tool.Handler)
+	}
+
 	// Registry-private toolset - Private provider tools
 	if toolsets.IsToolEnabled("search_private_providers", r.enabledToolsets) {
 		tool := r.createDynamicTFETool("search_private_providers", tfeTools.SearchPrivateProviders)
@@ -373,12 +379,6 @@ func (r *DynamicToolRegistry) registerTFETools() {
 	// Terraform Toolset - Comments
 	if toolsets.IsToolEnabled("get_run_comments", r.enabledToolsets) {
 		tool := r.createDynamicTFETool("get_run_comments", tfeTools.GetRunComments)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	// Terraform Access Toolset - Access Levels
-	if toolsets.IsToolEnabled("grant_team_access", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("grant_team_access", tfeTools.GrantTeamAccess)
 		r.mcpServer.AddTool(tool.Tool, tool.Handler)
 	}
 

--- a/pkg/tools/dynamic_tool.go
+++ b/pkg/tools/dynamic_tool.go
@@ -191,12 +191,6 @@ func (r *DynamicToolRegistry) registerTFETools() {
 		r.mcpServer.AddTool(tool.Tool, tool.Handler)
 	}
 
-	// Only register grant_team_access if TF operations are enabled AND toolset is enabled
-	if isTerraformOperationsEnabled() && toolsets.IsToolEnabled("grant_team_access", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("grant_team_access", tfeTools.GrantTeamAccess)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
 	// Registry-private toolset - Private provider tools
 	if toolsets.IsToolEnabled("search_private_providers", r.enabledToolsets) {
 		tool := r.createDynamicTFETool("search_private_providers", tfeTools.SearchPrivateProviders)
@@ -379,6 +373,12 @@ func (r *DynamicToolRegistry) registerTFETools() {
 	// Terraform Toolset - Comments
 	if toolsets.IsToolEnabled("get_run_comments", r.enabledToolsets) {
 		tool := r.createDynamicTFETool("get_run_comments", tfeTools.GetRunComments)
+		r.mcpServer.AddTool(tool.Tool, tool.Handler)
+	}
+
+	// Terraform Toolset - Teams
+	if toolsets.IsToolEnabled("grant_team_access", r.enabledToolsets) {
+		tool := r.createDynamicTFETool("grant_team_access", tfeTools.GrantTeamAccess)
 		r.mcpServer.AddTool(tool.Tool, tool.Handler)
 	}
 

--- a/pkg/tools/tfe/grant_team_access.go
+++ b/pkg/tools/tfe/grant_team_access.go
@@ -35,8 +35,8 @@ func GrantTeamAccess(logger *log.Logger) server.ServerTool {
 			mcp.WithString("access_level",
 				mcp.Required(),
 				mcp.Description(`The permission level to grant the team.
-				For workspace access (workspace_id): "read" (view only), "plan" (can queue plans), "write" (apply runs), "admin" (full control), "custom" (fine-grained permissions).
-				For project access (project_id): "read", "write", "maintain" (manage workspaces), "admin" (full control), "custom". Note: "plan" is only valid for workspaces; "maintain" is only valid for projects.`),
+				For workspace access (workspace_id): "read" (view only), "plan" (can queue plans), "write" (apply runs), "admin" (full control).
+				For project access (project_id): "read", "write", "maintain" (manage workspaces), "admin" (full control). Note: "plan" is only valid for workspaces; "maintain" is only valid for projects.`),
 			),
 			mcp.WithString("workspace_id",
 				mcp.Description(`The ID of the workspace to grant the team access to. Workspace IDs begin with 'ws-' (e.g., 'ws-abc123def456'). Mutually exclusive with project_id — provide one or the other, not both.`),
@@ -51,9 +51,9 @@ func GrantTeamAccess(logger *log.Logger) server.ServerTool {
 	}
 }
 
-var validTeamAccessLevels = []string{"admin", "read", "write", "plan", "custom"}
+var validTeamAccessLevels = []string{"admin", "read", "write", "plan"}
 var validTeamAccessLevelsStr = strings.Join(validTeamAccessLevels, ", ")
-var validTeamProjectAccessLevels = []string{"admin", "read", "write", "maintain", "custom"}
+var validTeamProjectAccessLevels = []string{"admin", "read", "write", "maintain"}
 var validTeamProjectAccessLevelsStr = strings.Join(validTeamProjectAccessLevels, ", ")
 
 // grantTeamAccessHandler handles tool logics and functionality

--- a/pkg/tools/tfe/grant_team_access.go
+++ b/pkg/tools/tfe/grant_team_access.go
@@ -70,7 +70,7 @@ func grantTeamAccessHandler(ctx context.Context, request mcp.CallToolRequest, lo
 	workspaceID := request.GetString("workspace_id", "")
 	projectID := request.GetString("project_id", "")
 
-	teamID = strings.TrimLeft(strings.TrimSpace(teamID), "/")
+	teamID = strings.TrimSpace(teamID)
 	workspaceID = strings.TrimSpace(workspaceID)
 	projectID = strings.TrimSpace(projectID)
 	accessLevel = strings.ToLower(strings.TrimSpace(accessLevel))

--- a/pkg/tools/tfe/grant_team_access.go
+++ b/pkg/tools/tfe/grant_team_access.go
@@ -108,7 +108,7 @@ func grantTeamAccessHandler(ctx context.Context, request mcp.CallToolRequest, lo
 			Access:      string(ta.Access),
 		})
 		if err != nil {
-			return ToolError(logger, "failed to serialize summary", err)
+			return ToolError(logger, "Failed to serialize summary", err)
 		}
 		return mcp.NewToolResultText(string(summaryJSON)), nil
 	}
@@ -133,7 +133,7 @@ func grantTeamAccessHandler(ctx context.Context, request mcp.CallToolRequest, lo
 		Access:    string(tpa.Access),
 	})
 	if err != nil {
-		return ToolError(logger, "failed to serialize summary", err)
+		return ToolError(logger, "Failed to serialize summary", err)
 	}
 	return mcp.NewToolResultText(string(summaryJSON)), nil
 }

--- a/pkg/tools/tfe/grant_team_access.go
+++ b/pkg/tools/tfe/grant_team_access.go
@@ -97,14 +97,9 @@ func grantTeamAccessHandler(ctx context.Context, request mcp.CallToolRequest, lo
 			return ToolErrorf(logger, "Invalid Team access level %q - must be one of: %s", accessLevel, validTeamAccessLevelsStr)
 		}
 
-		workspace, err := tfeClient.Workspaces.ReadByID(ctx, workspaceID)
-		if err != nil {
-			return ToolErrorf(logger, "Workspace %q not found: %v", workspaceID, err)
-		}
-
 		ta, err := tfeClient.TeamAccess.Add(ctx, tfe.TeamAccessAddOptions{
 			Access:    tfe.Access(tfe.AccessType(accessLevel)),
-			Workspace: workspace,
+			Workspace: &tfe.Workspace{ID: workspaceID},
 			Team:      &tfe.Team{ID: teamID},
 		})
 		if err != nil {
@@ -128,14 +123,9 @@ func grantTeamAccessHandler(ctx context.Context, request mcp.CallToolRequest, lo
 		return ToolErrorf(logger, "Invalid Team Project access level %q - must be one of: %s", accessLevel, validTeamProjectAccessLevelsStr)
 	}
 
-	project, err := tfeClient.Projects.Read(ctx, projectID)
-	if err != nil {
-		return ToolErrorf(logger, "Project %q not found: %v", projectID, err)
-	}
-
 	tpa, err := tfeClient.TeamProjectAccess.Add(ctx, tfe.TeamProjectAccessAddOptions{
 		Access:  tfe.TeamProjectAccessType(accessLevel),
-		Project: project,
+		Project: &tfe.Project{ID: projectID},
 		Team:    &tfe.Team{ID: teamID},
 	})
 	if err != nil {

--- a/pkg/tools/tfe/grant_team_access.go
+++ b/pkg/tools/tfe/grant_team_access.go
@@ -21,24 +21,28 @@ func GrantTeamAccess(logger *log.Logger) server.ServerTool {
 	return server.ServerTool{
 		Tool: mcp.NewTool(
 			"grant_team_access",
-			mcp.WithDescription("Grant a team access to a workspace or project"),
-			mcp.WithTitleAnnotation("Grant team access"),
+			mcp.WithDescription(`Grants a team permission to access a workspace or a project in Terraform Cloud/Enterprise.
+			Provide either workspace_id (for workspace-level access) or project_id (for project-level access) — not both.
+			Returns the created access grant including its ID, team ID, target resource ID, and access level.`),
+			mcp.WithTitleAnnotation("Grant team access to a workspace or project"),
 			mcp.WithOpenWorldHintAnnotation(true),
 			mcp.WithReadOnlyHintAnnotation(false),
 			mcp.WithDestructiveHintAnnotation(false),
 			mcp.WithString("team_id",
 				mcp.Required(),
-				mcp.Description(`The ID of the Terraform Cloud/Enterprise team to grant access to (e.g., 'team-abc123def456')`),
+				mcp.Description(`The ID of the team to grant access. Team IDs begin with 'team-' (e.g., 'team-abc123def456').`),
 			),
 			mcp.WithString("access_level",
 				mcp.Required(),
-				mcp.Description(`The access level to grant access for (e.g. "admin", "read", "write", "plan", "custom")`),
+				mcp.Description(`The permission level to grant the team.
+				For workspace access (workspace_id): "read" (view only), "plan" (can queue plans), "write" (apply runs), "admin" (full control), "custom" (fine-grained permissions).
+				For project access (project_id): "read", "write", "maintain" (manage workspaces), "admin" (full control), "custom". Note: "plan" is only valid for workspaces; "maintain" is only valid for projects.`),
 			),
 			mcp.WithString("workspace_id",
-				mcp.Description(`The ID of the Terraform Cloud/Enterprise workspace to grant access to (e.g., "ws-abc123def456")`),
+				mcp.Description(`The ID of the workspace to grant the team access to. Workspace IDs begin with 'ws-' (e.g., 'ws-abc123def456'). Mutually exclusive with project_id — provide one or the other, not both.`),
 			),
 			mcp.WithString("project_id",
-				mcp.Description(`The ID of the Terraform Cloud/Enterprise project to grant access to (e.g., "prj-abc123def456")`),
+				mcp.Description(`The ID of the project to grant the team access to. Project IDs begin with 'prj-' (e.g., 'prj-abc123def456'). Mutually exclusive with workspace_id — provide one or the other, not both.`),
 			),
 		),
 		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -71,12 +75,10 @@ func grantTeamAccessHandler(ctx context.Context, request mcp.CallToolRequest, lo
 	projectID = strings.TrimSpace(projectID)
 	accessLevel = strings.ToLower(strings.TrimSpace(accessLevel))
 
-	// At least one must be provided, not neither
 	if workspaceID == "" && projectID == "" {
 		return ToolError(logger, "One of workspace_id or project_id must be provided", nil)
 	}
 
-	// Only one must be provided, not both
 	if workspaceID != "" && projectID != "" {
 		return ToolError(logger, "Only one of workspace_id or project_id may be provided, not both", nil)
 	}
@@ -137,7 +139,7 @@ func grantTeamAccessHandler(ctx context.Context, request mcp.CallToolRequest, lo
 		Team:    &tfe.Team{ID: teamID},
 	})
 	if err != nil {
-		return ToolErrorf(logger, "Failed to grant team project access to project %q: %v", workspaceID, err)
+		return ToolErrorf(logger, "Failed to grant team project access to project %q: %v", projectID, err)
 	}
 
 	summaryJSON, err := json.Marshal(TeamProjectAccessSummary{

--- a/pkg/tools/tfe/grant_team_access.go
+++ b/pkg/tools/tfe/grant_team_access.go
@@ -58,7 +58,6 @@ var validTeamProjectAccessLevelsStr = strings.Join(validTeamProjectAccessLevels,
 
 // grantTeamAccessHandler handles tool logics and functionality
 func grantTeamAccessHandler(ctx context.Context, request mcp.CallToolRequest, logger *log.Logger) (*mcp.CallToolResult, error) {
-
 	teamID, err := request.RequireString("team_id")
 	if err != nil {
 		return ToolError(logger, "Missing required input: team_id", err)
@@ -67,12 +66,9 @@ func grantTeamAccessHandler(ctx context.Context, request mcp.CallToolRequest, lo
 	if err != nil {
 		return ToolError(logger, "Missing required input: access_level", err)
 	}
-	workspaceID := request.GetString("workspace_id", "")
-	projectID := request.GetString("project_id", "")
-
+	workspaceID := GetTrimmedString(request, "workspace_id", "")
+	projectID := GetTrimmedString(request, "project_id", "")
 	teamID = strings.TrimSpace(teamID)
-	workspaceID = strings.TrimSpace(workspaceID)
-	projectID = strings.TrimSpace(projectID)
 	accessLevel = strings.ToLower(strings.TrimSpace(accessLevel))
 
 	if workspaceID == "" && projectID == "" {
@@ -92,7 +88,6 @@ func grantTeamAccessHandler(ctx context.Context, request mcp.CallToolRequest, lo
 	}
 
 	if workspaceID != "" {
-
 		if !slices.Contains(validTeamAccessLevels, accessLevel) {
 			return ToolErrorf(logger, "Invalid Team access level %q - must be one of: %s", accessLevel, validTeamAccessLevelsStr)
 		}
@@ -115,7 +110,6 @@ func grantTeamAccessHandler(ctx context.Context, request mcp.CallToolRequest, lo
 		if err != nil {
 			return ToolError(logger, "failed to serialize summary", err)
 		}
-
 		return mcp.NewToolResultText(string(summaryJSON)), nil
 	}
 
@@ -141,7 +135,6 @@ func grantTeamAccessHandler(ctx context.Context, request mcp.CallToolRequest, lo
 	if err != nil {
 		return ToolError(logger, "failed to serialize summary", err)
 	}
-
 	return mcp.NewToolResultText(string(summaryJSON)), nil
 }
 

--- a/pkg/tools/tfe/grant_team_access.go
+++ b/pkg/tools/tfe/grant_team_access.go
@@ -1,0 +1,170 @@
+// Copyright IBM Corp. 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"slices"
+	"strings"
+
+	"github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-mcp-server/pkg/client"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	log "github.com/sirupsen/logrus"
+)
+
+// GrantTeamAccess creates a tool to grant team access to a given workspace or project.
+func GrantTeamAccess(logger *log.Logger) server.ServerTool {
+	return server.ServerTool{
+		Tool: mcp.NewTool(
+			"grant_team_access",
+			mcp.WithDescription("Grant a team access to a workspace or project"),
+			mcp.WithTitleAnnotation("Grant team access"),
+			mcp.WithOpenWorldHintAnnotation(true),
+			mcp.WithReadOnlyHintAnnotation(false),
+			mcp.WithDestructiveHintAnnotation(false),
+			mcp.WithString("team_id",
+				mcp.Required(),
+				mcp.Description(`The ID of the Terraform Cloud/Enterprise team to grant access to (e.g., 'team-abc123def456')`),
+			),
+			mcp.WithString("access_level",
+				mcp.Required(),
+				mcp.Description(`The access level to grant access for (e.g. "admin", "read", "write", "plan", "custom")`),
+			),
+			mcp.WithString("workspace_id",
+				mcp.Description(`The ID of the Terraform Cloud/Enterprise workspace to grant access to (e.g., "ws-abc123def456")`),
+			),
+			mcp.WithString("project_id",
+				mcp.Description(`The ID of the Terraform Cloud/Enterprise project to grant access to (e.g., "prj-abc123def456")`),
+			),
+		),
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return grantTeamAccessHandler(ctx, request, logger)
+		},
+	}
+}
+
+var validTeamAccessLevels = []string{"admin", "read", "write", "plan", "custom"}
+var validTeamAccessLevelsStr = strings.Join(validTeamAccessLevels, ", ")
+var validTeamProjectAccessLevels = []string{"admin", "read", "write", "maintain", "custom"}
+var validTeamProjectAccessLevelsStr = strings.Join(validTeamProjectAccessLevels, ", ")
+
+// grantTeamAccessHandler handles tool logics and functionality
+func grantTeamAccessHandler(ctx context.Context, request mcp.CallToolRequest, logger *log.Logger) (*mcp.CallToolResult, error) {
+
+	teamID, err := request.RequireString("team_id")
+	if err != nil {
+		return ToolError(logger, "Missing required input: team_id", err)
+	}
+	accessLevel, err := request.RequireString("access_level")
+	if err != nil {
+		return ToolError(logger, "Missing required input: access_level", err)
+	}
+	workspaceID := request.GetString("workspace_id", "")
+	projectID := request.GetString("project_id", "")
+
+	teamID = strings.TrimLeft(strings.TrimSpace(teamID), "/")
+	workspaceID = strings.TrimSpace(workspaceID)
+	projectID = strings.TrimSpace(projectID)
+	accessLevel = strings.ToLower(strings.TrimSpace(accessLevel))
+
+	// At least one must be provided, not neither
+	if workspaceID == "" && projectID == "" {
+		return ToolError(logger, "One of workspace_id or project_id must be provided", nil)
+	}
+
+	// Only one must be provided, not both
+	if workspaceID != "" && projectID != "" {
+		return ToolError(logger, "Only one of workspace_id or project_id may be provided, not both", nil)
+	}
+
+	tfeClient, err := client.GetTfeClientFromContext(ctx, logger)
+	if err != nil {
+		return ToolError(logger, "Failed to get Terraform client", err)
+	}
+	if tfeClient == nil {
+		return ToolError(logger, "Failed to get Terraform client - ensure TFE_TOKEN and TFE_ADDRESS are configured", nil)
+	}
+
+	if workspaceID != "" {
+
+		if !slices.Contains(validTeamAccessLevels, accessLevel) {
+			return ToolErrorf(logger, "Invalid Team access level %q - must be one of: %s", accessLevel, validTeamAccessLevelsStr)
+		}
+
+		workspace, err := tfeClient.Workspaces.ReadByID(ctx, workspaceID)
+		if err != nil {
+			return ToolErrorf(logger, "Workspace %q not found: %v", workspaceID, err)
+		}
+
+		ta, err := tfeClient.TeamAccess.Add(ctx, tfe.TeamAccessAddOptions{
+			Access:    tfe.Access(tfe.AccessType(accessLevel)),
+			Workspace: workspace,
+			Team:      &tfe.Team{ID: teamID},
+		})
+		if err != nil {
+			return ToolErrorf(logger, "Failed to grant team access to workspace %q: %v", workspaceID, err)
+		}
+
+		summaryJSON, err := json.Marshal(TeamAccessSummary{
+			ID:          ta.ID,
+			TeamID:      ta.Team.ID,
+			WorkspaceID: ta.Workspace.ID,
+			Access:      string(ta.Access),
+		})
+		if err != nil {
+			return ToolError(logger, "failed to serialize summary", err)
+		}
+
+		return mcp.NewToolResultText(string(summaryJSON)), nil
+	}
+
+	if !slices.Contains(validTeamProjectAccessLevels, accessLevel) {
+		return ToolErrorf(logger, "Invalid Team Project access level %q - must be one of: %s", accessLevel, validTeamProjectAccessLevelsStr)
+	}
+
+	project, err := tfeClient.Projects.Read(ctx, projectID)
+	if err != nil {
+		return ToolErrorf(logger, "Project %q not found: %v", projectID, err)
+	}
+
+	tpa, err := tfeClient.TeamProjectAccess.Add(ctx, tfe.TeamProjectAccessAddOptions{
+		Access:  tfe.TeamProjectAccessType(accessLevel),
+		Project: project,
+		Team:    &tfe.Team{ID: teamID},
+	})
+	if err != nil {
+		return ToolErrorf(logger, "Failed to grant team project access to project %q: %v", workspaceID, err)
+	}
+
+	summaryJSON, err := json.Marshal(TeamProjectAccessSummary{
+		ID:        tpa.ID,
+		TeamID:    tpa.Team.ID,
+		ProjectID: tpa.Project.ID,
+		Access:    string(tpa.Access),
+	})
+	if err != nil {
+		return ToolError(logger, "failed to serialize summary", err)
+	}
+
+	return mcp.NewToolResultText(string(summaryJSON)), nil
+}
+
+// TeamAccessSummary is the response summary for a granted workspace team access
+type TeamAccessSummary struct {
+	ID          string `json:"id"`
+	TeamID      string `json:"team_id"`
+	WorkspaceID string `json:"workspace_id"`
+	Access      string `json:"access"`
+}
+
+// TeamProjectAccessSummary is the response summary for a granted project team access
+type TeamProjectAccessSummary struct {
+	ID        string `json:"id"`
+	TeamID    string `json:"team_id"`
+	ProjectID string `json:"project_id"`
+	Access    string `json:"access"`
+}

--- a/pkg/tools/tfe/grant_team_access_test.go
+++ b/pkg/tools/tfe/grant_team_access_test.go
@@ -70,33 +70,3 @@ func TestGrantTeamAccessHandler_InputValidation(t *testing.T) {
 		assert.Contains(t, err.Error(), "missing required parameter")
 	})
 }
-
-func TestGrantTeamAccessHandler_AccessLevelValidation(t *testing.T) {
-	t.Run("valid workspace access levels", func(t *testing.T) {
-		validLevels := []string{"admin", "read", "write", "plan", "custom"}
-		for _, level := range validLevels {
-			found := false
-			for _, v := range validTeamAccessLevels {
-				if v == level {
-					found = true
-					break
-				}
-			}
-			assert.True(t, found, "expected %q to be a valid workspace access level", level)
-		}
-	})
-
-	t.Run("valid project access levels", func(t *testing.T) {
-		validLevels := []string{"admin", "read", "write", "maintain", "custom"}
-		for _, level := range validLevels {
-			found := false
-			for _, v := range validTeamProjectAccessLevels {
-				if v == level {
-					found = true
-					break
-				}
-			}
-			assert.True(t, found, "expected %q to be a valid project access level", level)
-		}
-	})
-}

--- a/pkg/tools/tfe/grant_team_access_test.go
+++ b/pkg/tools/tfe/grant_team_access_test.go
@@ -99,15 +99,4 @@ func TestGrantTeamAccessHandler_AccessLevelValidation(t *testing.T) {
 			assert.True(t, found, "expected %q to be a valid project access level", level)
 		}
 	})
-
-	t.Run("plan is invalid for project access", func(t *testing.T) {
-		found := false
-		for _, v := range validTeamProjectAccessLevels {
-			if v == "plan" {
-				found = true
-				break
-			}
-		}
-		assert.False(t, found, `"plan" must not be a valid project access level`)
-	})
 }

--- a/pkg/tools/tfe/grant_team_access_test.go
+++ b/pkg/tools/tfe/grant_team_access_test.go
@@ -1,0 +1,199 @@
+// Copyright IBM Corp. 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package tools
+
+import (
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGrantTeamAccess(t *testing.T) {
+	logger := log.New()
+	logger.SetLevel(log.ErrorLevel)
+
+	t.Run("tool creation", func(t *testing.T) {
+		tool := GrantTeamAccess(logger)
+
+		assert.Equal(t, "grant_team_access", tool.Tool.Name)
+		assert.Contains(t, tool.Tool.Description, "Grants a team permission to access a workspace or a project")
+		assert.NotNil(t, tool.Handler)
+
+		// Check annotations
+		assert.NotNil(t, tool.Tool.Annotations.ReadOnlyHint)
+		assert.False(t, *tool.Tool.Annotations.ReadOnlyHint)
+		assert.NotNil(t, tool.Tool.Annotations.DestructiveHint)
+		assert.False(t, *tool.Tool.Annotations.DestructiveHint)
+
+		// Check required parameters
+		assert.Contains(t, tool.Tool.InputSchema.Required, "team_id")
+		assert.Contains(t, tool.Tool.InputSchema.Required, "access_level")
+
+		// Check optional parameters exist in schema
+		assert.NotNil(t, tool.Tool.InputSchema.Properties["workspace_id"])
+		assert.NotNil(t, tool.Tool.InputSchema.Properties["project_id"])
+	})
+}
+
+func TestGrantTeamAccessHandler_InputValidation(t *testing.T) {
+	logger := log.New()
+	logger.SetLevel(log.ErrorLevel)
+	_ = logger
+
+	t.Run("missing team_id", func(t *testing.T) {
+		request := &MockCallToolRequest{
+			params: map[string]interface{}{
+				// team_id intentionally omitted
+				"access_level": "read",
+				"workspace_id": "ws-abc123",
+			},
+		}
+
+		_, err := request.RequireString("team_id")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "missing required parameter")
+	})
+
+	t.Run("missing access_level", func(t *testing.T) {
+		request := &MockCallToolRequest{
+			params: map[string]interface{}{
+				"team_id":      "team-abc123",
+				"workspace_id": "ws-abc123",
+				// access_level intentionally omitted
+			},
+		}
+
+		_, err := request.RequireString("access_level")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "missing required parameter")
+	})
+
+	t.Run("neither workspace_id nor project_id provided", func(t *testing.T) {
+		request := &MockCallToolRequest{
+			params: map[string]interface{}{
+				"team_id":      "team-abc123",
+				"access_level": "read",
+				// neither workspace_id nor project_id provided
+			},
+		}
+
+		workspaceID := request.GetString("workspace_id", "")
+		projectID := request.GetString("project_id", "")
+
+		assert.Empty(t, workspaceID)
+		assert.Empty(t, projectID)
+	})
+
+	t.Run("both workspace_id and project_id provided", func(t *testing.T) {
+		request := &MockCallToolRequest{
+			params: map[string]interface{}{
+				"team_id":      "team-abc123",
+				"access_level": "read",
+				"workspace_id": "ws-abc123",
+				"project_id":   "prj-abc123",
+			},
+		}
+
+		workspaceID := request.GetString("workspace_id", "")
+		projectID := request.GetString("project_id", "")
+
+		assert.NotEmpty(t, workspaceID)
+		assert.NotEmpty(t, projectID)
+	})
+
+	t.Run("parameter parsing", func(t *testing.T) {
+		request := &MockCallToolRequest{
+			params: map[string]interface{}{
+				"team_id":      "team-abc123",
+				"access_level": "admin",
+				"workspace_id": "ws-abc123",
+			},
+		}
+
+		teamID, err := request.RequireString("team_id")
+		assert.NoError(t, err)
+		assert.Equal(t, "team-abc123", teamID)
+
+		accessLevel, err := request.RequireString("access_level")
+		assert.NoError(t, err)
+		assert.Equal(t, "admin", accessLevel)
+
+		workspaceID := request.GetString("workspace_id", "")
+		assert.Equal(t, "ws-abc123", workspaceID)
+
+		projectID := request.GetString("project_id", "")
+		assert.Empty(t, projectID)
+	})
+}
+
+func TestGrantTeamAccessHandler_AccessLevelValidation(t *testing.T) {
+	t.Run("valid workspace access levels", func(t *testing.T) {
+		validLevels := []string{"admin", "read", "write", "plan", "custom"}
+		for _, level := range validLevels {
+			found := false
+			for _, v := range validTeamAccessLevels {
+				if v == level {
+					found = true
+					break
+				}
+			}
+			assert.True(t, found, "expected %q to be a valid workspace access level", level)
+		}
+	})
+
+	t.Run("valid project access levels", func(t *testing.T) {
+		validLevels := []string{"admin", "read", "write", "maintain", "custom"}
+		for _, level := range validLevels {
+			found := false
+			for _, v := range validTeamProjectAccessLevels {
+				if v == level {
+					found = true
+					break
+				}
+			}
+			assert.True(t, found, "expected %q to be a valid project access level", level)
+		}
+	})
+
+	t.Run("plan is invalid for project access", func(t *testing.T) {
+		found := false
+		for _, v := range validTeamProjectAccessLevels {
+			if v == "plan" {
+				found = true
+				break
+			}
+		}
+		assert.False(t, found, `"plan" must not be a valid project access level`)
+	})
+
+	t.Run("maintain is invalid for workspace access", func(t *testing.T) {
+		found := false
+		for _, v := range validTeamAccessLevels {
+			if v == "maintain" {
+				found = true
+				break
+			}
+		}
+		assert.False(t, found, `"maintain" must not be a valid workspace access level`)
+	})
+
+	t.Run("invalid access level is not in either list", func(t *testing.T) {
+		invalidLevel := "superadmin"
+		foundInWorkspace := false
+		foundInProject := false
+		for _, v := range validTeamAccessLevels {
+			if v == invalidLevel {
+				foundInWorkspace = true
+			}
+		}
+		for _, v := range validTeamProjectAccessLevels {
+			if v == invalidLevel {
+				foundInProject = true
+			}
+		}
+		assert.False(t, foundInWorkspace)
+		assert.False(t, foundInProject)
+	})
+}

--- a/pkg/tools/tfe/grant_team_access_test.go
+++ b/pkg/tools/tfe/grant_team_access_test.go
@@ -69,63 +69,6 @@ func TestGrantTeamAccessHandler_InputValidation(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "missing required parameter")
 	})
-
-	t.Run("neither workspace_id nor project_id provided", func(t *testing.T) {
-		request := &MockCallToolRequest{
-			params: map[string]interface{}{
-				"team_id":      "team-abc123",
-				"access_level": "read",
-				// neither workspace_id nor project_id provided
-			},
-		}
-
-		workspaceID := request.GetString("workspace_id", "")
-		projectID := request.GetString("project_id", "")
-
-		assert.Empty(t, workspaceID)
-		assert.Empty(t, projectID)
-	})
-
-	t.Run("both workspace_id and project_id provided", func(t *testing.T) {
-		request := &MockCallToolRequest{
-			params: map[string]interface{}{
-				"team_id":      "team-abc123",
-				"access_level": "read",
-				"workspace_id": "ws-abc123",
-				"project_id":   "prj-abc123",
-			},
-		}
-
-		workspaceID := request.GetString("workspace_id", "")
-		projectID := request.GetString("project_id", "")
-
-		assert.NotEmpty(t, workspaceID)
-		assert.NotEmpty(t, projectID)
-	})
-
-	t.Run("parameter parsing", func(t *testing.T) {
-		request := &MockCallToolRequest{
-			params: map[string]interface{}{
-				"team_id":      "team-abc123",
-				"access_level": "admin",
-				"workspace_id": "ws-abc123",
-			},
-		}
-
-		teamID, err := request.RequireString("team_id")
-		assert.NoError(t, err)
-		assert.Equal(t, "team-abc123", teamID)
-
-		accessLevel, err := request.RequireString("access_level")
-		assert.NoError(t, err)
-		assert.Equal(t, "admin", accessLevel)
-
-		workspaceID := request.GetString("workspace_id", "")
-		assert.Equal(t, "ws-abc123", workspaceID)
-
-		projectID := request.GetString("project_id", "")
-		assert.Empty(t, projectID)
-	})
 }
 
 func TestGrantTeamAccessHandler_AccessLevelValidation(t *testing.T) {
@@ -166,34 +109,5 @@ func TestGrantTeamAccessHandler_AccessLevelValidation(t *testing.T) {
 			}
 		}
 		assert.False(t, found, `"plan" must not be a valid project access level`)
-	})
-
-	t.Run("maintain is invalid for workspace access", func(t *testing.T) {
-		found := false
-		for _, v := range validTeamAccessLevels {
-			if v == "maintain" {
-				found = true
-				break
-			}
-		}
-		assert.False(t, found, `"maintain" must not be a valid workspace access level`)
-	})
-
-	t.Run("invalid access level is not in either list", func(t *testing.T) {
-		invalidLevel := "superadmin"
-		foundInWorkspace := false
-		foundInProject := false
-		for _, v := range validTeamAccessLevels {
-			if v == invalidLevel {
-				foundInWorkspace = true
-			}
-		}
-		for _, v := range validTeamProjectAccessLevels {
-			if v == invalidLevel {
-				foundInProject = true
-			}
-		}
-		assert.False(t, foundInWorkspace)
-		assert.False(t, foundInProject)
 	})
 }

--- a/pkg/toolsets/mapping.go
+++ b/pkg/toolsets/mapping.go
@@ -78,6 +78,7 @@ var ToolToToolset = map[string]string{
 	"list_state_versions":                 Terraform,
 	"get_state_version":                   Terraform,
 	"get_run_comments":                    Terraform,
+	"grant_team_access":                   Terraform,
 }
 
 // GetToolsetForTool returns the toolset name for a given tool name

--- a/pkg/toolsets/mapping.go
+++ b/pkg/toolsets/mapping.go
@@ -24,7 +24,7 @@ var ToolToToolset = map[string]string{
 	"get_private_provider_details": RegistryPrivate,
 
 	// Terraform Tools - User
-	"whoami":              Terraform,
+	"whoami": Terraform,
 
 	// Terraform tools - Organization
 	"list_terraform_orgs": Terraform,
@@ -78,7 +78,6 @@ var ToolToToolset = map[string]string{
 	"list_state_versions":                 Terraform,
 	"get_state_version":                   Terraform,
 	"get_run_comments":                    Terraform,
-	"grant_team_access":                   Terraform,
 }
 
 // GetToolsetForTool returns the toolset name for a given tool name

--- a/pkg/toolsets/mapping.go
+++ b/pkg/toolsets/mapping.go
@@ -36,10 +36,11 @@ var ToolToToolset = map[string]string{
 	"get_project":             Terraform,
 
 	// Terraform tools - Team
-	"create_team":     Terraform,
-	"list_teams":      Terraform,
-	"get_team":        Terraform,
-	"add_team_member": Terraform,
+	"create_team":       Terraform,
+	"list_teams":        Terraform,
+	"get_team":          Terraform,
+	"add_team_member":   Terraform,
+	"grant_team_access": Terraform,
 
 	// Terraform tools - Workspace management
 	"list_workspaces":                     Terraform,

--- a/test/terraform/teams_test.go
+++ b/test/terraform/teams_test.go
@@ -220,13 +220,7 @@ func TestAddTeamMember(t *testing.T) {
 
 func TestGrantTeamAccess(t *testing.T) {
 	client := tfeClient(t)
-
-	// Guard: skip if the organization does not support team management.
-	entitlements, err := client.Organizations.ReadEntitlements(t.Context(), tfeOrgName)
-	require.NoError(t, err, "Failed to read entitlements for organization %q", tfeOrgName)
-	if !entitlements.Teams {
-		t.Skipf("Organization %q does not have the Teams entitlement", tfeOrgName)
-	}
+	requireTeamsEntitlement(t, client)
 
 	// Resolve a real team ID to use for all sub-tests.
 	teams, err := client.Teams.List(t.Context(), tfeOrgName, nil)

--- a/test/terraform/teams_test.go
+++ b/test/terraform/teams_test.go
@@ -217,3 +217,128 @@ func TestAddTeamMember(t *testing.T) {
 		assert.Contains(t, resultText, "username", "Error message should mention the conflicting inputs")
 	})
 }
+
+func TestGrantTeamAccess(t *testing.T) {
+	client := tfeClient(t)
+
+	// Guard: skip if the organization does not support team management.
+	entitlements, err := client.Organizations.ReadEntitlements(t.Context(), tfeOrgName)
+	require.NoError(t, err, "Failed to read entitlements for organization %q", tfeOrgName)
+	if !entitlements.Teams {
+		t.Skipf("Organization %q does not have the Teams entitlement", tfeOrgName)
+	}
+
+	// Resolve a real team ID to use for all sub-tests.
+	teams, err := client.Teams.List(t.Context(), tfeOrgName, nil)
+	require.NoError(t, err, "Failed to list teams")
+	require.NotEmpty(t, teams.Items, "Expected at least one team in the organization")
+	teamID := teams.Items[0].ID
+
+	t.Run("grant workspace access", func(t *testing.T) {
+		s := newTestingSession(t)
+		defer s.Close()
+
+		// Create a temporary workspace to grant access to.
+		ws, err := client.Workspaces.Create(t.Context(), tfeOrgName, tfe.WorkspaceCreateOptions{
+			Name: tfe.String(randomName("ws-")),
+		})
+		require.NoError(t, err, "Failed to create test workspace")
+		defer client.Workspaces.SafeDeleteByID(t.Context(), ws.ID)
+
+		result, resultText := callTool(t, s, "grant_team_access", map[string]any{
+			"team_id":      teamID,
+			"workspace_id": ws.ID,
+			"access_level": "read",
+		})
+
+		require.False(t, result.IsError, "grant_team_access returned an error: %s", resultText)
+		require.NotEmpty(t, resultText, "Tool call result must not be empty")
+
+		assert.NotEmpty(t, gjson.Get(resultText, "id").String(), "Response should contain a grant ID")
+		assert.Equal(t, teamID, gjson.Get(resultText, "team_id").String(), "Response should contain the requested team ID")
+		assert.Equal(t, ws.ID, gjson.Get(resultText, "workspace_id").String(), "Response should contain the requested workspace ID")
+		assert.Equal(t, "read", gjson.Get(resultText, "access").String(), "Response should reflect the requested access level")
+	})
+
+	t.Run("grant project access", func(t *testing.T) {
+		s := newTestingSession(t)
+		defer s.Close()
+
+		// Create a temporary project to grant access to.
+		project, err := client.Projects.Create(t.Context(), tfeOrgName, tfe.ProjectCreateOptions{
+			Name: randomName("proj-"),
+		})
+		require.NoError(t, err, "Failed to create test project")
+		defer client.Projects.Delete(t.Context(), project.ID)
+
+		result, resultText := callTool(t, s, "grant_team_access", map[string]any{
+			"team_id":      teamID,
+			"project_id":   project.ID,
+			"access_level": "read",
+		})
+
+		require.False(t, result.IsError, "grant_team_access returned an error: %s", resultText)
+		require.NotEmpty(t, resultText, "Tool call result must not be empty")
+
+		assert.NotEmpty(t, gjson.Get(resultText, "id").String(), "Response should contain a grant ID")
+		assert.Equal(t, teamID, gjson.Get(resultText, "team_id").String(), "Response should contain the requested team ID")
+		assert.Equal(t, project.ID, gjson.Get(resultText, "project_id").String(), "Response should contain the requested project ID")
+		assert.Equal(t, "read", gjson.Get(resultText, "access").String(), "Response should reflect the requested access level")
+	})
+
+	t.Run("error on both workspace_id and project_id", func(t *testing.T) {
+		s := newTestingSession(t)
+		defer s.Close()
+
+		result, resultText := callTool(t, s, "grant_team_access", map[string]any{
+			"team_id":      teamID,
+			"workspace_id": "ws-fakeid",
+			"project_id":   "prj-fakeid",
+			"access_level": "read",
+		})
+
+		require.True(t, result.IsError, "Expected an error when both workspace_id and project_id are provided")
+		assert.Contains(t, resultText, "Only one of workspace_id or project_id may be provided")
+	})
+
+	t.Run("error on neither workspace_id nor project_id", func(t *testing.T) {
+		s := newTestingSession(t)
+		defer s.Close()
+
+		result, resultText := callTool(t, s, "grant_team_access", map[string]any{
+			"team_id":      teamID,
+			"access_level": "read",
+		})
+
+		require.True(t, result.IsError, "Expected an error when neither workspace_id nor project_id is provided")
+		assert.Contains(t, resultText, "One of workspace_id or project_id must be provided")
+	})
+
+	t.Run("error on invalid workspace access level", func(t *testing.T) {
+		s := newTestingSession(t)
+		defer s.Close()
+
+		result, resultText := callTool(t, s, "grant_team_access", map[string]any{
+			"team_id":      teamID,
+			"workspace_id": "ws-fakeid",
+			"access_level": "maintain",
+		})
+
+		require.True(t, result.IsError, "Expected an error when 'maintain' is used for workspace access")
+		assert.Contains(t, resultText, "Invalid Team access level")
+	})
+
+	t.Run("error on invalid project access level", func(t *testing.T) {
+		s := newTestingSession(t)
+		defer s.Close()
+
+		result, resultText := callTool(t, s, "grant_team_access", map[string]any{
+			"team_id":      teamID,
+			"project_id":   "prj-fakeid",
+			"access_level": "plan",
+		})
+
+		require.True(t, result.IsError, "Expected an error when 'plan' is used for project access")
+		assert.Contains(t, resultText, "Invalid Team Project access level")
+	})
+}

--- a/test/terraform/teams_test.go
+++ b/test/terraform/teams_test.go
@@ -103,7 +103,7 @@ func TestGetTeam(t *testing.T) {
 	client := tfeClient(t)
 	requireTeamsEntitlement(t, client)
 
-	// Get a real team ID to look up (the owners team always exists)
+	// Get a real team ID to look up
 	teams, err := client.Teams.List(t.Context(), tfeOrgName, nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, teams.Items, "Expected at least one team in the organization")
@@ -222,11 +222,15 @@ func TestGrantTeamAccess(t *testing.T) {
 	client := tfeClient(t)
 	requireTeamsEntitlement(t, client)
 
-	// Resolve a real team ID to use for all sub-tests.
-	teams, err := client.Teams.List(t.Context(), tfeOrgName, nil)
-	require.NoError(t, err, "Failed to list teams")
-	require.NotEmpty(t, teams.Items, "Expected at least one team in the organization")
-	teamID := teams.Items[0].ID
+	// Create a temporary team for all sub-tests so we never touch the owners group.
+	team, err := client.Teams.Create(t.Context(), tfeOrgName, tfe.TeamCreateOptions{
+		Name: tfe.String(randomName("team-")),
+	})
+	require.NoError(t, err, "Failed to create test team")
+
+	// Safety net: if the delete tool fails mid-test, clean up via the API.
+	defer client.Teams.Delete(t.Context(), team.ID)
+	teamID := team.ID
 
 	t.Run("grant workspace access", func(t *testing.T) {
 		s := newTestingSession(t)


### PR DESCRIPTION
## New Tool: `grant_team_access`

Grants a team permission to access a workspace or a project in Terraform Cloud/Enterprise. 

### What changed

- `pkg/tools/tfe/grant_team_access.go` — tool definition, handler, and response structs 
- `pkg/tools/tfe/grant_team_access_test.go` — unit tests 
- `pkg/tools/dynamic_tool.go` — registers `grant_team_access
- `pkg/toolsets/mapping.go` — maps `grant_team_access` to the `terraform` toolset
- `CHANGELOG.md` — entry added under `1.3.0` FEATURES
- `test/terraform/teams_test.go` — hcpt  integration tests in `TestGrantTeamAccess`

### Inputs / Output

**Required:** `team_id` (e.g. `team-abc123def456`), `access_level`

**Required, exactly one of:**
- `workspace_id` — workspace to grant access to (e.g. `ws-abc123def456`)
- `project_id` — project to grant access to (e.g. `prj-abc123def456`)

**Valid access levels:**
- Workspace: `read`, `plan`, `write`, `admin`
- Project: `read`, `write`, `maintain`, `admin`
- Note: `plan` is workspace-only; `maintain` is project-only

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
