### PR TITLE
Add `delete_team` tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ FEATURES
 FIXES
 
 * `get_apply_logs` now checks the apply status before attempting to stream logs. If the apply is not yet in a terminal state (`finished`, `errored`, `canceled`), the tool returns an informative message instead of timing out.
+* [New Tool] `delete_team` Permanently deletes a Terraform team by its `team_id`. Requires `team_id` (e.g. `team-abc123def456`). This is a destructive operation and must set `ENABLE_TF_OPERATIONS=true`.
 
 # 1.2.0
 
@@ -24,7 +25,6 @@ FEATURES
 * [New Tool] `create_project` Creates a new Terraform project in the specified organization. Requires `terraform_org_name` and `project_name`. [420](https://github.com/hashicorp/terraform-mcp-server/pull/420)
 * [New Tool] `delete_project` Deletes a Terraform project by ID. Requires `project_id`. TFC/TFE will refuse to delete a project that still contains workspaces or stacks. [420](https://github.com/hashicorp/terraform-mcp-server/pull/420)
 * [New Tool] `create_team` Creates a new team in a Terraform Cloud/Enterprise organization. Requires `terraform_org_name` and `team_name`; optional `visibility` ("secret" or "organization"). [427](https://github.com/hashicorp/terraform-mcp-server/pull/427)
-* [New Tool] `delete_team` Permanently deletes a Terraform team by its `team_id`. Requires `team_id` (e.g. `team-abc123def456`). This is a destructive operation and must set `ENABLE_TF_OPERATIONS=true`.
 
 IMPROVEMENTS
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,11 @@ FEATURES
 * [New Tool] `create_team` Creates a new team in a Terraform Cloud/Enterprise organization. Requires `terraform_org_name` and `team_name`; optional `visibility` ("secret" or "organization"). [427](https://github.com/hashicorp/terraform-mcp-server/pull/427)
 * [New Tool] `add_team_member` Adds a single member to a Terraform Cloud/Enterprise team. Requires `team_id`; accepts either `username` (accepted-invite users only) or `organization_membership_id` (works for pending and accepted invites). Exactly one must be provided.
 * [New Tool] `grant_team_access` Grants a team access to a workspace or project by ID. Requires `team_id`, `access_level`, and either `workspace_id` or `project_id` (mutually exclusive). Valid access levels for workspaces: `admin`, `read`, `write`, `plan`, `custom`. Valid access levels for projects: `admin`, `read`, `write`, `maintain`, `custom`.
+* [New Tool] `delete_team` Permanently deletes a Terraform team by its `team_id`. Requires `team_id` (e.g. `team-abc123def456`). This is a destructive operation and must set `ENABLE_TF_OPERATIONS=true`.
 
 FIXES
 
 * `get_apply_logs` now checks the apply status before attempting to stream logs. If the apply is not yet in a terminal state (`finished`, `errored`, `canceled`), the tool returns an informative message instead of timing out.
-* [New Tool] `delete_team` Permanently deletes a Terraform team by its `team_id`. Requires `team_id` (e.g. `team-abc123def456`). This is a destructive operation and must set `ENABLE_TF_OPERATIONS=true`.
-* [New Tool] `create_team` Creates a new team in a Terraform Cloud/Enterprise organization. Requires `terraform_org_name` and `team_name`; optional `visibility` ("secret" or "organization"). [427](https://github.com/hashicorp/terraform-mcp-server/pull/427)
 
 # 1.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ FIXES
 
 * `get_apply_logs` now checks the apply status before attempting to stream logs. If the apply is not yet in a terminal state (`finished`, `errored`, `canceled`), the tool returns an informative message instead of timing out.
 * [New Tool] `delete_team` Permanently deletes a Terraform team by its `team_id`. Requires `team_id` (e.g. `team-abc123def456`). This is a destructive operation and must set `ENABLE_TF_OPERATIONS=true`.
+* [New Tool] `create_team` Creates a new team in a Terraform Cloud/Enterprise organization. Requires `terraform_org_name` and `team_name`; optional `visibility` ("secret" or "organization"). [427](https://github.com/hashicorp/terraform-mcp-server/pull/427)
 
 # 1.2.0
 
@@ -24,7 +25,6 @@ FEATURES
 * [New Tool] `get_run_comments` Lists all discussion comments associated with a given Terraform run. Requires `run_id`.
 * [New Tool] `create_project` Creates a new Terraform project in the specified organization. Requires `terraform_org_name` and `project_name`. [420](https://github.com/hashicorp/terraform-mcp-server/pull/420)
 * [New Tool] `delete_project` Deletes a Terraform project by ID. Requires `project_id`. TFC/TFE will refuse to delete a project that still contains workspaces or stacks. [420](https://github.com/hashicorp/terraform-mcp-server/pull/420)
-* [New Tool] `create_team` Creates a new team in a Terraform Cloud/Enterprise organization. Requires `terraform_org_name` and `team_name`; optional `visibility` ("secret" or "organization"). [427](https://github.com/hashicorp/terraform-mcp-server/pull/427)
 
 IMPROVEMENTS
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ FEATURES
 * [New Tool] `get_run_comments` Lists all discussion comments associated with a given Terraform run. Requires `run_id`.
 * [New Tool] `create_project` Creates a new Terraform project in the specified organization. Requires `terraform_org_name` and `project_name`. [420](https://github.com/hashicorp/terraform-mcp-server/pull/420)
 * [New Tool] `delete_project` Deletes a Terraform project by ID. Requires `project_id`. TFC/TFE will refuse to delete a project that still contains workspaces or stacks. [420](https://github.com/hashicorp/terraform-mcp-server/pull/420)
+* [New Tool] `create_team` Creates a new team in a Terraform Cloud/Enterprise organization. Requires `terraform_org_name` and `team_name`; optional `visibility` ("secret" or "organization"). [427](https://github.com/hashicorp/terraform-mcp-server/pull/427)
+* [New Tool] `delete_team` Permanently deletes a Terraform team by its `team_id`. Requires `team_id` (e.g. `team-abc123def456`). This is a destructive operation and must set `ENABLE_TF_OPERATIONS=true`.
 
 IMPROVEMENTS
 

--- a/pkg/tools/dynamic_tool.go
+++ b/pkg/tools/dynamic_tool.go
@@ -196,6 +196,12 @@ func (r *DynamicToolRegistry) registerTFETools() {
 		r.mcpServer.AddTool(tool.Tool, tool.Handler)
 	}
 
+	// Only register delete_team if TF operations are enable AND toolset is enable
+	if isTerraformOperationsEnabled() && toolsets.IsToolEnabled("delete_team", r.enabledToolsets) {
+		tool := r.createDynamicTFETool("delete_team", tfeTools.DeleteTeam)
+		r.mcpServer.AddTool(tool.Tool, tool.Handler)
+	}
+
 	// Registry-private toolset - Private provider tools
 	if toolsets.IsToolEnabled("search_private_providers", r.enabledToolsets) {
 		tool := r.createDynamicTFETool("search_private_providers", tfeTools.SearchPrivateProviders)

--- a/pkg/tools/dynamic_tool.go
+++ b/pkg/tools/dynamic_tool.go
@@ -142,6 +142,12 @@ func (r *DynamicToolRegistry) registerTFETools() {
 		r.mcpServer.AddTool(tool.Tool, tool.Handler)
 	}
 
+	// Only register delete_team if TF operations are enable AND toolset is enable
+	if isTerraformOperationsEnabled() && toolsets.IsToolEnabled("delete_team", r.enabledToolsets) {
+		tool := r.createDynamicTFETool("delete_team", tfeTools.DeleteTeam)
+		r.mcpServer.AddTool(tool.Tool, tool.Handler)
+	}
+
 	// Terraform toolset - Workspace management tools
 	if toolsets.IsToolEnabled("list_workspaces", r.enabledToolsets) {
 		tool := r.createDynamicTFETool("list_workspaces", tfeTools.ListWorkspaces)
@@ -193,12 +199,6 @@ func (r *DynamicToolRegistry) registerTFETools() {
 
 	if isTerraformOperationsEnabled() && toolsets.IsToolEnabled("force_unlock_workspace", r.enabledToolsets) {
 		tool := r.createDynamicTFETool("force_unlock_workspace", tfeTools.ForceUnlockWorkspace)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	// Only register delete_team if TF operations are enable AND toolset is enable
-	if isTerraformOperationsEnabled() && toolsets.IsToolEnabled("delete_team", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("delete_team", tfeTools.DeleteTeam)
 		r.mcpServer.AddTool(tool.Tool, tool.Handler)
 	}
 

--- a/pkg/tools/tfe/action_run.go
+++ b/pkg/tools/tfe/action_run.go
@@ -5,7 +5,6 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-mcp-server/pkg/client"
@@ -74,20 +73,9 @@ func actionRunHandler(ctx context.Context, request mcp.CallToolRequest, logger *
 	default:
 		return ToolErrorf(logger, "invalid run_action: %s - must be 'apply', 'discard', or 'cancel'", runAction)
 	}
-
 	if err != nil {
 		return ToolErrorf(logger, "failed to %s run %s: %v", runAction, runID, err)
 	}
 
-	result := map[string]interface{}{
-		"success": true,
-		"message": msg,
-		"run_id":  runID,
-	}
-
-	resultJSON, err := json.Marshal(result)
-	if err != nil {
-		return ToolError(logger, "failed to marshal result", err)
-	}
-	return mcp.NewToolResultText(string(resultJSON)), nil
+	return mcp.NewToolResultText(msg), nil
 }

--- a/pkg/tools/tfe/delete_team.go
+++ b/pkg/tools/tfe/delete_team.go
@@ -5,6 +5,8 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/hashicorp/terraform-mcp-server/pkg/client"
@@ -20,8 +22,8 @@ func DeleteTeam(logger *log.Logger) server.ServerTool {
 	return server.ServerTool{
 		Tool: mcp.NewTool(
 			"delete_team",
-			mcp.WithDescription(`Permanently deletes a Terraform team by its team_id.  If you don't have the team_id, look it up first via the organization's Teams URL page from the HCP Terraform/TFE UI.`),
-			mcp.WithTitleAnnotation("Deletes a Terraform Team by team_id"),
+			mcp.WithDescription("Permanently deletes a Terraform team by its team_id.  If you don't have the team_id, look it up first via the organization's Teams URL page from the HCP Terraform/TFE UI."),
+			mcp.WithTitleAnnotation(`Deletes a Terraform Team by team_id`),
 			mcp.WithReadOnlyHintAnnotation(false),
 			mcp.WithOpenWorldHintAnnotation(true),
 			mcp.WithDestructiveHintAnnotation(true),
@@ -34,13 +36,11 @@ func DeleteTeam(logger *log.Logger) server.ServerTool {
 			return deleteTeamHandler(ctx, request, logger)
 		},
 	}
-
 }
 
 // deleteTeamHandler handles tool logics and functionality
 func deleteTeamHandler(ctx context.Context, request mcp.CallToolRequest, logger *log.Logger) (*mcp.CallToolResult, error) {
 
-	// Init clint object
 	tfeClient, err := client.GetTfeClientFromContext(ctx, logger)
 	if err != nil {
 		return ToolError(logger, "Failed to get Terraform client", err)
@@ -49,21 +49,36 @@ func deleteTeamHandler(ctx context.Context, request mcp.CallToolRequest, logger 
 		return ToolError(logger, "Failed to get Terraform client - ensure TFE_TOKEN and TFE_ADDRESS are configured", nil)
 	}
 
-	// Params Required
 	teamID, err := request.RequireString("team_id")
 	if err != nil {
 		return ToolError(logger, "Missing required input: team_id", err)
 	}
-	// Handle White Spaces
 	teamID = strings.TrimSpace(teamID)
 
-	// Read ID
 	team, err := tfeClient.Teams.Read(ctx, teamID)
-
-	// Delete Team
-	err = tfeClient.Teams.Delete(ctx, teamID)
 	if err != nil {
-		return ToolErrorf(logger, "Failed to delete team '%s' %v", teamID, err)
+		return ToolErrorf(logger, "Team not found: %s", teamID)
 	}
 
+	err = tfeClient.Teams.Delete(ctx, teamID)
+	if err != nil {
+		return ToolErrorf(logger, "Failed to delete team '%s'", teamID)
+	}
+
+	result := map[string]interface{}{
+		"success": true,
+		"message": fmt.Sprintf("team %q (%s) deleted successfully", team.Name, team.ID),
+		"team_id": team.ID,
+	}
+
+	resultJSON, err := json.Marshal(result)
+	if err != nil {
+		return ToolError(logger, "failed to marshal result", err)
+	}
+
+	// logger.Infof("team %s (%s) deleted successfully", team.Name, team.ID)
+
+	// return mcp.NewToolResultText(fmt.Sprintf("team %q (%s) with %d member(s) deleted successfully", team.Name, team.ID, team.UserCount)), nil
+
+	return mcp.NewToolResultText(string(resultJSON)), nil
 }

--- a/pkg/tools/tfe/delete_team.go
+++ b/pkg/tools/tfe/delete_team.go
@@ -41,6 +41,12 @@ func DeleteTeam(logger *log.Logger) server.ServerTool {
 // deleteTeamHandler handles tool logics and functionality
 func deleteTeamHandler(ctx context.Context, request mcp.CallToolRequest, logger *log.Logger) (*mcp.CallToolResult, error) {
 
+	teamID, err := request.RequireString("team_id")
+	if err != nil {
+		return ToolError(logger, "Missing required input: team_id", err)
+	}
+	teamID = strings.TrimSpace(teamID)
+
 	tfeClient, err := client.GetTfeClientFromContext(ctx, logger)
 	if err != nil {
 		return ToolError(logger, "Failed to get Terraform client", err)
@@ -48,12 +54,6 @@ func deleteTeamHandler(ctx context.Context, request mcp.CallToolRequest, logger 
 	if tfeClient == nil {
 		return ToolError(logger, "Failed to get Terraform client - ensure TFE_TOKEN and TFE_ADDRESS are configured", nil)
 	}
-
-	teamID, err := request.RequireString("team_id")
-	if err != nil {
-		return ToolError(logger, "Missing required input: team_id", err)
-	}
-	teamID = strings.TrimSpace(teamID)
 
 	team, err := tfeClient.Teams.Read(ctx, teamID)
 	if err != nil {

--- a/pkg/tools/tfe/delete_team.go
+++ b/pkg/tools/tfe/delete_team.go
@@ -67,18 +67,14 @@ func deleteTeamHandler(ctx context.Context, request mcp.CallToolRequest, logger 
 
 	result := map[string]interface{}{
 		"success": true,
-		"message": fmt.Sprintf("team %q (%s) deleted successfully", team.Name, team.ID),
+		"message": fmt.Sprintf("Team %q (%s) deleted successfully", team.Name, team.ID),
 		"team_id": team.ID,
 	}
 
 	resultJSON, err := json.Marshal(result)
 	if err != nil {
-		return ToolError(logger, "failed to marshal result", err)
+		return ToolError(logger, "Failed to marshal result", err)
 	}
-
-	// logger.Infof("team %s (%s) deleted successfully", team.Name, team.ID)
-
-	// return mcp.NewToolResultText(fmt.Sprintf("team %q (%s) with %d member(s) deleted successfully", team.Name, team.ID, team.UserCount)), nil
 
 	return mcp.NewToolResultText(string(resultJSON)), nil
 }

--- a/pkg/tools/tfe/delete_team.go
+++ b/pkg/tools/tfe/delete_team.go
@@ -1,0 +1,69 @@
+// Copyright IBM Corp. 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package tools
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-mcp-server/pkg/client"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	log "github.com/sirupsen/logrus"
+)
+
+// DeleteTeam creates a tool to delete a Terraform team by ID
+// Team ID can be found at:
+// https://app.terraform.io/app/your-organization/settings/teams/team-xxxxxxxx
+func DeleteTeam(logger *log.Logger) server.ServerTool {
+	return server.ServerTool{
+		Tool: mcp.NewTool(
+			"delete_team",
+			mcp.WithDescription(`Permanently deletes a Terraform team by its team_id.  If you don't have the team_id, look it up first via the organization's Teams URL page from the HCP Terraform/TFE UI.`),
+			mcp.WithTitleAnnotation("Deletes a Terraform Team by team_id"),
+			mcp.WithReadOnlyHintAnnotation(false),
+			mcp.WithOpenWorldHintAnnotation(true),
+			mcp.WithDestructiveHintAnnotation(true),
+			mcp.WithString("team_id",
+				mcp.Required(),
+				mcp.Description("The ID of the team to delete (e.g., 'team-abc123def456')"),
+			),
+		),
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return deleteTeamHandler(ctx, request, logger)
+		},
+	}
+
+}
+
+// deleteTeamHandler handles tool logics and functionality
+func deleteTeamHandler(ctx context.Context, request mcp.CallToolRequest, logger *log.Logger) (*mcp.CallToolResult, error) {
+
+	// Init clint object
+	tfeClient, err := client.GetTfeClientFromContext(ctx, logger)
+	if err != nil {
+		return ToolError(logger, "Failed to get Terraform client", err)
+	}
+	if tfeClient == nil {
+		return ToolError(logger, "Failed to get Terraform client - ensure TFE_TOKEN and TFE_ADDRESS are configured", nil)
+	}
+
+	// Params Required
+	teamID, err := request.RequireString("team_id")
+	if err != nil {
+		return ToolError(logger, "Missing required input: team_id", err)
+	}
+	// Handle White Spaces
+	teamID = strings.TrimSpace(teamID)
+
+	// Read ID
+	team, err := tfeClient.Teams.Read(ctx, teamID)
+
+	// Delete Team
+	err = tfeClient.Teams.Delete(ctx, teamID)
+	if err != nil {
+		return ToolErrorf(logger, "Failed to delete team '%s' %v", teamID, err)
+	}
+
+}

--- a/pkg/tools/tfe/delete_team.go
+++ b/pkg/tools/tfe/delete_team.go
@@ -37,7 +37,6 @@ func DeleteTeam(logger *log.Logger) server.ServerTool {
 
 // deleteTeamHandler handles tool logics and functionality
 func deleteTeamHandler(ctx context.Context, request mcp.CallToolRequest, logger *log.Logger) (*mcp.CallToolResult, error) {
-
 	teamID, err := request.RequireString("team_id")
 	if err != nil {
 		return ToolError(logger, "Missing required input: team_id", err)

--- a/pkg/tools/tfe/delete_team.go
+++ b/pkg/tools/tfe/delete_team.go
@@ -5,7 +5,6 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -20,8 +19,8 @@ func DeleteTeam(logger *log.Logger) server.ServerTool {
 	return server.ServerTool{
 		Tool: mcp.NewTool(
 			"delete_team",
-			mcp.WithDescription("Permanently deletes a Terraform team by its team_id. This also removes all team memberships and any workspace or project access granted through the team. Organization users and workspaces are not deleted."),
-			mcp.WithTitleAnnotation(`Deletes a Terraform Team by team_id`),
+			mcp.WithDescription(`Permanently deletes a Terraform team by its "team_id". This also removes all team memberships and any workspace or project access granted through the team. Organization users and workspaces are not deleted.`),
+			mcp.WithTitleAnnotation(`Deletes a Terraform Team by "team_id"`),
 			mcp.WithReadOnlyHintAnnotation(false),
 			mcp.WithOpenWorldHintAnnotation(true),
 			mcp.WithDestructiveHintAnnotation(true),
@@ -43,7 +42,7 @@ func deleteTeamHandler(ctx context.Context, request mcp.CallToolRequest, logger 
 	if err != nil {
 		return ToolError(logger, "Missing required input: team_id", err)
 	}
-	teamID = strings.TrimLeft(strings.TrimSpace(teamID), "/")
+	teamID = strings.TrimSpace(teamID)
 
 	tfeClient, err := client.GetTfeClientFromContext(ctx, logger)
 	if err != nil {
@@ -53,26 +52,10 @@ func deleteTeamHandler(ctx context.Context, request mcp.CallToolRequest, logger 
 		return ToolError(logger, "Failed to get Terraform client - ensure TFE_TOKEN and TFE_ADDRESS are configured", nil)
 	}
 
-	team, err := tfeClient.Teams.Read(ctx, teamID)
-	if err != nil {
-		return ToolErrorf(logger, "Team not found: %s", teamID)
-	}
-
 	err = tfeClient.Teams.Delete(ctx, teamID)
 	if err != nil {
 		return ToolErrorf(logger, "Failed to delete team %q", teamID)
 	}
 
-	result := map[string]interface{}{
-		"success": true,
-		"message": fmt.Sprintf("Team %q (%s) deleted successfully", team.Name, team.ID),
-		"team_id": team.ID,
-	}
-
-	resultJSON, err := json.Marshal(result)
-	if err != nil {
-		return ToolError(logger, "Failed to marshal result", err)
-	}
-
-	return mcp.NewToolResultText(string(resultJSON)), nil
+	return mcp.NewToolResultText(fmt.Sprintf("Team %q deleted", teamID)), nil
 }

--- a/pkg/tools/tfe/delete_team.go
+++ b/pkg/tools/tfe/delete_team.go
@@ -16,8 +16,6 @@ import (
 )
 
 // DeleteTeam creates a tool to delete a Terraform team by ID
-// Team ID can be found at:
-// https://app.terraform.io/app/your-organization/settings/teams/team-xxxxxxxx
 func DeleteTeam(logger *log.Logger) server.ServerTool {
 	return server.ServerTool{
 		Tool: mcp.NewTool(

--- a/pkg/tools/tfe/delete_team.go
+++ b/pkg/tools/tfe/delete_team.go
@@ -19,7 +19,7 @@ func DeleteTeam(logger *log.Logger) server.ServerTool {
 	return server.ServerTool{
 		Tool: mcp.NewTool(
 			"delete_team",
-			mcp.WithDescription(`Permanently deletes a Terraform team by its "team_id". This also removes all team memberships and any workspace or project access granted through the team. Organization users and workspaces are not deleted.`),
+			mcp.WithDescription(`Permanently deletes a Terraform team by its "team_id". This also removes all team memberships and any workspace or project access granted through the team. Organization users and workspaces are not deleted. If only a team name is known, use the list_teams tool first to look up the team_id.`),
 			mcp.WithTitleAnnotation(`Deletes a Terraform Team by "team_id"`),
 			mcp.WithReadOnlyHintAnnotation(false),
 			mcp.WithOpenWorldHintAnnotation(true),
@@ -53,7 +53,7 @@ func deleteTeamHandler(ctx context.Context, request mcp.CallToolRequest, logger 
 
 	err = tfeClient.Teams.Delete(ctx, teamID)
 	if err != nil {
-		return ToolErrorf(logger, "Failed to delete team %q", teamID)
+		return ToolErrorf(logger, "Failed to delete team %q: %v", teamID, err)
 	}
 
 	return mcp.NewToolResultText(fmt.Sprintf("Team %q deleted", teamID)), nil

--- a/pkg/tools/tfe/delete_team.go
+++ b/pkg/tools/tfe/delete_team.go
@@ -43,7 +43,7 @@ func deleteTeamHandler(ctx context.Context, request mcp.CallToolRequest, logger 
 	if err != nil {
 		return ToolError(logger, "Missing required input: team_id", err)
 	}
-	teamID = strings.TrimSpace(teamID)
+	teamID = strings.TrimLeft(strings.TrimSpace(teamID), "/")
 
 	tfeClient, err := client.GetTfeClientFromContext(ctx, logger)
 	if err != nil {

--- a/pkg/tools/tfe/delete_team.go
+++ b/pkg/tools/tfe/delete_team.go
@@ -22,7 +22,7 @@ func DeleteTeam(logger *log.Logger) server.ServerTool {
 	return server.ServerTool{
 		Tool: mcp.NewTool(
 			"delete_team",
-			mcp.WithDescription("Permanently deletes a Terraform team by its team_id.  If you don't have the team_id, look it up first via the organization's Teams URL page from the HCP Terraform/TFE UI."),
+			mcp.WithDescription("Permanently deletes a Terraform team by its team_id. This also removes all team memberships and any workspace or project access granted through the team. Organization users and workspaces are not deleted."),
 			mcp.WithTitleAnnotation(`Deletes a Terraform Team by team_id`),
 			mcp.WithReadOnlyHintAnnotation(false),
 			mcp.WithOpenWorldHintAnnotation(true),
@@ -62,7 +62,7 @@ func deleteTeamHandler(ctx context.Context, request mcp.CallToolRequest, logger 
 
 	err = tfeClient.Teams.Delete(ctx, teamID)
 	if err != nil {
-		return ToolErrorf(logger, "Failed to delete team '%s'", teamID)
+		return ToolErrorf(logger, "Failed to delete team %q", teamID)
 	}
 
 	result := map[string]interface{}{

--- a/pkg/tools/tfe/delete_team_test.go
+++ b/pkg/tools/tfe/delete_team_test.go
@@ -1,0 +1,128 @@
+// Copyright IBM Corp. 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package tools
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeleteTeam(t *testing.T) {
+	logger := log.New()
+	logger.SetLevel(log.ErrorLevel) // Reduce noise in tests
+
+	t.Run("tool creation", func(t *testing.T) {
+		tool := DeleteTeam(logger)
+
+		assert.Equal(t, "delete_team", tool.Tool.Name)
+		assert.Contains(t, tool.Tool.Description, "Permanently deletes a Terraform team")
+		assert.NotNil(t, tool.Handler)
+
+		// Verify it's marked as destructive
+		assert.NotNil(t, tool.Tool.Annotations.DestructiveHint)
+		assert.True(t, *tool.Tool.Annotations.DestructiveHint)
+		assert.NotNil(t, tool.Tool.Annotations.ReadOnlyHint)
+		assert.False(t, *tool.Tool.Annotations.ReadOnlyHint)
+
+		// Check that required parameters are defined
+		assert.Contains(t, tool.Tool.InputSchema.Required, "team_id")
+	})
+
+	t.Run("parameter validation", func(t *testing.T) {
+		tests := []struct {
+			name        string
+			params      map[string]interface{}
+			expectError bool
+			errorField  string
+		}{
+			{
+				name: "valid team ID",
+				params: map[string]interface{}{
+					"team_id": "team-abc123def456",
+				},
+				expectError: false,
+			},
+			{
+				name:        "missing team ID",
+				params:      map[string]interface{}{},
+				expectError: true,
+				errorField:  "team_id",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				request := &MockCallToolRequest{params: tt.params}
+
+				teamID, err := request.RequireString("team_id")
+
+				if tt.expectError {
+					switch tt.errorField {
+					case "team_id":
+						assert.Error(t, err)
+					}
+				} else {
+					assert.NoError(t, err)
+					if val, ok := tt.params["team_id"]; ok {
+						assert.Equal(t, val, teamID)
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("team ID format validation", func(t *testing.T) {
+		tests := []struct {
+			name        string
+			teamID      string
+			expectValid bool
+		}{
+			{"valid team ID", "team-abc123def456", true},
+			{"valid short team ID", "team-abc123", true},
+			{"invalid format - no prefix", "abc123def456", false},
+			{"invalid format - wrong prefix", "workspace-abc123", false},
+			{"empty team ID", "", false},
+			{"only prefix", "team-", false},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				// Simple validation: team ID should start with "team-" and have content after
+				isValid := strings.HasPrefix(tt.teamID, "team-") && len(tt.teamID) > 5
+				assert.Equal(t, tt.expectValid, isValid)
+			})
+		}
+	})
+
+	t.Run("team deletion result structure", func(t *testing.T) {
+		type TeamDeletionResult struct {
+			Success bool   `json:"success"`
+			Message string `json:"message"`
+			TeamID  string `json:"team_id"`
+		}
+
+		result := TeamDeletionResult{
+			Success: true,
+			Message: `team "my-platform-team" (team-abc123def456) deleted successfully`,
+			TeamID:  "team-abc123def456",
+		}
+
+		jsonData, err := json.Marshal(result)
+		assert.NoError(t, err)
+		assert.Contains(t, string(jsonData), "team-abc123def456")
+		assert.Contains(t, string(jsonData), "deleted successfully")
+		assert.Contains(t, string(jsonData), `"success":true`)
+
+		var unmarshaled TeamDeletionResult
+		err = json.Unmarshal(jsonData, &unmarshaled)
+		assert.NoError(t, err)
+		assert.Equal(t, result.Success, unmarshaled.Success)
+		assert.Equal(t, result.TeamID, unmarshaled.TeamID)
+		assert.Equal(t, result.Message, unmarshaled.Message)
+	})
+}

--- a/pkg/tools/tfe/delete_team_test.go
+++ b/pkg/tools/tfe/delete_team_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestDeleteTeam(t *testing.T) {
 	logger := log.New()
-	logger.SetLevel(log.ErrorLevel) // Reduce noise in tests
+	logger.SetLevel(log.ErrorLevel)
 
 	t.Run("tool creation", func(t *testing.T) {
 		tool := DeleteTeam(logger)

--- a/pkg/tools/tfe/delete_team_test.go
+++ b/pkg/tools/tfe/delete_team_test.go
@@ -4,7 +4,6 @@
 package tools
 
 import (
-	"encoding/json"
 	"strings"
 	"testing"
 
@@ -99,30 +98,4 @@ func TestDeleteTeam(t *testing.T) {
 		}
 	})
 
-	t.Run("team deletion result structure", func(t *testing.T) {
-		type TeamDeletionResult struct {
-			Success bool   `json:"success"`
-			Message string `json:"message"`
-			TeamID  string `json:"team_id"`
-		}
-
-		result := TeamDeletionResult{
-			Success: true,
-			Message: `team "my-platform-team" (team-abc123def456) deleted successfully`,
-			TeamID:  "team-abc123def456",
-		}
-
-		jsonData, err := json.Marshal(result)
-		assert.NoError(t, err)
-		assert.Contains(t, string(jsonData), "team-abc123def456")
-		assert.Contains(t, string(jsonData), "deleted successfully")
-		assert.Contains(t, string(jsonData), `"success":true`)
-
-		var unmarshaled TeamDeletionResult
-		err = json.Unmarshal(jsonData, &unmarshaled)
-		assert.NoError(t, err)
-		assert.Equal(t, result.Success, unmarshaled.Success)
-		assert.Equal(t, result.TeamID, unmarshaled.TeamID)
-		assert.Equal(t, result.Message, unmarshaled.Message)
-	})
 }

--- a/pkg/tools/tfe/delete_team_test.go
+++ b/pkg/tools/tfe/delete_team_test.go
@@ -4,7 +4,6 @@
 package tools
 
 import (
-	"strings"
 	"testing"
 
 	log "github.com/sirupsen/logrus"
@@ -74,49 +73,4 @@ func TestDeleteTeam(t *testing.T) {
 			})
 		}
 	})
-
-	t.Run("team ID format validation", func(t *testing.T) {
-		tests := []struct {
-			name        string
-			teamID      string
-			expectValid bool
-		}{
-			{"valid team ID", "team-abc123def456", true},
-			{"valid short team ID", "team-abc123", true},
-			{"invalid format - no prefix", "abc123def456", false},
-			{"invalid format - wrong prefix", "workspace-abc123", false},
-			{"empty team ID", "", false},
-			{"only prefix", "team-", false},
-		}
-
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				// Simple validation: team ID should start with "team-" and have content after
-				isValid := strings.HasPrefix(tt.teamID, "team-") && len(tt.teamID) > 5
-				assert.Equal(t, tt.expectValid, isValid)
-			})
-		}
-	})
-
-	t.Run("team ID sanitisation", func(t *testing.T) {
-		tests := []struct {
-			name     string
-			input    string
-			expected string
-		}{
-			{"clean ID unchanged", "team-abc123def456", "team-abc123def456"},
-			{"leading slash", "/team-abc123def456", "team-abc123def456"},
-			{"multiple leading slashes", "///team-abc123def456", "team-abc123def456"},
-			{"leading whitespace only", "  team-abc123def456", "team-abc123def456"},
-			{"leading whitespace and slash", "  /team-abc123def456", "team-abc123def456"},
-		}
-
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				cleaned := strings.TrimLeft(strings.TrimSpace(tt.input), "/")
-				assert.Equal(t, tt.expected, cleaned)
-			})
-		}
-	})
-
 }

--- a/pkg/tools/tfe/delete_team_test.go
+++ b/pkg/tools/tfe/delete_team_test.go
@@ -98,4 +98,25 @@ func TestDeleteTeam(t *testing.T) {
 		}
 	})
 
+	t.Run("team ID sanitisation", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			input    string
+			expected string
+		}{
+			{"clean ID unchanged", "team-abc123def456", "team-abc123def456"},
+			{"leading slash", "/team-abc123def456", "team-abc123def456"},
+			{"multiple leading slashes", "///team-abc123def456", "team-abc123def456"},
+			{"leading whitespace only", "  team-abc123def456", "team-abc123def456"},
+			{"leading whitespace and slash", "  /team-abc123def456", "team-abc123def456"},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				cleaned := strings.TrimLeft(strings.TrimSpace(tt.input), "/")
+				assert.Equal(t, tt.expected, cleaned)
+			})
+		}
+	})
+
 }

--- a/pkg/tools/tfe/force_unlock_workspace.go
+++ b/pkg/tools/tfe/force_unlock_workspace.go
@@ -4,10 +4,9 @@
 package tools
 
 import (
-	"fmt"
 	"context"
+	"fmt"
 	"strings"
-	"encoding/json"
 
 	"github.com/hashicorp/terraform-mcp-server/pkg/client"
 	log "github.com/sirupsen/logrus"
@@ -61,22 +60,11 @@ func forceUnlockWorkspace(ctx context.Context, request mcp.CallToolRequest, logg
 	if !workspace.Locked {
 		return ToolErrorf(logger, "workspace %q is not locked", workspaceID)
 	}
-	
+
 	workspace, err = tfeClient.Workspaces.ForceUnlock(ctx, workspaceID)
 	if err != nil {
 		return ToolErrorf(logger, "failed to force unlock workspace %q. This is the reported error: %v", workspaceID, err)
 	}
 
-	result := map[string]interface{}{
-		"Success": true,
-		"msg": fmt.Sprintf("Workspace %q is now unlocked", workspaceID),
-	}
-
-	resultJSON, err := json.Marshal(result)
-
-	if err != nil {
-		return ToolError(logger, "failed to marshal result", err)
-	}
-
-	return mcp.NewToolResultText(string(resultJSON)), nil
+	return mcp.NewToolResultText(fmt.Sprintf("Workspace %q is now unlocked", workspaceID)), nil
 }

--- a/pkg/toolsets/mapping.go
+++ b/pkg/toolsets/mapping.go
@@ -79,7 +79,6 @@ var ToolToToolset = map[string]string{
 	"list_state_versions":                 Terraform,
 	"get_state_version":                   Terraform,
 	"get_run_comments":                    Terraform,
-	"delete_team":                         Terraform,
 }
 
 // GetToolsetForTool returns the toolset name for a given tool name

--- a/pkg/toolsets/mapping.go
+++ b/pkg/toolsets/mapping.go
@@ -41,6 +41,7 @@ var ToolToToolset = map[string]string{
 	"get_team":          Terraform,
 	"add_team_member":   Terraform,
 	"grant_team_access": Terraform,
+	"delete_team":       Terraform,
 
 	// Terraform tools - Workspace management
 	"list_workspaces":                     Terraform,

--- a/pkg/toolsets/mapping.go
+++ b/pkg/toolsets/mapping.go
@@ -79,6 +79,7 @@ var ToolToToolset = map[string]string{
 	"list_state_versions":                 Terraform,
 	"get_state_version":                   Terraform,
 	"get_run_comments":                    Terraform,
+	"delete_team":                         Terraform,
 }
 
 // GetToolsetForTool returns the toolset name for a given tool name

--- a/pkg/toolsets/mapping.go
+++ b/pkg/toolsets/mapping.go
@@ -23,63 +23,75 @@ var ToolToToolset = map[string]string{
 	"search_private_providers":     RegistryPrivate,
 	"get_private_provider_details": RegistryPrivate,
 
-	// Terraform Tools - User
-	"whoami": Terraform,
+	// Terraform tools - User
+	"whoami":                Terraform,
+	"get_token_permissions": Terraform,
 
 	// Terraform tools - Organization
 	"list_terraform_orgs": Terraform,
 
-	// Terraform tools - Project
+	// Terraform tools - Projects
 	"list_terraform_projects": Terraform,
 	"create_project":          Terraform,
-	"delete_project":          Terraform,
 	"get_project":             Terraform,
+	"delete_project":          Terraform,
 
-	// Terraform tools - Team
-	"create_team":       Terraform,
+	// Terraform tools - Teams
 	"list_teams":        Terraform,
 	"get_team":          Terraform,
+	"create_team":       Terraform,
 	"add_team_member":   Terraform,
 	"grant_team_access": Terraform,
 	"delete_team":       Terraform,
 
-	// Terraform tools - Workspace management
-	"list_workspaces":                     Terraform,
-	"get_workspace_details":               Terraform,
-	"create_workspace":                    Terraform,
-	"create_no_code_workspace":            Terraform,
-	"update_workspace":                    Terraform,
-	"delete_workspace_safely":             Terraform,
-	"list_runs":                           Terraform,
-	"get_run_details":                     Terraform,
-	"get_plan_details":                    Terraform,
-	"get_plan_logs":                       Terraform,
-	"get_plan_json_output":                Terraform,
-	"get_apply_details":                   Terraform,
-	"get_apply_logs":                      Terraform,
-	"get_sentinel_mock":                   Terraform,
-	"create_run":                          Terraform,
-	"action_run":                          Terraform,
-	"list_workspace_variables":            Terraform,
-	"create_workspace_variable":           Terraform,
-	"update_workspace_variable":           Terraform,
+	// Terraform tools - Workspaces
+	"list_workspaces":          Terraform,
+	"get_workspace_details":    Terraform,
+	"create_workspace":         Terraform,
+	"create_no_code_workspace": Terraform,
+	"update_workspace":         Terraform,
+	"delete_workspace_safely":  Terraform,
+	"force_unlock_workspace":   Terraform,
+
+	// Terraform tools - Runs and Plans
+	"list_runs":            Terraform,
+	"get_run_details":      Terraform,
+	"get_run_comments":     Terraform,
+	"create_run":           Terraform,
+	"action_run":           Terraform,
+	"get_plan_details":     Terraform,
+	"get_plan_logs":        Terraform,
+	"get_plan_json_output": Terraform,
+	"get_apply_details":    Terraform,
+	"get_apply_logs":       Terraform,
+	"get_sentinel_mock":    Terraform,
+
+	// Terraform tools - Workspace Variables
+	"list_workspace_variables":  Terraform,
+	"create_workspace_variable": Terraform,
+	"update_workspace_variable": Terraform,
+
+	// Terraform tools - Variable Sets
 	"list_variable_sets":                  Terraform,
 	"create_variable_set":                 Terraform,
 	"create_variable_in_variable_set":     Terraform,
 	"delete_variable_in_variable_set":     Terraform,
 	"attach_variable_set_to_workspaces":   Terraform,
 	"detach_variable_set_from_workspaces": Terraform,
-	"create_workspace_tags":               Terraform,
-	"read_workspace_tags":                 Terraform,
-	"attach_policy_set_to_workspaces":     Terraform,
-	"get_token_permissions":               Terraform,
-	"list_stacks":                         Terraform,
-	"get_stack_details":                   Terraform,
-	"list_workspace_policy_sets":          Terraform,
-	"force_unlock_workspace":              Terraform,
-	"list_state_versions":                 Terraform,
-	"get_state_version":                   Terraform,
-	"get_run_comments":                    Terraform,
+
+	// Terraform tools - Tags and Policies
+	"create_workspace_tags":           Terraform,
+	"read_workspace_tags":             Terraform,
+	"attach_policy_set_to_workspaces": Terraform,
+	"list_workspace_policy_sets":      Terraform,
+
+	// Terraform tools - Stacks
+	"list_stacks":       Terraform,
+	"get_stack_details": Terraform,
+
+	// Terraform tools - State Versions
+	"list_state_versions": Terraform,
+	"get_state_version":   Terraform,
 }
 
 // GetToolsetForTool returns the toolset name for a given tool name

--- a/test/terraform/teams_test.go
+++ b/test/terraform/teams_test.go
@@ -340,3 +340,44 @@ func TestGrantTeamAccess(t *testing.T) {
 		assert.Contains(t, resultText, "Invalid Team Project access level")
 	})
 }
+
+func TestDeleteTeam(t *testing.T) {
+	requireTfOperations(t)
+
+	client := tfeClient(t)
+	requireTeamsEntitlement(t, client)
+
+	s := newTestingSession(t)
+	defer s.Close()
+
+	// Create a team directly via the TFE API — independent of the tool under test.
+	team, err := client.Teams.Create(t.Context(), tfeOrgName, tfe.TeamCreateOptions{
+		Name: tfe.String(randomName("team-")),
+	})
+	require.NoError(t, err, "setup: failed to create team via TFE API")
+
+	// Safety net: if the delete tool fails mid-test, clean up via the API.
+	defer client.Teams.Delete(t.Context(), team.ID)
+
+	t.Run("deletes an existing team", func(t *testing.T) {
+		result, resultText := callTool(t, s, "delete_team", map[string]any{
+			"team_id": team.ID,
+		})
+
+		require.False(t, result.IsError, "delete_team should not return an error for an existing team: %s", resultText)
+		assert.Contains(t, resultText, team.ID, "response should reference the deleted team_id")
+
+		// Confirm the team is gone via the API directly.
+		_, err := client.Teams.Read(t.Context(), team.ID)
+		assert.Error(t, err, "team should no longer exist in the TFE API after deletion")
+	})
+
+	t.Run("returns an error for a non-existent team_id", func(t *testing.T) {
+		result, resultText := callTool(t, s, "delete_team", map[string]any{
+			"team_id": "team-doesnotexist000",
+		})
+
+		require.True(t, result.IsError, "delete_team should return an error for a non-existent team_id")
+		assert.Contains(t, resultText, "team-doesnotexist000", "error message should reference the unknown team_id")
+	})
+}


### PR DESCRIPTION
## New Tool: `delete_team`

Permanently deletes a Terraform team by its `team_id`. Removes all team memberships and any workspace or project access granted through the team. Organization users and workspaces are not affected.

### Changes

- `pkg/tools/tfe/delete_team.go` — tool definition and handler
- `pkg/tools/tfe/delete_team_test.go` — unit tests 
- `pkg/tools/dynamic_tool.go` — registers `delete_team` behind `ENABLE_TF_OPERATIONS`
- `pkg/toolsets/mapping.go` — maps `delete_team` to the `terraform` toolset and organized toolset mapping
- `pkg/tools/tfe/action_run.go` — replaced JSON map response with plain text confirmation
- `pkg/tools/tfe/force_unlock_workspace.go` — replaced JSON map response with plain text confirmation
- `CHANGELOG.md` — entry added under `1.3.0` FEATURES
- `test/terraform/teams_test.go` — integration tests in `TestDeleteTeam`

### Inputs / Output

**Required:** `team_id` (e.g. `team-abc123def456`)

**Returns:** `Team "team-abc123def456" deleted`

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
