### PR TITLE
Fix get_apply_logs tool hanging when run is in pending state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ FEATURES
 * [New Tool] `get_project` Fetches detailed information about a Terraform project by its ID. Requires `project_id`.
 * [New Tool] `create_team` Creates a new team in a Terraform Cloud/Enterprise organization. Requires `terraform_org_name` and `team_name`; optional `visibility` ("secret" or "organization"). [427](https://github.com/hashicorp/terraform-mcp-server/pull/427)
 
+FIXES
+
+* `get_apply_logs` now checks the apply status before attempting to stream logs. If the apply is not yet in a terminal state (`finished`, `errored`, `canceled`), the tool returns an informative message instead of timing out.
+
 # 1.2.0
 
 FEATURES

--- a/pkg/tools/tfe/get_apply_logs.go
+++ b/pkg/tools/tfe/get_apply_logs.go
@@ -5,8 +5,10 @@ package tools
 
 import (
 	"context"
+	"fmt"
 	"io"
 
+	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-mcp-server/pkg/client"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -41,6 +43,29 @@ func getApplyLogsHandler(ctx context.Context, request mcp.CallToolRequest, logge
 	tfeClient, err := client.GetTfeClientFromContext(ctx, logger)
 	if err != nil {
 		return ToolError(logger, "failed to get Terraform client", err)
+	}
+
+	apply, err := tfeClient.Applies.Read(ctx, applyID)
+	if err != nil {
+		return ToolErrorf(logger, "apply not found: %s", applyID)
+	}
+
+	nonTerminalStatuses := []tfe.ApplyStatus{
+		tfe.ApplyPending,
+		tfe.ApplyCreated,
+		tfe.ApplyQueued,
+		tfe.ApplyMFAWaiting,
+		tfe.ApplyUnreachable,
+		tfe.ApplyRunning,
+	}
+
+	for _, s := range nonTerminalStatuses {
+		if apply.Status == s {
+			return mcp.NewToolResultText(fmt.Sprintf(
+				"Apply %s is currently in status %q. Wait for the status to change to a terminal state (finished, errored, canceled) before calling again.",
+				applyID, apply.Status,
+			)), nil
+		}
 	}
 
 	logReader, err := tfeClient.Applies.Logs(ctx, applyID)

--- a/pkg/tools/tfe/get_apply_logs.go
+++ b/pkg/tools/tfe/get_apply_logs.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"slices"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-mcp-server/pkg/client"
@@ -50,22 +51,17 @@ func getApplyLogsHandler(ctx context.Context, request mcp.CallToolRequest, logge
 		return ToolErrorf(logger, "apply not found: %s", applyID)
 	}
 
-	nonTerminalStatuses := []tfe.ApplyStatus{
-		tfe.ApplyPending,
-		tfe.ApplyCreated,
-		tfe.ApplyQueued,
-		tfe.ApplyMFAWaiting,
-		tfe.ApplyUnreachable,
-		tfe.ApplyRunning,
+	terminalStatuses := []tfe.ApplyStatus{
+		tfe.ApplyErrored,
+		tfe.ApplyFinished,
+		tfe.ApplyCanceled,
 	}
 
-	for _, s := range nonTerminalStatuses {
-		if apply.Status == s {
-			return mcp.NewToolResultText(fmt.Sprintf(
-				"Apply %s is currently in status %q. Wait for the status to change to a terminal state (finished, errored, canceled) before calling again.",
-				applyID, apply.Status,
-			)), nil
-		}
+	if !slices.Contains(terminalStatuses, apply.Status) {
+		return mcp.NewToolResultText(fmt.Sprintf(
+			"Apply %s is currently in status %q. Wait for the status to change to a terminal state (finished, errored, canceled) before calling again.",
+			applyID, apply.Status,
+		)), nil
 	}
 
 	logReader, err := tfeClient.Applies.Logs(ctx, applyID)


### PR DESCRIPTION
This PR contains a fix for this issue: #462.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
