### PR TITLE
Add HCPT integration tests for `State Version` management tools

### DIFF
--- a/pkg/tools/tfe/get_state_version.go
+++ b/pkg/tools/tfe/get_state_version.go
@@ -42,8 +42,8 @@ func GetStateVersion(logger *log.Logger) server.ServerTool {
 
 // getStateVersionWithIDHandler handles tool logics and functionality
 func getStateVersionWithIDHandler(ctx context.Context, request mcp.CallToolRequest, logger *log.Logger) (*mcp.CallToolResult, error) {
-	stateVersionID := request.GetString("state_version_id", "")
-	workspaceID := request.GetString("workspace_id", "")
+	stateVersionID := GetTrimmedString(request, "state_version_id", "")
+	workspaceID := GetTrimmedString(request, "workspace_id", "")
 
 	stateVersionID = strings.TrimLeft(strings.TrimSpace(stateVersionID), "#")
 	workspaceID = strings.TrimLeft(strings.TrimSpace(workspaceID), "#")
@@ -57,7 +57,6 @@ func getStateVersionWithIDHandler(ctx context.Context, request mcp.CallToolReque
 	}
 
 	var sv *tfe.StateVersion
-
 	if stateVersionID == "" && workspaceID == "" {
 		return ToolError(logger, "One of state_version_id or workspace_id must be provided", nil)
 	}
@@ -75,6 +74,5 @@ func getStateVersionWithIDHandler(ctx context.Context, request mcp.CallToolReque
 	if err != nil {
 		return ToolError(logger, "failed to marshal state version", err)
 	}
-
 	return mcp.NewToolResultText(buf.String()), nil
 }

--- a/pkg/tools/tfe/get_state_version.go
+++ b/pkg/tools/tfe/get_state_version.go
@@ -32,12 +32,10 @@ func GetStateVersion(logger *log.Logger) server.ServerTool {
 				mcp.Description("Optional Workspace id to fetch latest version"),
 			),
 		),
-
 		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			return getStateVersionWithIDHandler(ctx, request, logger)
 		},
 	}
-
 }
 
 // getStateVersionWithIDHandler handles tool logics and functionality

--- a/pkg/tools/tfe/get_state_version.go
+++ b/pkg/tools/tfe/get_state_version.go
@@ -41,10 +41,12 @@ func GetStateVersion(logger *log.Logger) server.ServerTool {
 }
 
 // getStateVersionWithIDHandler handles tool logics and functionality
-func getStateVersionWithIDHandler(
-	ctx context.Context,
-	request mcp.CallToolRequest,
-	logger *log.Logger) (*mcp.CallToolResult, error) {
+func getStateVersionWithIDHandler(ctx context.Context, request mcp.CallToolRequest, logger *log.Logger) (*mcp.CallToolResult, error) {
+	stateVersionID := request.GetString("state_version_id", "")
+	workspaceID := request.GetString("workspace_id", "")
+
+	stateVersionID = strings.TrimLeft(strings.TrimSpace(stateVersionID), "#")
+	workspaceID = strings.TrimLeft(strings.TrimSpace(workspaceID), "#")
 
 	tfeClient, err := client.GetTfeClientFromContext(ctx, logger)
 	if err != nil {
@@ -53,12 +55,6 @@ func getStateVersionWithIDHandler(
 	if tfeClient == nil {
 		return ToolError(logger, "Failed to get Terraform client - ensure TFE_TOKEN and TFE_ADDRESS are configured", nil)
 	}
-
-	stateVersionID := request.GetString("state_version_id", "")
-	stateVersionID = strings.TrimLeft(strings.TrimSpace(stateVersionID), "#")
-
-	workspaceID := request.GetString("workspace_id", "")
-	workspaceID = strings.TrimLeft(strings.TrimSpace(workspaceID), "#")
 
 	var sv *tfe.StateVersion
 

--- a/pkg/tools/tfe/get_state_version.go
+++ b/pkg/tools/tfe/get_state_version.go
@@ -4,11 +4,12 @@
 package tools
 
 import (
+	"bytes"
 	"context"
-	"encoding/json"
 	"strings"
 
 	"github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/jsonapi"
 	"github.com/hashicorp/terraform-mcp-server/pkg/client"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -73,10 +74,11 @@ func getStateVersionWithIDHandler(
 		return ToolError(logger, "Failed to get state version", err)
 	}
 
-	svJSON, err := json.Marshal(sv)
+	buf := bytes.NewBuffer(nil)
+	err = jsonapi.MarshalPayloadWithoutIncluded(buf, sv)
 	if err != nil {
-		return ToolError(logger, "Failed to serialize state version", err)
+		return ToolError(logger, "failed to marshal state version", err)
 	}
 
-	return mcp.NewToolResultText(string(svJSON)), nil
+	return mcp.NewToolResultText(buf.String()), nil
 }

--- a/pkg/tools/tfe/get_state_version.go
+++ b/pkg/tools/tfe/get_state_version.go
@@ -56,14 +56,11 @@ func getStateVersionWithIDHandler(ctx context.Context, request mcp.CallToolReque
 	}
 	if stateVersionID != "" {
 		sv, err = tfeClient.StateVersions.Read(ctx, stateVersionID)
-		if err != nil {
-			return ToolErrorf(logger, "Failed to get state version %s: %v", stateVersionID, err)
-		}
 	} else {
 		sv, err = tfeClient.StateVersions.ReadCurrent(ctx, workspaceID)
-		if err != nil {
-			return ToolErrorf(logger, "Failed to get current state version for workspace %s: %v", workspaceID, err)
-		}
+	}
+	if err != nil {
+		return ToolError(logger, "Failed to get state version", err)
 	}
 
 	buf := bytes.NewBuffer(nil)

--- a/pkg/tools/tfe/get_state_version.go
+++ b/pkg/tools/tfe/get_state_version.go
@@ -6,7 +6,6 @@ package tools
 import (
 	"bytes"
 	"context"
-	"strings"
 
 	"github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/jsonapi"
@@ -43,9 +42,6 @@ func getStateVersionWithIDHandler(ctx context.Context, request mcp.CallToolReque
 	stateVersionID := GetTrimmedString(request, "state_version_id", "")
 	workspaceID := GetTrimmedString(request, "workspace_id", "")
 
-	stateVersionID = strings.TrimLeft(strings.TrimSpace(stateVersionID), "#")
-	workspaceID = strings.TrimLeft(strings.TrimSpace(workspaceID), "#")
-
 	tfeClient, err := client.GetTfeClientFromContext(ctx, logger)
 	if err != nil {
 		return ToolError(logger, "Failed to get Terraform client", err)
@@ -60,11 +56,14 @@ func getStateVersionWithIDHandler(ctx context.Context, request mcp.CallToolReque
 	}
 	if stateVersionID != "" {
 		sv, err = tfeClient.StateVersions.Read(ctx, stateVersionID)
+		if err != nil {
+			return ToolErrorf(logger, "Failed to get state version %s: %v", stateVersionID, err)
+		}
 	} else {
 		sv, err = tfeClient.StateVersions.ReadCurrent(ctx, workspaceID)
-	}
-	if err != nil {
-		return ToolError(logger, "Failed to get state version", err)
+		if err != nil {
+			return ToolErrorf(logger, "Failed to get current state version for workspace %s: %v", workspaceID, err)
+		}
 	}
 
 	buf := bytes.NewBuffer(nil)

--- a/pkg/tools/tfe/list_state_versions.go
+++ b/pkg/tools/tfe/list_state_versions.go
@@ -44,11 +44,7 @@ func ListStateVersions(logger *log.Logger) server.ServerTool {
 }
 
 // listStateVersionsHandler handles tool logics and functionality
-func listStateVersionsHandler(
-	ctx context.Context,
-	request mcp.CallToolRequest,
-	logger *log.Logger) (*mcp.CallToolResult, error) {
-
+func listStateVersionsHandler(ctx context.Context, request mcp.CallToolRequest, logger *log.Logger) (*mcp.CallToolResult, error) {
 	tfeClient, err := client.GetTfeClientFromContext(ctx, logger)
 	if err != nil {
 		return ToolError(logger, "Failed to get Terraform client", err)
@@ -108,9 +104,7 @@ func listStateVersionsHandler(
 	if err != nil {
 		return ToolError(logger, "Failed to marshal organization names", err)
 	}
-
 	return mcp.NewToolResultText(string(svJSON)), nil
-
 }
 
 // StateVersionsSummary is a truncated summary of State Version details for listing

--- a/test/terraform/run_test.go
+++ b/test/terraform/run_test.go
@@ -1,9 +1,6 @@
 package terraform
 
 import (
-	"archive/tar"
-	"bytes"
-	"compress/gzip"
 	"context"
 	_ "embed"
 	"fmt"
@@ -253,32 +250,10 @@ func TestRunLifecycle(t *testing.T) {
 	})
 }
 
-// packages the HCL as a gzipped tar archive and uploads it to the workspace.
+// uploadRunTestConfiguration uploads the shared run test fixture to the workspace.
 func uploadRunTestConfiguration(t *testing.T, client *tfe.Client, workspaceID string) {
 	t.Helper()
-
-	// Package main.tf as gzip(tar(main.tf)) entirely in memory.
-	var archive bytes.Buffer
-	gzipWriter := gzip.NewWriter(&archive)
-	tarWriter := tar.NewWriter(gzipWriter)
-	configuration := []byte(runTestConfiguration)
-
-	require.NoError(t, tarWriter.WriteHeader(&tar.Header{
-		Name: "main.tf",
-		Mode: 0o600,
-		Size: int64(len(configuration)),
-	}))
-	_, err := tarWriter.Write(configuration)
-	require.NoError(t, err)
-	require.NoError(t, tarWriter.Close())
-	require.NoError(t, gzipWriter.Close())
-
-	// Create the configuration-version record without auto-queuing a run.
-	configurationVersion, err := client.ConfigurationVersions.Create(t.Context(), workspaceID, tfe.ConfigurationVersionCreateOptions{
-		AutoQueueRuns: tfe.Bool(false),
-	})
-	require.NoError(t, err, "failed to create a configuration version")
-	require.NoError(t, client.ConfigurationVersions.UploadTarGzip(t.Context(), configurationVersion.UploadURL, &archive), "failed to upload the test configuration")
+	uploadConfiguration(t, client, workspaceID, runTestConfiguration)
 }
 
 // waitForRun polls TFE until the run reaches the requested condition or times out.

--- a/test/terraform/state_version_test.go
+++ b/test/terraform/state_version_test.go
@@ -4,6 +4,7 @@
 package terraform
 
 import (
+	_ "embed"
 	"testing"
 
 	"github.com/hashicorp/go-tfe"
@@ -11,6 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 )
+
+//go:embed testdata/state_version_test.tf
+var stateVersionTestConfiguration string
 
 func TestListStateVersionsHappyPath(t *testing.T) {
 	requireTfOperations(t)
@@ -33,9 +37,9 @@ func TestListStateVersionsHappyPath(t *testing.T) {
 
 	// Upload a Terraform configuration then create and apply a run via the TFE
 	// client directly — we are only testing list_state_versions here.
-	uploadRunTestConfiguration(t, client, workspace.ID)
+	uploadStateVersionTestConfiguration(t, client, workspace.ID)
 
-	runMessage := "Created by terraform-mcp-server state version integration tests"
+	runMessage := "Created by terraform-mcp-server list state version integration tests"
 	run, err := client.Runs.Create(t.Context(), tfe.RunCreateOptions{
 		Workspace: workspace,
 		AutoApply: tfe.Bool(false),
@@ -90,8 +94,8 @@ func TestListStateVersionsErrorPaths(t *testing.T) {
 
 	client := tfeClient(t)
 
-	nonExistentOrg := randomName("org-")
-	nonExistentWs := randomName("workspace-")
+	nonExistentOrg := "org-doesnotexist123"
+	nonExistentWs := "ws-doesnotexist123"
 
 	t.Run("list_state_versions non-existent org", func(t *testing.T) {
 		result, _ := callTool(t, s, "list_state_versions", map[string]any{
@@ -143,7 +147,10 @@ func TestGetStateVersionHappyPath(t *testing.T) {
 	require.NoError(t, err, "failed to create test workspace")
 	defer client.Workspaces.DeleteByID(t.Context(), workspace.ID)
 
-	uploadRunTestConfiguration(t, client, workspace.ID)
+	// Upload a Terraform configuration then create and apply a run via the TFE
+	// client directly — we are only testing list_state_versions here.
+	uploadStateVersionTestConfiguration(t, client, workspace.ID)
+
 	runMessage := "Created by terraform-mcp-server get state version integration tests"
 	run, err := client.Runs.Create(t.Context(), tfe.RunCreateOptions{
 		Workspace: workspace,
@@ -169,9 +176,15 @@ func TestGetStateVersionHappyPath(t *testing.T) {
 	require.NotEmpty(t, stateVersions.Items, "applied run should create a state version")
 	stateVersion := stateVersions.Items[0]
 
+	// Download the raw state file once and reuse it across sub-tests so we only
+	// hit the download URL a single time.
+	stateBytes, err := client.StateVersions.Download(t.Context(), stateVersion.DownloadURL)
+	require.NoError(t, err, "failed to download state file")
+	stateJSON := string(stateBytes)
+
 	t.Run("gets an exact state version by state_version_id", func(t *testing.T) {
 		result, resultText := callTool(t, s, "get_state_version", map[string]any{
-			"state_version_id": "#" + stateVersion.ID,
+			"state_version_id": stateVersion.ID,
 		})
 
 		require.False(t, result.IsError, "get_state_version should not return an error")
@@ -179,16 +192,24 @@ func TestGetStateVersionHappyPath(t *testing.T) {
 		assert.Equal(t, stateVersion.ID, gjson.Get(resultText, "data.id").String())
 		assert.Equal(t, stateVersion.Serial, gjson.Get(resultText, "data.attributes.serial").Int())
 		assert.NotEmpty(t, gjson.Get(resultText, "data.attributes.created-at").String())
+
+		// Verify the state file contains the resources from the test fixture.
+		assert.Contains(t, stateJSON, `"name": "resource_one"`, "state file should contain resource_one from the test fixture")
+		assert.Contains(t, stateJSON, `"name": "resource_two"`, "state file should contain resource_two from the test fixture")
 	})
 
 	t.Run("gets the current state version by workspace_id", func(t *testing.T) {
 		result, resultText := callTool(t, s, "get_state_version", map[string]any{
-			"workspace_id": "#" + workspace.ID,
+			"workspace_id": workspace.ID,
 		})
 
 		require.False(t, result.IsError, "get_state_version should not return an error")
 		require.NotEmpty(t, resultText, "get_state_version response must not be empty")
 		assert.Equal(t, stateVersion.ID, gjson.Get(resultText, "data.id").String())
+
+		// Verify the state file contains the resources from the test fixture.
+		assert.Contains(t, stateJSON, `"name": "resource_one"`, "state file should contain resource_one from the test fixture")
+		assert.Contains(t, stateJSON, `"name": "resource_two"`, "state file should contain resource_two from the test fixture")
 	})
 }
 
@@ -198,6 +219,9 @@ func TestGetStateVersionErrorPaths(t *testing.T) {
 	s := newTestingSession(t)
 	defer s.Close()
 
+	nonExistentSV := "sv-doesnotexist123"
+	nonExistentWs := "ws-doesnotexist123"
+
 	t.Run("requires a state version or workspace ID", func(t *testing.T) {
 		result, resultText := callTool(t, s, "get_state_version", map[string]any{})
 		require.True(t, result.IsError, "get_state_version without an identifier should return an error")
@@ -205,18 +229,20 @@ func TestGetStateVersionErrorPaths(t *testing.T) {
 	})
 
 	t.Run("rejects a non-existent state version", func(t *testing.T) {
-		result, resultText := callTool(t, s, "get_state_version", map[string]any{
-			"state_version_id": "sv-0000000000dead",
+		result, _ := callTool(t, s, "get_state_version", map[string]any{
+			"state_version_id": nonExistentSV,
 		})
 		require.True(t, result.IsError, "get_state_version should return an error for an unknown state version")
-		assert.Contains(t, resultText, "sv-0000000000dead")
 	})
 
 	t.Run("rejects a non-existent workspace", func(t *testing.T) {
-		result, resultText := callTool(t, s, "get_state_version", map[string]any{
-			"workspace_id": "ws-0000000000dead",
+		result, _ := callTool(t, s, "get_state_version", map[string]any{
+			"workspace_id": nonExistentWs,
 		})
 		require.True(t, result.IsError, "get_state_version should return an error for an unknown workspace")
-		assert.Contains(t, resultText, "ws-0000000000dead")
 	})
+}
+
+func uploadStateVersionTestConfiguration(t *testing.T, client *tfe.Client, workspaceID string) {
+	uploadConfiguration(t, client, workspaceID, stateVersionTestConfiguration)
 }

--- a/test/terraform/state_version_test.go
+++ b/test/terraform/state_version_test.go
@@ -1,0 +1,127 @@
+// Copyright IBM Corp. 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package terraform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-tfe"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestListStateVersionsHappyPath(t *testing.T) {
+	requireTfOperations(t)
+
+	s := newTestingSession(t)
+	defer s.Close()
+
+	// Create an isolated remote workspace for the run that will produce a state version.
+	client := tfeClient(t)
+	workspaceName := randomName("sv-test-")
+	executionMode := "remote"
+
+	workspace, err := client.Workspaces.Create(t.Context(), tfeOrgName, tfe.WorkspaceCreateOptions{
+		Name:          &workspaceName,
+		ExecutionMode: &executionMode,
+		AutoApply:     tfe.Bool(false),
+	})
+	require.NoError(t, err, "failed to create test workspace")
+	defer client.Workspaces.DeleteByID(t.Context(), workspace.ID)
+
+	// Upload a Terraform configuration then create and apply a run via the TFE
+	// client directly — we are only testing list_state_versions here.
+	uploadRunTestConfiguration(t, client, workspace.ID)
+
+	runMessage := "Created by terraform-mcp-server state version integration tests"
+	run, err := client.Runs.Create(t.Context(), tfe.RunCreateOptions{
+		Workspace: workspace,
+		AutoApply: tfe.Bool(false),
+		Message:   &runMessage,
+	})
+	require.NoError(t, err, "failed to create run")
+
+	waitForRun(t, client, run.ID, "become confirmable", func(r *tfe.Run) bool {
+		return r.Actions != nil && r.Actions.IsConfirmable
+	})
+
+	applyComment := "Approved by state version integration tests"
+	require.NoError(t, client.Runs.Apply(t.Context(), run.ID, tfe.RunApplyOptions{Comment: &applyComment}), "failed to apply run")
+
+	// A state version is only created after a successful apply.
+	waitForRun(t, client, run.ID, "finish applying", func(r *tfe.Run) bool {
+		return r.Status == tfe.RunApplied
+	})
+
+	t.Run("list_state_versions returns at least one state version", func(t *testing.T) {
+		svResult, svText := callTool(t, s, "list_state_versions", map[string]any{
+			"terraform_org_name": tfeOrgName,
+			"workspace_name":     workspaceName,
+		})
+		require.False(t, svResult.IsError, "list_state_versions should not return an error")
+		require.NotEmpty(t, svText, "list_state_versions response must not be empty")
+
+		require.Greater(t, int(gjson.Get(svText, "items.#").Int()), 0, "list_state_versions should return at least one item")
+
+		toolSVID := gjson.Get(svText, "items.0.id").String()
+		require.NotEmpty(t, toolSVID, "state version item should have an id")
+
+		// Cross-verify against the TFE API directly.
+		svList, err := client.StateVersions.List(t.Context(), &tfe.StateVersionListOptions{
+			Organization: tfeOrgName,
+			Workspace:    workspaceName,
+		})
+		require.NoError(t, err, "TFE API should be able to list state versions")
+		require.NotEmpty(t, svList.Items, "TFE API should return at least one state version")
+		assert.Equal(t, svList.Items[0].ID, toolSVID, "tool state version ID should match the TFE API")
+
+		// Verify the summary fields are populated.
+		assert.NotEmpty(t, gjson.Get(svText, "items.0.created_at").String(), "state version should have a created_at timestamp")
+		assert.NotEmpty(t, gjson.Get(svText, "items.0.terraform_version").String(), "state version should include the terraform_version")
+		assert.True(t, gjson.Get(svText, "items.0.serial").Exists(), "state version should include a serial number")
+	})
+}
+
+func TestListStateVersionsErrorPaths(t *testing.T) {
+	s := newTestingSession(t)
+	defer s.Close()
+
+	client := tfeClient(t)
+
+	nonExistentOrg := randomName("org-")
+	nonExistentWs := randomName("workspace-")
+
+	t.Run("list_state_versions non-existent org", func(t *testing.T) {
+		result, _ := callTool(t, s, "list_state_versions", map[string]any{
+			"terraform_org_name": nonExistentOrg,
+			"workspace_name":     nonExistentWs,
+		})
+		assert.True(t, result.IsError, "list_state_versions with a non-existent org should return an error")
+	})
+
+	t.Run("list_state_versions non-existent workspace", func(t *testing.T) {
+		result, _ := callTool(t, s, "list_state_versions", map[string]any{
+			"terraform_org_name": tfeOrgName,
+			"workspace_name":     nonExistentWs,
+		})
+		assert.True(t, result.IsError, "list_state_versions with a non-existent workspace should return an error")
+	})
+
+	t.Run("list_state_versions empty workspace has no state versions", func(t *testing.T) {
+		// Create a real workspace that has never had a run — it will have no state versions.
+		wsName := randomName("sv-empty-")
+		workspace, err := client.Workspaces.Create(t.Context(), tfeOrgName, tfe.WorkspaceCreateOptions{
+			Name: &wsName,
+		})
+		require.NoError(t, err, "failed to create empty test workspace")
+		defer client.Workspaces.DeleteByID(t.Context(), workspace.ID)
+
+		result, _ := callTool(t, s, "list_state_versions", map[string]any{
+			"terraform_org_name": tfeOrgName,
+			"workspace_name":     wsName,
+		})
+		assert.True(t, result.IsError, "list_state_versions on a workspace with no state should return an error")
+	})
+}

--- a/test/terraform/state_version_test.go
+++ b/test/terraform/state_version_test.go
@@ -125,3 +125,98 @@ func TestListStateVersionsErrorPaths(t *testing.T) {
 		assert.True(t, result.IsError, "list_state_versions on a workspace with no state should return an error")
 	})
 }
+
+func TestGetStateVersionHappyPath(t *testing.T) {
+	requireTfOperations(t)
+
+	s := newTestingSession(t)
+	defer s.Close()
+
+	client := tfeClient(t)
+	workspaceName := randomName("sv-get-")
+	executionMode := "remote"
+	workspace, err := client.Workspaces.Create(t.Context(), tfeOrgName, tfe.WorkspaceCreateOptions{
+		Name:          &workspaceName,
+		ExecutionMode: &executionMode,
+		AutoApply:     tfe.Bool(false),
+	})
+	require.NoError(t, err, "failed to create test workspace")
+	defer client.Workspaces.DeleteByID(t.Context(), workspace.ID)
+
+	uploadRunTestConfiguration(t, client, workspace.ID)
+	runMessage := "Created by terraform-mcp-server get state version integration tests"
+	run, err := client.Runs.Create(t.Context(), tfe.RunCreateOptions{
+		Workspace: workspace,
+		AutoApply: tfe.Bool(false),
+		Message:   &runMessage,
+	})
+	require.NoError(t, err, "failed to create run")
+
+	waitForRun(t, client, run.ID, "become confirmable", func(r *tfe.Run) bool {
+		return r.Actions != nil && r.Actions.IsConfirmable
+	})
+	applyComment := "Approved by get state version integration tests"
+	require.NoError(t, client.Runs.Apply(t.Context(), run.ID, tfe.RunApplyOptions{Comment: &applyComment}), "failed to apply run")
+	waitForRun(t, client, run.ID, "finish applying", func(r *tfe.Run) bool {
+		return r.Status == tfe.RunApplied
+	})
+
+	stateVersions, err := client.StateVersions.List(t.Context(), &tfe.StateVersionListOptions{
+		Organization: tfeOrgName,
+		Workspace:    workspaceName,
+	})
+	require.NoError(t, err, "failed to list created state versions")
+	require.NotEmpty(t, stateVersions.Items, "applied run should create a state version")
+	stateVersion := stateVersions.Items[0]
+
+	t.Run("gets an exact state version by state_version_id", func(t *testing.T) {
+		result, resultText := callTool(t, s, "get_state_version", map[string]any{
+			"state_version_id": "#" + stateVersion.ID,
+		})
+
+		require.False(t, result.IsError, "get_state_version should not return an error")
+		require.NotEmpty(t, resultText, "get_state_version response must not be empty")
+		assert.Equal(t, stateVersion.ID, gjson.Get(resultText, "data.id").String())
+		assert.Equal(t, stateVersion.Serial, gjson.Get(resultText, "data.attributes.serial").Int())
+		assert.NotEmpty(t, gjson.Get(resultText, "data.attributes.created-at").String())
+	})
+
+	t.Run("gets the current state version by workspace_id", func(t *testing.T) {
+		result, resultText := callTool(t, s, "get_state_version", map[string]any{
+			"workspace_id": "#" + workspace.ID,
+		})
+
+		require.False(t, result.IsError, "get_state_version should not return an error")
+		require.NotEmpty(t, resultText, "get_state_version response must not be empty")
+		assert.Equal(t, stateVersion.ID, gjson.Get(resultText, "data.id").String())
+	})
+}
+
+func TestGetStateVersionErrorPaths(t *testing.T) {
+	requireTfOperations(t)
+
+	s := newTestingSession(t)
+	defer s.Close()
+
+	t.Run("requires a state version or workspace ID", func(t *testing.T) {
+		result, resultText := callTool(t, s, "get_state_version", map[string]any{})
+		require.True(t, result.IsError, "get_state_version without an identifier should return an error")
+		assert.Contains(t, resultText, "One of state_version_id or workspace_id must be provided")
+	})
+
+	t.Run("rejects a non-existent state version", func(t *testing.T) {
+		result, resultText := callTool(t, s, "get_state_version", map[string]any{
+			"state_version_id": "sv-0000000000dead",
+		})
+		require.True(t, result.IsError, "get_state_version should return an error for an unknown state version")
+		assert.Contains(t, resultText, "sv-0000000000dead")
+	})
+
+	t.Run("rejects a non-existent workspace", func(t *testing.T) {
+		result, resultText := callTool(t, s, "get_state_version", map[string]any{
+			"workspace_id": "ws-0000000000dead",
+		})
+		require.True(t, result.IsError, "get_state_version should return an error for an unknown workspace")
+		assert.Contains(t, resultText, "ws-0000000000dead")
+	})
+}

--- a/test/terraform/terraform_test.go
+++ b/test/terraform/terraform_test.go
@@ -1,6 +1,9 @@
 package terraform
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"context"
 	"math/rand"
 	"net/http"
@@ -222,4 +225,31 @@ func waitFor[T any](t *testing.T, timeout time.Duration, description string, pol
 		case <-ticker.C:
 		}
 	}
+}
+
+// packages the HCL as a gzipped tar archive and uploads it to the workspace.
+func uploadConfiguration(t *testing.T, client *tfe.Client, workspaceID string, config string) {
+	t.Helper()
+
+	var archive bytes.Buffer
+	gzipWriter := gzip.NewWriter(&archive)
+	tarWriter := tar.NewWriter(gzipWriter)
+	configuration := []byte(config)
+
+	require.NoError(t, tarWriter.WriteHeader(&tar.Header{
+		Name: "main.tf",
+		Mode: 0o600,
+		Size: int64(len(configuration)),
+	}))
+	_, err := tarWriter.Write(configuration)
+	require.NoError(t, err)
+	require.NoError(t, tarWriter.Close())
+	require.NoError(t, gzipWriter.Close())
+
+	// Create the configuration-version record without auto-queuing a run.
+	configurationVersion, err := client.ConfigurationVersions.Create(t.Context(), workspaceID, tfe.ConfigurationVersionCreateOptions{
+		AutoQueueRuns: tfe.Bool(false),
+	})
+	require.NoError(t, err, "failed to create a configuration version")
+	require.NoError(t, client.ConfigurationVersions.UploadTarGzip(t.Context(), configurationVersion.UploadURL, &archive), "failed to upload the test configuration")
 }

--- a/test/terraform/testdata/state_version_test.tf
+++ b/test/terraform/testdata/state_version_test.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.4.0"
+}
+
+resource "terraform_data" "resource_one" {
+  input = "terraform-mcp-server state version integration test - resource one"
+}
+
+resource "terraform_data" "resource_two" {
+  input = "terraform-mcp-server state version integration test - resource two"
+}
+
+output "resource_one_id" {
+  value = terraform_data.resource_one.id
+}
+
+output "resource_two_id" {
+  value = terraform_data.resource_two.id
+}


### PR DESCRIPTION
## Add: HCPT integration tests for `list_state_versions` and `get_state_version`

### Changes

- **`test/terraform/state_version_test.go`** — adds four integration test functions:
  - `TestListStateVersionsHappyPath`
  - `TestListStateVersionsErrorPaths` 
  - `TestGetStateVersionHappyPath`
  - `TestGetStateVersionErrorPaths` 

- **`test/terraform/testdata/state_version_test.tf`** — dedicated test fixture with two `terraform_data` resources, used to assert state contents after apply

- **`test/terraform/terraform_test.go`** — moves `uploadConfiguration` here as a shared primitive; each test file provides its own thin wrapper (`uploadRunTestConfiguration`, `uploadStateVersionTestConfiguration`)

- **`pkg/tools/tfe/get_state_version.go`** — error messages now include the requested state version ID or workspace ID to aid debugging

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
