### PR TITLE
Add logging middleare handler

### DIFF
--- a/cmd/terraform-mcp-server/main.go
+++ b/cmd/terraform-mcp-server/main.go
@@ -188,6 +188,7 @@ func NewServer(version string, logger *log.Logger, enabledToolsets []string, opt
 		server.WithResourceCapabilities(true, true),
 		server.WithInstructions(instructions),
 		server.WithToolHandlerMiddleware(rateLimitMiddleware.Middleware()),
+		server.WithToolHandlerMiddleware(client.ToolLoggingMiddleware(logger)),
 		server.WithElicitation(),
 	}
 	opts = append(defaultOpts, opts...)

--- a/pkg/client/tool_logging_middleware.go
+++ b/pkg/client/tool_logging_middleware.go
@@ -1,0 +1,23 @@
+// Copyright IBM Corp. 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package client
+
+import (
+	"context"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	log "github.com/sirupsen/logrus"
+)
+
+func ToolLoggingMiddleware(logger *log.Logger) server.ToolHandlerMiddleware {
+	return func(nextToolHandler server.ToolHandlerFunc) server.ToolHandlerFunc {
+		return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			if logger != nil {
+				logger.Infof("Tool call %q executed with args: %v", request.Params.Name, request.Params.Arguments)
+			}
+			return nextToolHandler(ctx, request)
+		}
+	}
+}

--- a/pkg/client/tool_logging_middleware_test.go
+++ b/pkg/client/tool_logging_middleware_test.go
@@ -1,0 +1,100 @@
+// Copyright IBM Corp. 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package client
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToolLoggingMiddleware(t *testing.T) {
+	t.Run("logs tool call name and args at info level", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := log.New()
+		logger.SetOutput(&buf)
+		logger.SetLevel(log.InfoLevel)
+
+		nextCalled := false
+		mockHandler := func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			nextCalled = true
+			return mcp.NewToolResultText("success"), nil
+		}
+
+		handler := ToolLoggingMiddleware(logger)(mockHandler)
+
+		request := mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Name: "list_workspaces",
+				Arguments: map[string]any{
+					"terraform_org_name": "my-org",
+				},
+			},
+		}
+
+		result, err := handler(context.Background(), request)
+
+		require.NoError(t, err)
+		assert.True(t, nextCalled)
+		assert.False(t, result.IsError)
+
+		logOutput := buf.String()
+		t.Logf("Captured log output:\n%s", logOutput)
+		assert.Contains(t, logOutput, "level=info")
+		assert.Contains(t, logOutput, "list_workspaces")
+		assert.Contains(t, logOutput, "terraform_org_name")
+		assert.Contains(t, logOutput, "my-org")
+	})
+
+	t.Run("handles nil logger gracefully", func(t *testing.T) {
+		nextCalled := false
+		mockHandler := func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			nextCalled = true
+			return mcp.NewToolResultText("success"), nil
+		}
+
+		handler := ToolLoggingMiddleware(nil)(mockHandler)
+
+		request := mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Name: "test_tool",
+			},
+		}
+
+		result, err := handler(context.Background(), request)
+
+		require.NoError(t, err)
+		assert.True(t, nextCalled)
+		assert.False(t, result.IsError)
+	})
+
+	t.Run("passes through tool handler errors and results", func(t *testing.T) {
+		logger := log.New()
+		logger.SetLevel(log.ErrorLevel) // Suppress log output during error test
+
+		expectedErr := errors.New("tool error")
+		mockHandler := func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return nil, expectedErr
+		}
+
+		handler := ToolLoggingMiddleware(logger)(mockHandler)
+
+		request := mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Name: "failing_tool",
+			},
+		}
+
+		result, err := handler(context.Background(), request)
+
+		assert.Equal(t, expectedErr, err)
+		assert.Nil(t, result)
+	})
+}


### PR DESCRIPTION
This PR adds the func `ToolLoggingMiddleware` which serves as a logging middleware wrapper. Prints `INFO` log everytime a tool is called and set `defaultOpt` at server start ensuring it is always present in the pipeline.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
