### PR TITLE
add run tools integration tests and add guard for create_run tool

### DIFF
--- a/pkg/tools/tfe/create_run.go
+++ b/pkg/tools/tfe/create_run.go
@@ -74,6 +74,10 @@ func createRunSafeHandler(ctx context.Context, request mcp.CallToolRequest, logg
 		return ToolErrorf(logger, "workspace '%s' not found in org '%s': %v", workspaceName, terraformOrgName, err)
 	}
 
+	if workspace.Locked {
+		return ToolErrorf(logger, "workspace '%s' is locked and cannot accept new runs. Use the force_unlock_workspace tool to unlock first", workspaceName)
+	}
+
 	options := &tfe.RunCreateOptions{
 		Workspace: workspace,
 	}
@@ -164,6 +168,10 @@ func createRunHandler(ctx context.Context, request mcp.CallToolRequest, logger *
 	workspace, err := tfeClient.Workspaces.Read(ctx, terraformOrgName, workspaceName)
 	if err != nil {
 		return ToolErrorf(logger, "workspace '%s' not found in org '%s': %v", workspaceName, terraformOrgName, err)
+	}
+
+	if workspace.Locked {
+		return ToolErrorf(logger, "workspace '%s' is locked and cannot accept new runs. Use the force_unlock_workspace tool to unlock first", workspaceName)
 	}
 
 	options := &tfe.RunCreateOptions{

--- a/pkg/tools/tfe/create_run.go
+++ b/pkg/tools/tfe/create_run.go
@@ -16,6 +16,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const workspaceLockedError = "workspace %q is locked and cannot accept new runs. Use the force_unlock_workspace tool to unlock first"
+
 // CreateRunSafe creates a tool to create a new Terraform run without destructive options.
 func CreateRunSafe(logger *log.Logger) server.ServerTool {
 	return server.ServerTool{
@@ -75,7 +77,7 @@ func createRunSafeHandler(ctx context.Context, request mcp.CallToolRequest, logg
 	}
 
 	if workspace.Locked {
-		return ToolErrorf(logger, "workspace '%s' is locked and cannot accept new runs. Use the force_unlock_workspace tool to unlock first", workspaceName)
+		return ToolErrorf(logger, workspaceLockedError, workspaceName)
 	}
 
 	options := &tfe.RunCreateOptions{
@@ -171,7 +173,7 @@ func createRunHandler(ctx context.Context, request mcp.CallToolRequest, logger *
 	}
 
 	if workspace.Locked {
-		return ToolErrorf(logger, "workspace '%s' is locked and cannot accept new runs. Use the force_unlock_workspace tool to unlock first", workspaceName)
+		return ToolErrorf(logger, workspaceLockedError, workspaceName)
 	}
 
 	options := &tfe.RunCreateOptions{

--- a/pkg/tools/tfe/create_run_test.go
+++ b/pkg/tools/tfe/create_run_test.go
@@ -4,17 +4,10 @@
 package tools
 
 import (
-	"io"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
-	"github.com/hashicorp/terraform-mcp-server/pkg/client"
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestCreateRunSafe(t *testing.T) {
@@ -65,49 +58,4 @@ func TestCreateRun(t *testing.T) {
 		runTypeProperty := tool.Tool.InputSchema.Properties["run_type"]
 		assert.NotNil(t, runTypeProperty)
 	})
-}
-
-func TestCreateRunLockedWorkspace(t *testing.T) {
-	logger := log.New()
-	logger.SetLevel(log.ErrorLevel)
-	logger.SetOutput(io.Discard)
-
-	terraformServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/vnd.api+json")
-		_, err := io.WriteString(w, `{"data":{"id":"test", "type":"workspaces", "attributes":{"name":"test-workspace","locked":true}}}`)
-		assert.NoError(t, err)
-	}))
-
-	t.Cleanup(terraformServer.Close)
-	t.Setenv(client.TerraformAddress, terraformServer.URL)
-	t.Setenv(client.TerraformToken, "test-token")
-
-	mcpServer := server.NewMCPServer("test", "1.0.0")
-	ctx := mcpServer.WithContext(t.Context(), server.NewInProcessSession("", nil))
-	request := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
-		"terraform_org_name": "test-org",
-		"workspace_name":     "test-workspace",
-	}}}
-
-	tests := []struct {
-		name string
-		tool server.ServerTool
-	}{
-		{name: "safe tool", tool: CreateRunSafe(logger)},
-		{name: "full tool", tool: CreateRun(logger)},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result, err := tt.tool.Handler(ctx, request)
-
-			require.NoError(t, err)
-			require.NotNil(t, result)
-			assert.True(t, result.IsError)
-			require.Len(t, result.Content, 1)
-			content, ok := result.Content[0].(mcp.TextContent)
-			require.True(t, ok)
-			assert.Equal(t, `workspace "test-workspace" is locked and cannot accept new runs. Use the force_unlock_workspace tool to unlock first`, content.Text)
-		})
-	}
 }

--- a/pkg/tools/tfe/create_run_test.go
+++ b/pkg/tools/tfe/create_run_test.go
@@ -4,10 +4,17 @@
 package tools
 
 import (
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/hashicorp/terraform-mcp-server/pkg/client"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateRunSafe(t *testing.T) {
@@ -58,4 +65,49 @@ func TestCreateRun(t *testing.T) {
 		runTypeProperty := tool.Tool.InputSchema.Properties["run_type"]
 		assert.NotNil(t, runTypeProperty)
 	})
+}
+
+func TestCreateRunLockedWorkspace(t *testing.T) {
+	logger := log.New()
+	logger.SetLevel(log.ErrorLevel)
+	logger.SetOutput(io.Discard)
+
+	terraformServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		_, err := io.WriteString(w, `{"data":{"id":"test", "type":"workspaces", "attributes":{"name":"test-workspace","locked":true}}}`)
+		assert.NoError(t, err)
+	}))
+
+	t.Cleanup(terraformServer.Close)
+	t.Setenv(client.TerraformAddress, terraformServer.URL)
+	t.Setenv(client.TerraformToken, "test-token")
+
+	mcpServer := server.NewMCPServer("test", "1.0.0")
+	ctx := mcpServer.WithContext(t.Context(), server.NewInProcessSession("", nil))
+	request := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+		"terraform_org_name": "test-org",
+		"workspace_name":     "test-workspace",
+	}}}
+
+	tests := []struct {
+		name string
+		tool server.ServerTool
+	}{
+		{name: "safe tool", tool: CreateRunSafe(logger)},
+		{name: "full tool", tool: CreateRun(logger)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tt.tool.Handler(ctx, request)
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.True(t, result.IsError)
+			require.Len(t, result.Content, 1)
+			content, ok := result.Content[0].(mcp.TextContent)
+			require.True(t, ok)
+			assert.Equal(t, `workspace "test-workspace" is locked and cannot accept new runs. Use the force_unlock_workspace tool to unlock first`, content.Text)
+		})
+	}
 }

--- a/test/terraform/run_test.go
+++ b/test/terraform/run_test.go
@@ -19,6 +19,30 @@ import (
 //go:embed testdata/run_test.tf
 var runTestConfiguration string
 
+func TestCreateRunLockedWorkspace(t *testing.T) {
+	s := newTestingSession(t)
+	defer s.Close()
+
+	client := tfeClient(t)
+	workspaceName := randomName("run-test-")
+	workspace, err := client.Workspaces.Create(t.Context(), tfeOrgName, tfe.WorkspaceCreateOptions{Name: &workspaceName})
+	require.NoError(t, err, "failed to create test workspace")
+	defer client.Workspaces.DeleteByID(t.Context(), workspace.ID)
+
+	lockReason := "Test create_run with a locked workspace"
+	_, err = client.Workspaces.Lock(t.Context(), workspace.ID, tfe.WorkspaceLockOptions{Reason: &lockReason})
+	require.NoError(t, err, "failed to lock test workspace")
+	defer client.Workspaces.ForceUnlock(t.Context(), workspace.ID)
+
+	result, resultText := callTool(t, s, "create_run", map[string]any{
+		"terraform_org_name": tfeOrgName,
+		"workspace_name":     workspaceName,
+	})
+
+	assert.True(t, result.IsError, "create_run should return an error for a locked workspace")
+	assert.Equal(t, `workspace "`+workspaceName+`" is locked and cannot accept new runs. Use the force_unlock_workspace tool to unlock first`, resultText)
+}
+
 func TestRunLifecycle(t *testing.T) {
 	requireTfOperations(t)
 

--- a/test/terraform/run_test.go
+++ b/test/terraform/run_test.go
@@ -6,6 +6,7 @@ import (
 	"compress/gzip"
 	"context"
 	_ "embed"
+	"fmt"
 	"io"
 	"testing"
 	"time"

--- a/test/terraform/run_test.go
+++ b/test/terraform/run_test.go
@@ -40,7 +40,7 @@ func TestCreateRunLockedWorkspace(t *testing.T) {
 	})
 
 	assert.True(t, result.IsError, "create_run should return an error for a locked workspace")
-	assert.Equal(t, `workspace "`+workspaceName+`" is locked and cannot accept new runs. Use the force_unlock_workspace tool to unlock first`, resultText)
+	assert.Equal(t, fmt.Sprintf(`workspace %q is locked and cannot accept new runs. Use the force_unlock_workspace tool to unlock first`, workspaceName), resultText)
 }
 
 func TestRunLifecycle(t *testing.T) {

--- a/test/terraform/run_test.go
+++ b/test/terraform/run_test.go
@@ -1,0 +1,304 @@
+package terraform
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-tfe"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+// runTestConfiguration creates a state-only resource with no external provider dependencies.
+const runTestConfiguration = `
+terraform {
+  required_version = ">= 1.4.0"
+}
+
+resource "terraform_data" "run_test" {
+  input = "terraform-mcp-server integration test for run tools"
+}
+
+output "run_test_id" {
+  value = terraform_data.run_test.id
+}
+`
+
+func TestRunLifecycle(t *testing.T) {
+	requireTfOperations(t)
+
+	s := newTestingSession(t)
+	defer s.Close()
+
+	// Create an isolated remote workspace for the run lifecycle.
+	client := tfeClient(t)
+	workspaceName := randomName("run-test-")
+	executionMode := "remote"
+
+	workspace, err := client.Workspaces.Create(t.Context(), tfeOrgName, tfe.WorkspaceCreateOptions{
+		Name:          &workspaceName,
+		ExecutionMode: &executionMode,
+		AutoApply:     tfe.Bool(false),
+	})
+	require.NoError(t, err, "failed to create test workspace")
+	defer client.Workspaces.DeleteByID(t.Context(), workspace.ID)
+
+	// Upload the configuration without automatically queuing a run.
+	uploadRunTestConfiguration(t, client, workspace.ID)
+
+	const (
+		runMessage  = "Created by terraform-mcp-server integration tests"
+		commentBody = "Run comment created by integration tests"
+	)
+
+	var runID string
+	t.Run("Create run", func(t *testing.T) {
+		result, resultText := callTool(t, s, "create_run", map[string]any{
+			"terraform_org_name": tfeOrgName,
+			"workspace_name":     workspaceName,
+			"run_type":           "plan_and_apply",
+			"message":            runMessage,
+		})
+		require.False(t, result.IsError, "create_run should not return an error")
+		require.NotEmpty(t, resultText, "create_run response must not be empty")
+
+		runID = gjson.Get(resultText, "data.id").String()
+		require.NotEmpty(t, runID, "Tool response should include a run ID")
+		toolRunMessage := gjson.Get(resultText, "data.attributes.message").String()
+		assert.Equal(t, runMessage, toolRunMessage)
+
+		// Verify against the TFE API directly
+		run, err := client.Runs.Read(t.Context(), runID)
+		require.NoError(t, err, "create run tool reported as created but produced an error when reading")
+		assert.Equal(t, run.ID, runID)
+		assert.Equal(t, run.Message, toolRunMessage)
+		require.NotNil(t, run.Workspace)
+		assert.Equal(t, workspace.ID, run.Workspace.ID)
+	})
+
+	t.Run("List runs", func(t *testing.T) {
+		result, resultText := callTool(t, s, "list_runs", map[string]any{
+			"terraform_org_name": tfeOrgName,
+			"workspace_name":     workspaceName,
+		})
+		require.False(t, result.IsError, "list_runs should not return an error")
+		require.NotEmpty(t, resultText, "list_runs response must not be empty")
+
+		listedRunID := gjson.Get(resultText, "items.0.id").String()
+		require.NotEmpty(t, listedRunID, "Tool response should include a run ID")
+		assert.Equal(t, runID, listedRunID)
+		listedRunMessage := gjson.Get(resultText, "items.0.message").String()
+		listedWorkspaceName := gjson.Get(resultText, "items.0.workspace_name").String()
+
+		// Verify against the TFE API directly
+		runs, err := client.Runs.List(t.Context(), workspace.ID, nil)
+		require.NoError(t, err)
+		require.Len(t, runs.Items, 1, "the dedicated workspace should contain one run")
+		assert.Equal(t, runs.Items[0].ID, listedRunID)
+		assert.Equal(t, runs.Items[0].Message, listedRunMessage)
+		require.NotNil(t, runs.Items[0].Workspace)
+		assert.Equal(t, runs.Items[0].Workspace.Name, listedWorkspaceName)
+	})
+
+	t.Run("Get run details", func(t *testing.T) {
+		result, resultText := callTool(t, s, "get_run_details", map[string]any{"run_id": runID})
+		require.False(t, result.IsError, "get_run_details should not return an error")
+		require.NotEmpty(t, resultText, "get_run_details response must not be empty")
+		toolRunID := gjson.Get(resultText, "data.id").String()
+		toolRunMessage := gjson.Get(resultText, "data.attributes.message").String()
+
+		// Verify against the TFE API directly
+		run, err := client.Runs.Read(t.Context(), runID)
+		require.NoError(t, err)
+		assert.Equal(t, run.ID, toolRunID)
+		assert.Equal(t, run.Message, toolRunMessage)
+	})
+
+	t.Run("Get run comments", func(t *testing.T) {
+		comment, err := client.Comments.Create(t.Context(), runID, tfe.CommentCreateOptions{Body: commentBody})
+		require.NoError(t, err, "failed to create a run comment with the TFE client")
+
+		result, resultText := callTool(t, s, "get_run_comments", map[string]any{"run_id": runID})
+		require.False(t, result.IsError, "get_run_comments should not return an error")
+		require.NotEmpty(t, resultText, "get_run_comments response must not be empty")
+
+		listedCommentID := gjson.Get(resultText, "items.0.id").String()
+		listedCommentBody := gjson.Get(resultText, "items.0.body").String()
+
+		comments, err := client.Comments.List(t.Context(), runID)
+		require.NoError(t, err)
+		require.Len(t, comments.Items, 1, "the run should contain one comment")
+		assert.Equal(t, comment.ID, comments.Items[0].ID)
+		assert.Equal(t, comments.Items[0].ID, listedCommentID)
+		assert.Equal(t, comments.Items[0].Body, listedCommentBody)
+	})
+
+	// create_run starts planning asynchronously; wait until the run can be applied.
+	plannedRun := waitForRun(t, client, runID, "become confirmable", func(run *tfe.Run) bool {
+		return run.Actions != nil && run.Actions.IsConfirmable
+	})
+	require.NotNil(t, plannedRun.Plan, "the planned run should have a plan")
+	planID := plannedRun.Plan.ID
+	require.NotEmpty(t, planID, "the planned run should have a plan ID")
+
+	t.Run("Get plan details", func(t *testing.T) {
+		result, resultText := callTool(t, s, "get_plan_details", map[string]any{"plan_id": planID})
+		require.False(t, result.IsError, "get_plan_details should not return an error")
+		require.NotEmpty(t, resultText, "get_plan_details response must not be empty")
+		toolPlanID := gjson.Get(resultText, "data.id").String()
+		toolPlanStatus := gjson.Get(resultText, "data.attributes.status").String()
+		toolPlanHasChanges := gjson.Get(resultText, "data.attributes.has-changes").Bool()
+
+		plan, err := client.Plans.Read(t.Context(), planID)
+		require.NoError(t, err)
+		assert.Equal(t, plan.ID, toolPlanID)
+		assert.Equal(t, string(plan.Status), toolPlanStatus)
+		assert.Equal(t, plan.HasChanges, toolPlanHasChanges)
+		assert.Equal(t, tfe.PlanFinished, plan.Status)
+		assert.True(t, plan.HasChanges)
+	})
+
+	t.Run("Get plan logs", func(t *testing.T) {
+		result, resultText := callTool(t, s, "get_plan_logs", map[string]any{"plan_id": planID})
+		require.False(t, result.IsError, "get_plan_logs should not return an error")
+		require.NotEmpty(t, resultText, "get_plan_logs response must not be empty")
+		assert.Contains(t, resultText, "terraform_data.run_test")
+
+		logReader, err := client.Plans.Logs(t.Context(), planID)
+		require.NoError(t, err)
+		directLogs, err := io.ReadAll(logReader)
+		require.NoError(t, err)
+		assert.Equal(t, string(directLogs), resultText)
+	})
+
+	t.Run("Get plan JSON output", func(t *testing.T) {
+		result, resultText := callTool(t, s, "get_plan_json_output", map[string]any{"plan_id": planID})
+		require.False(t, result.IsError, "get_plan_json_output should not return an error")
+		require.NotEmpty(t, resultText, "get_plan_json_output response must not be empty")
+		require.True(t, gjson.Valid(resultText), "get_plan_json_output should return valid JSON")
+		resourceAction := gjson.Get(resultText, `resource_changes.#(address=="terraform_data.run_test").change.actions.0`).String()
+		assert.Equal(t, "create", resourceAction)
+
+		directJSON, err := client.Plans.ReadJSONOutput(t.Context(), planID)
+		require.NoError(t, err)
+		assert.JSONEq(t, string(directJSON), resultText)
+	})
+
+	var actionRunID string
+	t.Run("Action run", func(t *testing.T) {
+		result, resultText := callTool(t, s, "action_run", map[string]any{
+			"run_id":     runID,
+			"run_action": "apply",
+			"comment":    "Approved by integration tests",
+		})
+		require.False(t, result.IsError, "action_run should not return an error")
+		require.NotEmpty(t, resultText, "action_run response must not be empty")
+		actionSucceeded := gjson.Get(resultText, "success").Bool()
+		actionRunID = gjson.Get(resultText, "run_id").String()
+		assert.True(t, actionSucceeded)
+		assert.Equal(t, runID, actionRunID)
+	})
+
+	// action_run starts applying asynchronously; wait until the apply finishes.
+	appliedRun := waitForRun(t, client, runID, "finish applying", func(run *tfe.Run) bool {
+		return run.Status == tfe.RunApplied
+	})
+	assert.Equal(t, appliedRun.ID, actionRunID)
+	require.NotNil(t, appliedRun.Apply, "the applied run should have an apply")
+	applyID := appliedRun.Apply.ID
+	require.NotEmpty(t, applyID, "the applied run should have an apply ID")
+
+	t.Run("Get apply details", func(t *testing.T) {
+		result, resultText := callTool(t, s, "get_apply_details", map[string]any{"apply_id": applyID})
+		require.False(t, result.IsError, "get_apply_details should not return an error")
+		require.NotEmpty(t, resultText, "get_apply_details response must not be empty")
+		toolApplyID := gjson.Get(resultText, "data.id").String()
+		toolApplyStatus := gjson.Get(resultText, "data.attributes.status").String()
+
+		apply, err := client.Applies.Read(t.Context(), applyID)
+		require.NoError(t, err)
+		assert.Equal(t, apply.ID, toolApplyID)
+		assert.Equal(t, string(apply.Status), toolApplyStatus)
+		assert.Equal(t, tfe.ApplyFinished, apply.Status)
+	})
+
+	t.Run("Get apply logs", func(t *testing.T) {
+		result, resultText := callTool(t, s, "get_apply_logs", map[string]any{"apply_id": applyID})
+		require.False(t, result.IsError, "get_apply_logs should not return an error")
+		require.NotEmpty(t, resultText, "get_apply_logs response must not be empty")
+		assert.Contains(t, resultText, "Apply complete!")
+
+		logReader, err := client.Applies.Logs(t.Context(), applyID)
+		require.NoError(t, err)
+		directLogs, err := io.ReadAll(logReader)
+		require.NoError(t, err)
+		assert.Equal(t, string(directLogs), resultText)
+	})
+}
+
+// packages the HCL as a gzipped tar archive and uploads it to the workspace.
+func uploadRunTestConfiguration(t *testing.T, client *tfe.Client, workspaceID string) {
+	t.Helper()
+
+	// Package main.tf as gzip(tar(main.tf)) entirely in memory.
+	var archive bytes.Buffer
+	gzipWriter := gzip.NewWriter(&archive)
+	tarWriter := tar.NewWriter(gzipWriter)
+	configuration := []byte(runTestConfiguration)
+
+	require.NoError(t, tarWriter.WriteHeader(&tar.Header{
+		Name: "main.tf",
+		Mode: 0o600,
+		Size: int64(len(configuration)),
+	}))
+	_, err := tarWriter.Write(configuration)
+	require.NoError(t, err)
+	require.NoError(t, tarWriter.Close())
+	require.NoError(t, gzipWriter.Close())
+
+	// Create the configuration-version record without auto-queuing a run.
+	configurationVersion, err := client.ConfigurationVersions.Create(t.Context(), workspaceID, tfe.ConfigurationVersionCreateOptions{
+		AutoQueueRuns: tfe.Bool(false),
+	})
+	require.NoError(t, err, "failed to create a configuration version")
+	require.NoError(t, client.ConfigurationVersions.UploadTarGzip(t.Context(), configurationVersion.UploadURL, &archive), "failed to upload the test configuration")
+}
+
+// waitForRun polls TFE until the run reaches the requested condition or times out.
+func waitForRun(t *testing.T, client *tfe.Client, runID, condition string, conditionMet func(*tfe.Run) bool) *tfe.Run {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Minute)
+	defer cancel()
+
+	// polling interval
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		run, err := client.Runs.ReadWithOptions(ctx, runID, &tfe.RunReadOptions{
+			Include: []tfe.RunIncludeOpt{tfe.RunPlan, tfe.RunApply},
+		})
+		require.NoError(t, err, "failed to poll run with the TFE client")
+		if conditionMet(run) {
+			return run
+		}
+
+		switch run.Status {
+		case tfe.RunErrored, tfe.RunCanceled, tfe.RunDiscarded:
+			t.Fatalf("run %s reached terminal state %s while waiting for it to %s", runID, run.Status, condition)
+		}
+
+		select {
+		case <-ctx.Done():
+			t.Fatalf("timed out waiting 10 minutes for run %s to %s", runID, condition)
+		case <-ticker.C:
+		}
+	}
+}

--- a/test/terraform/run_test.go
+++ b/test/terraform/run_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	_ "embed"
 	"io"
 	"testing"
 	"time"
@@ -15,20 +16,8 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-// runTestConfiguration creates a state-only resource with no external provider dependencies.
-const runTestConfiguration = `
-terraform {
-  required_version = ">= 1.4.0"
-}
-
-resource "terraform_data" "run_test" {
-  input = "terraform-mcp-server integration test for run tools"
-}
-
-output "run_test_id" {
-  value = terraform_data.run_test.id
-}
-`
+//go:embed testdata/run_test.tf
+var runTestConfiguration string
 
 func TestRunLifecycle(t *testing.T) {
 	requireTfOperations(t)
@@ -274,7 +263,7 @@ func uploadRunTestConfiguration(t *testing.T, client *tfe.Client, workspaceID st
 func waitForRun(t *testing.T, client *tfe.Client, runID, condition string, conditionMet func(*tfe.Run) bool) *tfe.Run {
 	t.Helper()
 
-	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
 	defer cancel()
 
 	// polling interval
@@ -297,7 +286,7 @@ func waitForRun(t *testing.T, client *tfe.Client, runID, condition string, condi
 
 		select {
 		case <-ctx.Done():
-			t.Fatalf("timed out waiting 10 minutes for run %s to %s", runID, condition)
+			t.Fatalf("timed out waiting 2 minute for run %s to %s", runID, condition)
 		case <-ticker.C:
 		}
 	}

--- a/test/terraform/testdata/run_test.tf
+++ b/test/terraform/testdata/run_test.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_version = ">= 1.4.0"
+}
+
+# This state-only resource has no external provider dependencies.
+resource "terraform_data" "run_test" {
+  input = "terraform-mcp-server integration test for run tools"
+}
+
+output "run_test_id" {
+  value = terraform_data.run_test.id
+}


### PR DESCRIPTION
- Added integration tests for all run tools, comparing tool outputs with TFE API responses.
- Added a workspace lock check guard to the `create_run` tool.