### PR TITLE
fix(action_run): update test assertions to match plain-text response

### DIFF
--- a/test/terraform/run_test.go
+++ b/test/terraform/run_test.go
@@ -204,7 +204,6 @@ func TestRunLifecycle(t *testing.T) {
 		assert.JSONEq(t, string(directJSON), resultText)
 	})
 
-	var actionRunID string
 	t.Run("Action run", func(t *testing.T) {
 		result, resultText := callTool(t, s, "action_run", map[string]any{
 			"run_id":     runID,
@@ -213,17 +212,13 @@ func TestRunLifecycle(t *testing.T) {
 		})
 		require.False(t, result.IsError, "action_run should not return an error")
 		require.NotEmpty(t, resultText, "action_run response must not be empty")
-		actionSucceeded := gjson.Get(resultText, "success").Bool()
-		actionRunID = gjson.Get(resultText, "run_id").String()
-		assert.True(t, actionSucceeded)
-		assert.Equal(t, runID, actionRunID)
 	})
 
 	// action_run starts applying asynchronously; wait until the apply finishes.
 	appliedRun := waitForRun(t, client, runID, "finish applying", func(run *tfe.Run) bool {
 		return run.Status == tfe.RunApplied
 	})
-	assert.Equal(t, appliedRun.ID, actionRunID)
+	assert.Equal(t, appliedRun.ID, runID)
 	require.NotNil(t, appliedRun.Apply, "the applied run should have an apply")
 	applyID := appliedRun.Apply.ID
 	require.NotEmpty(t, applyID, "the applied run should have an apply ID")


### PR DESCRIPTION
The action_run handler was simplified to return a plain success message instead of a JSON object, because the JSON fields (success, run_id, message) were redundant they should return a simple success or failure message, not a full JSON object.

The test assertions that parsed "success" and "run_id" from the response are removed since those fields no longer exist. The post-apply check now uses the run ID that is already in scope rather than extracting it from the response.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
