### PR TITLE
Spec example

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -1,0 +1,91 @@
+# Terraform MCP Server Behavioral Specification
+
+## Status
+
+This directory specifies the externally observable behavior of the server in
+this repository. It is an implementation-derived specification, not a product
+roadmap. It records behavior that clients, operators, and compatibility tests
+can observe, including behavior that appears accidental or differs from the
+user-facing README.
+
+The implementation is authoritative when this specification and the code
+disagree. A behavior change in the implementation should update this
+specification in the same change.
+
+The key words **MUST**, **MUST NOT**, **SHOULD**, and **MAY** describe the
+current compatibility contract. They do not imply that every behavior is
+desirable.
+
+## Documents
+
+| Document | Scope |
+| --- | --- |
+| [runtime.md](runtime.md) | Process startup, MCP capabilities, transports, sessions, authentication, security, filtering, errors, resources, and observability |
+| [registry-tools.md](registry-tools.md) | Public and private Terraform Registry tool contracts |
+| [terraform-tools.md](terraform-tools.md) | HCP Terraform and Terraform Enterprise tool contracts |
+
+## Capability Summary
+
+The primary server identifies itself as `terraform-mcp-server` and can expose:
+
+| Capability | Count | Availability |
+| --- | ---: | --- |
+| Public Registry tools | 9 | Registered at startup when selected |
+| Private Registry tools | 4 | Registered after the first session constructs a TFE client when selected |
+| HCP Terraform/TFE tools | 48 | Registered after the first session constructs a TFE client when selected |
+| Concrete resources | 2 | Always registered |
+| Resource templates | 1 | Always registered |
+| Prompts | 0 | Not supported |
+
+With the CLI default `--toolsets=all`, the primary server advertises 9 tools
+before a Terraform client is constructed, 56 tools after client construction
+when `ENABLE_TF_OPERATIONS` is not `true`, and 61 tools after client
+construction when it is `true`. Client construction requires a non-empty token
+but does not prove that the token is authorized; an invalid token can therefore
+trigger advertisement while later API calls fail.
+
+An optional experimental server at `<mcp-endpoint>/official` identifies itself
+as `terraform-mcp-official` and exposes only its own `list_workspaces` tool.
+
+## Specification Conventions
+
+Tool parameter tables use these terms:
+
+| Term | Meaning |
+| --- | --- |
+| Required | The advertised JSON Schema marks the property as required |
+| Optional | The property may be omitted from the advertised input |
+| Schema default | A default advertised in JSON Schema |
+| Runtime default | The value the handler uses when the property is absent or empty |
+| Tool error | A successful JSON-RPC tool response with `isError: true` and text content |
+| Protocol error | A transport or JSON-RPC handler error with no tool result |
+| JSON text | JSON serialized into MCP text content, not MCP structured content |
+
+Unless a tool contract says otherwise:
+
+- Primary-server successes contain exactly one MCP text content item.
+- Primary-server validation and upstream API failures are tool errors.
+- HCP Terraform/TFE tools require an active session with a valid Terraform
+  client, even after the tool has become globally advertised.
+- Timestamps and dependency-owned JSON:API fields retain the formats emitted
+  by the pinned `go-tfe` and JSON:API libraries.
+- Backend authorization, licensing, and feature availability can add errors
+  beyond those enumerated here.
+
+## Compatibility Notes
+
+The specification intentionally preserves these broad implementation facts:
+
+- Tool advertisement is process-global after the first session constructs a
+  TFE client, but usable backend authorization remains session-specific.
+- Primary input schemas are advertised but not server-validated. Handler
+  accessors and explicit checks, rather than JSON Schema, define accepted input.
+- `ENABLE_TF_OPERATIONS` gates only five named tools and the destructive
+  `create_run` variant; it is not a general mutation lock.
+- Tool annotations are metadata. The MCP library fills omitted primary-tool
+  hints with defaults, and several mutating tools advertise
+  `destructiveHint: false`.
+- Most JSON-shaped results are text, not `structuredContent`.
+- JSON Schema constraints and handler validation do not always match. Known
+  behaviorally significant mismatches are stated in the relevant contracts.
+- Empty-list behavior is tool-specific and is not normalized across the API.

--- a/spec/registry-tools.md
+++ b/spec/registry-tools.md
@@ -1,0 +1,397 @@
+# Registry Tool Behavior
+
+## 1. Scope
+
+This document specifies the nine `registry` tools and four
+`registry-private` tools. All results use one MCP text content item. JSON and
+Markdown mentioned below are encoded in that text item.
+
+Public Registry tools are registered at startup when selected. Private
+Registry tools are dynamically registered after the first primary session
+constructs a TFE client when those tools are selected, and require a TFE client
+in the calling session. Client construction does not prove token authorization.
+Once registered, private tools remain globally listed after that session ends.
+
+All thirteen tools explicitly advertise `readOnlyHint: true`,
+`destructiveHint: false`, and `openWorldHint: true`. The primary MCP library's
+default also makes all thirteen advertise `idempotentHint: false`.
+
+The primary server does not validate advertised input schemas. Required fields,
+types, enums, defaults, and ranges below describe wire metadata; handler
+accessors and explicit checks define runtime acceptance. Unknown arguments are
+not rejected merely for being absent from schema, though middleware may inspect
+them. None of these tools advertises an output schema. The experimental
+official endpoint exposes no Registry tools.
+
+Provider version syntax is considered supported only when it matches
+`^v?(\d+\.\d+\.\d+(-[a-zA-Z0-9]+)?)$`. Other syntax, including dotted
+prereleases and build metadata, is treated as a request for the latest version
+where a handler performs version resolution.
+
+Shared public HTTP behavior is specified in
+[runtime.md](runtime.md#10-public-registry-http-contract). In particular,
+ordinary non-200 responses become the synthetic text `404 Not Found`.
+`search_policies` and `get_latest_module_version` include that synthetic status
+in their tool errors; several other handlers replace it with more generic text.
+
+## 2. Public Registry Tools
+
+### 2.1 `search_providers`
+
+Purpose: locate provider documentation and produce a `provider_doc_id` for
+`get_provider_details`.
+
+Annotation title:
+`Identify the most relevant provider document ID for a Terraform service`.
+
+#### Input
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `provider_name` | string | Required | Lowercased |
+| `provider_namespace` | string | Required | Lowercased; an absent/empty value reaching the handler defaults to `hashicorp` |
+| `service_slug` | string | Required | Lowercased; an empty value is rejected |
+| `provider_document_type` | string | Required; enum below | Missing/wrong-type defaults to `resources`; an explicit string is used exactly as supplied because it overwrites an earlier normalized value |
+| `provider_version` | string | Optional | Lowercased; supported syntax is accepted without existence lookup; absent, `latest`, or unsupported syntax resolves latest |
+
+`provider_document_type` accepts:
+
+```text
+resources
+data-sources
+functions
+guides
+overview
+actions
+list-resources
+```
+
+#### Behavior
+
+For a supported explicit version, the tool uses that value without first
+checking that it exists. For latest/unsupported syntax, it looks up latest in
+the requested namespace; only failure of that latest-version lookup retries in
+the `hashicorp` namespace. A later documentation or provider-version-ID failure
+does not trigger namespace fallback.
+
+Resource and data-source discovery uses public Registry v1 data and filters by
+the lowercased `service_slug`. Other document categories use v2 provider-doc
+APIs and can page until an empty page. For v2 categories, `service_slug` is
+required and checked for emptiness but does not filter results; overview always
+uses the overview/index path. Description-snippet lookup failures for
+individual matches are non-fatal.
+
+For v1 categories, success is Markdown-like text headed `Available
+Documentation` with repeated `providerDocID`, `Title`, `Category`, and
+`Description` fields. Every v2 success begins `# <provider> provider docs`.
+Non-overview v2 content then contains the same candidate-list fields; overview
+contains overview content instead.
+
+No matching v1 or non-overview v2 documents is a tool error. An overview with
+no returned document succeeds with only the provider-docs heading.
+Provider/version resolution, Registry transport, and response parsing failures
+are otherwise tool errors.
+
+Compatibility note: explicit uppercase or empty `provider_document_type` is not
+normalized at the final dispatch. It normally enters the v1 path and fails to
+match a category rather than using the advertised enum/default.
+
+### 2.2 `get_provider_details`
+
+Purpose: fetch one complete provider document selected by `search_providers`.
+
+Annotation title:
+`Fetch detailed Terraform provider documentation using a document ID`.
+
+#### Input
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `provider_doc_id` | string | Required | Must be non-empty base-10 integer text |
+
+The tool MUST call the public Registry v2 provider-document endpoint for that
+ID and return the document content verbatim. Empty, non-numeric, unknown, and
+unreadable IDs are tool errors.
+
+### 2.3 `get_latest_provider_version`
+
+Purpose: resolve the latest public version of a provider.
+
+Annotation title: `Get Latest Provider Version`.
+
+#### Input
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `namespace` | string | Required | Lowercased |
+| `name` | string | Required | Lowercased |
+
+Success MUST be only the version string. Registry and parse failures are tool
+errors.
+
+### 2.4 `get_provider_capabilities`
+
+Purpose: summarize the documentation categories supported by a provider.
+
+Annotation title:
+`Get Terraform provider capabilities and supported features`.
+
+#### Input
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `namespace` | string | Required | Lowercased |
+| `name` | string | Required | Lowercased |
+| `version` | string | Optional | Defaults to `latest`; `latest` or unsupported syntax resolves the latest version |
+
+The tool MUST fetch v1 provider documentation and count only HCL documents. It
+groups documents by category. A category with at most ten entries includes all
+entries; a larger category includes three examples and an `and N more` line.
+Categories with no entries are omitted. Category order is not stable because
+the implementation iterates a map.
+
+Success begins `Provider Capabilities: <namespace>/<name> (v<version>)`. A
+provider with no HCL capabilities returns successful text `No capabilities
+found for this provider.` Registry and parse failures are tool errors.
+
+### 2.5 `search_modules`
+
+Purpose: search public modules and produce compatible four-part `module_id`
+values for `get_module_details`.
+
+Annotation title:
+`Search and match Terraform modules based on name and relevance`.
+
+#### Input
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `module_query` | string | Required | Lowercased; an explicitly empty string is accepted and requests an unfiltered list |
+| `current_offset` | number | Optional; default 0; minimum 0 | Numbers are truncated, decimal integer strings are accepted, and unconvertible values default to 0; negative values are accepted |
+
+The tool fetches one Registry search page and sorts the returned modules by
+descending download count. Success is Markdown-like text containing, for each
+module, `module_id`, name, description, download count, verification status,
+and publication date.
+
+No results and response parsing failures are tool errors. Every Registry
+transport/status failure is deliberately relabeled as `no modules found for
+query: <query> - try a different search term`.
+
+### 2.6 `get_module_details`
+
+Purpose: fetch documentation for one exact public module version.
+
+Annotation title:
+`Retrieve documentation for a specific Terraform module`.
+
+#### Input
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `module_id` | string | Required | Must be non-empty and contain exactly four `/`-separated components; the complete value is lowercased |
+
+The required format is:
+
+```text
+namespace/name/provider/version
+```
+
+Success is Markdown headed `registry://modules/<namespace>/<name>` and includes
+the description, version, namespace, and source. Inputs, outputs, provider
+dependencies, and example README sections are included when present. The root
+module README and submodule details are decoded but not emitted.
+
+An invalid four-part format, unknown module, transport failure, or response
+parse failure is a tool error. Components are not otherwise validated locally.
+
+### 2.7 `get_latest_module_version`
+
+Purpose: resolve the latest public version of a module.
+
+Annotation title: `Get Latest Module Version`.
+
+#### Input
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `module_publisher` | string | Required | Lowercased |
+| `module_name` | string | Required | Lowercased |
+| `module_provider` | string | Required | Lowercased |
+
+Success MUST be only the version string. Missing modules and Registry or parse
+failures are tool errors.
+
+### 2.8 `search_policies`
+
+Purpose: search public Terraform policies and produce a
+`terraform_policy_id` for `get_policy_details`.
+
+Annotation title:
+`Search and match Terraform policies based on name and relevance`.
+
+#### Input
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `policy_query` | string | Required | Must be non-empty and is lowercased |
+
+The tool MUST fetch at most the first 100 public policies with latest versions
+included and perform local literal substring matching against lowercase policy
+title or name. It does not request subsequent pages.
+
+Success is text headed `Matching Terraform Policies` with repeated
+`terraform_policy_id`, name, title, and download count. An empty query, no
+matches, and Registry or parse failures are tool errors.
+
+### 2.9 `get_policy_details`
+
+Purpose: fetch a public policy library entry and construct usage guidance.
+
+Annotation title:
+`Fetch detailed Terraform policy documentation using a terraform_policy_id`.
+
+#### Input
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `terraform_policy_id` | string | Required | Must be non-empty; no local path-format validation |
+
+The tool fetches policy metadata, policy modules, and policy-library
+inclusions. Success is Markdown containing the first extracted README section,
+policy-module blocks, an advisory `policies.hcl` template, and policy
+names/checksums. A valid response with no included policies can still succeed
+with an empty policy list.
+
+Missing IDs and Registry or parse failures are tool errors.
+
+Compatibility note: IDs returned by `search_policies` begin `policies/...`
+without a leading slash. The generated HCL URLs concatenate that ID directly
+after `/v2`, producing `https://registry.terraform.io/v2policies/...`.
+
+## 3. Private Registry Tools
+
+### 3.1 `search_private_modules`
+
+Purpose: list or search modules in an organization's private Registry,
+including no-code module identifiers.
+
+Annotation title:
+`Search for private modules in Terraform Cloud/Enterprise`.
+
+#### Input
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `terraform_org_name` | string | Required | Passed without trimming |
+| `search_query` | string | Optional | Defaults to empty; passed without trimming |
+| `page_size` | number | Optional; minimum 1, maximum 100 | `GetInt` truncates numbers and accepts decimal integer strings; unconvertible values default to 100; runtime validates 1-100 |
+| `page_number` | number | Optional; minimum 1 | `GetInt` truncates numbers and accepts decimal integer strings; unconvertible values default to 1; runtime validates minimum 1 |
+
+Success is plain text containing organization, page information, and each
+module's `private_module_id`, name, namespace, registry, provider, timestamps,
+no-code status, and `no_code_module_id` when available. A `Search Query` line is
+included only for a non-empty query. Non-empty results end with pagination.
+
+No matches return a successful explanatory message before pagination is
+appended. For non-empty results, pagination is printed only when the API
+supplies a non-nil pagination object. API and explicit range-validation
+failures are tool errors.
+
+### 3.2 `get_private_module_details`
+
+Purpose: return usage and metadata for one private or public module visible
+through HCP Terraform/TFE.
+
+Annotation title: `Get detailed information about a private module`.
+
+#### Input
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `terraform_org_name` | string | Required | Trimmed |
+| `private_module_id` | string | Required | Whole value is trimmed and must have exactly three `/`-separated components; components are not individually trimmed, lowercased, or checked for emptiness/syntax |
+| `registry_name` | string | Optional; enum `private`, `public`; default `private` | Missing/wrong-type defaults to `private`; explicit strings are trimmed but empty or invalid values are not locally rejected |
+| `private_module_version` | string | Optional | Trimmed; empty requests API-selected/latest details |
+
+The module ID format is:
+
+```text
+namespace/name/provider
+```
+
+Success is Markdown/plain text containing an HCL module block and basic
+metadata. Organization, permissions, and VCS sections are conditional. Inputs,
+outputs, provider dependencies, resources, and a cleaned non-empty root README
+are included only when richer registry-module metadata supplies them. The HCL
+version is omitted when the base module has no version-status entries.
+
+`private_module_version` applies only to the richer metadata request. The HCL
+block takes its version from the first base-module version-status entry, so it
+can disagree with the requested metadata version. The HCL source always uses
+the configured TFE hostname, including when `registry_name` is `public`.
+
+Every failure to read the base registry module, including authorization,
+transport, validation, and absence, is collapsed to a `module not found` tool
+error. Failure to fetch the richer Terraform module details is non-fatal; the
+tool returns the available basic information.
+
+### 3.3 `search_private_providers`
+
+Purpose: list or search providers visible through an organization's private or
+public Registry view.
+
+Annotation title:
+`Search for private providers in Terraform Cloud/Enterprise`.
+
+#### Input
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `terraform_org_name` | string | Required | Trimmed |
+| `search_query` | string | Optional | Trimmed; defaults to empty |
+| `registry_name` | string | Optional; enum `private`, `public`; default `private` | Missing/wrong-type defaults to `private`; explicit strings are trimmed; empty omits the registry filter and invalid values are not locally rejected |
+| `page_size` | number | Optional; minimum 1, maximum 100 | `GetInt` truncates numbers and accepts decimal integer strings; unconvertible values default to 20; runtime validates 1-100 |
+| `page_number` | number | Optional; minimum 1 | `GetInt` truncates numbers and accepts decimal integer strings; unconvertible values default to 1; runtime validates minimum 1 |
+
+Success is plain text containing organization, registry, page, each provider's
+namespace/name, ID, registry, and timestamps, followed by pagination
+information. A search line is included only for a non-empty query. A `Versions`
+line is included only when versions exist.
+
+No matches return a successful explanatory message before pagination is
+appended. For non-empty results, pagination is printed only when the API
+supplies a non-nil pagination object. API and explicit range-validation
+failures are tool errors.
+
+### 3.4 `get_private_provider_details`
+
+Purpose: return usage, metadata, permissions, versions, and platforms for one
+provider visible through HCP Terraform/TFE.
+
+Annotation title: `Get detailed information about a private provider`.
+
+#### Input
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `terraform_org_name` | string | Required | Trimmed |
+| `private_provider_namespace` | string | Required | Trimmed |
+| `private_provider_name` | string | Required | Trimmed |
+| `registry_name` | string | Optional; enum `private`, `public`; default `private` | Missing/wrong-type defaults to `private`; explicit strings are trimmed but empty or invalid values are not locally rejected |
+| `include_versions` | boolean | Optional; default true | Accepts booleans, Go-parseable boolean strings, and numeric zero/nonzero values; otherwise defaults to true |
+
+Success is plain text/Markdown with an HCL `required_providers` example,
+provider ID/name/namespace/registry, timestamps, and permissions. Organization
+and links are conditional. When versions exist, the HCL block uses the first
+one; version/platform sections are included when requested. The HCL version is
+omitted if none are returned, and a `no version information` message appears
+only when `include_versions` is true.
+
+The HCL provider source is always `<namespace>/<name>` without a TFE hostname,
+including for the default private-registry mode; Terraform therefore interprets
+that address as public-registry syntax.
+
+Every base-provider read failure, including authorization, transport,
+validation, and absence, is collapsed to a `provider not found` tool error that
+directs the caller to search first.

--- a/spec/runtime.md
+++ b/spec/runtime.md
@@ -1,0 +1,787 @@
+# Runtime Behavior
+
+## 1. Server Identity And Capabilities
+
+The primary MCP server MUST advertise:
+
+- Name `terraform-mcp-server`.
+- The base version embedded from `version/VERSION`. MCP initialization omits
+  prerelease and build metadata that `GetHumanVersion` adds for display.
+- Tool support with list-change notifications enabled.
+- Resource support with subscriptions and list-change notifications enabled.
+- Elicitation support.
+- The text embedded from `cmd/terraform-mcp-server/instructions.md` as server
+  instructions.
+
+The primary server MUST NOT advertise or register MCP prompts.
+
+The server instructions are advisory model guidance. They do not add tools or
+server-side authorization. Some names in the embedded instructions do not
+correspond to registered tools; the tool catalogs in this specification are
+authoritative for availability.
+
+## 2. Process Invocation
+
+### 2.1 Commands
+
+| Invocation | Behavior |
+| --- | --- |
+| `terraform-mcp-server` | Start the primary server over stdio |
+| `terraform-mcp-server stdio` | Start the primary server over stdio |
+| `terraform-mcp-server streamable-http` | Start the primary Streamable HTTP server |
+| `terraform-mcp-server http` | Start Streamable HTTP and emit Cobra's deprecation notice |
+| `terraform-mcp-server --version` | Print `Terraform MCP Server` and `Version: <human-version>` |
+
+The stdio transport MUST read JSON-RPC from stdin and write JSON-RPC to stdout.
+It MUST write `Terraform MCP Server running on stdio` to stderr after starting.
+The configured server logger uses stderr unless a log file is configured.
+Package-global Logrus calls, including some rate-limit and experimental-server
+logs, continue to use stderr even when `--log-file` is set.
+
+### 2.2 CLI Flags
+
+| Flag | Scope | Default | Behavior |
+| --- | --- | --- | --- |
+| `--log-file` | Persistent | empty | Append logs to the named file, creating it with mode `0666` subject to umask |
+| `--log-level` | Persistent | `info` | One of Logrus `trace`, `debug`, `info`, `warn`, `warning`, `error`, `fatal`, or `panic`, case-insensitive but not whitespace-trimmed |
+| `--log-format` | Persistent | `text` | `text` or `json`, case-insensitive |
+| `--toolsets` | Persistent | `all` | Comma-separated toolset selection |
+| `--tools` | Persistent | empty | Comma-separated individual tool selection |
+| `--transport-host` | HTTP commands | `127.0.0.1` | Listener host |
+| `--transport-port`, `-p` | HTTP commands | `8080` | Listener port as a string |
+| `--heartbeat-interval` | HTTP commands | `0` | Go duration; zero disables heartbeat |
+| `--mcp-endpoint` | HTTP commands | `/mcp` | MCP path, normalized to begin at `/` |
+| `--organization-allowlist` | HTTP commands | empty | Comma-separated allowed organization names |
+
+`LOG_LEVEL` and `LOG_FORMAT` override their CLI flags. Invalid log values MUST
+produce a warning and fall back to `info` or `text`, respectively.
+
+`--tools` and an explicitly supplied `--toolsets` MUST be treated as mutually
+exclusive and terminate startup. The non-empty default value of `--toolsets`
+does not conflict with `--tools` unless the user explicitly set the flag.
+An explicitly empty `--tools=` does not enter individual-tool mode and does not
+conflict with `--toolsets`; ordinary toolset selection applies.
+
+### 2.3 Environment-Selected HTTP Mode
+
+The process MUST enter Streamable HTTP mode before Cobra command parsing when
+either condition is true:
+
+- `TRANSPORT_MODE` is exactly `http` or `streamable-http`.
+- Any of `TRANSPORT_PORT`, `TRANSPORT_HOST`, or `MCP_ENDPOINT` is non-empty.
+
+This comparison is case-sensitive. In this path, command-line arguments are
+not parsed. Persistent CLI values therefore remain their compiled defaults,
+while environment variables read directly by the process still apply.
+
+The environment-selected defaults are host `127.0.0.1`, port `8080`, endpoint
+`/mcp`, no heartbeat, and toolsets `all`.
+
+## 3. Streamable HTTP Surface
+
+### 3.1 Listener And Routes
+
+The MCP endpoint MUST be normalized with path joining and registered both with
+and without one trailing slash. The default routes are:
+
+| Route | Behavior |
+| --- | --- |
+| `/mcp` and `/mcp/` | Primary MCP Streamable HTTP handler |
+| `/health` | Unauthenticated health response |
+| `/mcp/official` and `/mcp/official/` | Experimental handler when enabled |
+
+The endpoint is not checked against reserved routes. Configuring it as
+`/health` causes a conflicting ServeMux registration panic. Configuring it as
+`/` also conflicts when the root redirect is enabled.
+
+If `MCP_REDIRECT_ROOT_URL` is non-empty, the root ServeMux pattern `/` MUST
+return HTTP 303 to that URL. Because `/` is a catch-all pattern, otherwise
+unmatched paths also reach this redirect. Without it, unmatched paths return
+the Go HTTP mux 404 response unless the configured MCP endpoint itself is `/`,
+in which case the primary MCP handler is the catch-all.
+
+The health handler does not restrict the HTTP method and MUST return HTTP 200,
+`Content-Type: application/json`, and this shape:
+
+```json
+{
+  "status": "ok",
+  "service": "terraform-mcp-server",
+  "transport": "streamable-http",
+  "endpoint": "/mcp",
+  "version": "<human-version>"
+}
+```
+
+The health and redirect handlers are outside the MCP authentication, Terraform
+context, and CORS wrappers.
+
+The HTTP server MUST use 30-second read, read-header, and write timeouts, a
+60-second idle timeout, and a five-second graceful-shutdown timeout.
+
+### 3.2 Sessions And Heartbeats
+
+The primary HTTP server is stateful by default. `MCP_SESSION_MODE` enables
+stateless mode only when its case-insensitive value is exactly `stateless`.
+All other values select stateful mode.
+
+In environment-selected HTTP mode, `MCP_HEARTBEAT_INTERVAL` is parsed as a Go
+duration. A missing, invalid, zero, or negative value disables heartbeat, and a
+positive value configures MCP HTTP heartbeats. An explicit `streamable-http` or
+`http` command reads only `--heartbeat-interval`; this environment variable
+does not override that flag and does not itself select HTTP mode. The similarly
+named `MCP_KEEP_ALIVE` documented by older material has no effect.
+
+### 3.3 CORS And Origin Validation
+
+`MCP_CORS_MODE` defaults to `strict`. Mode comparisons are case-sensitive and
+the only modes with special behavior are `strict`, `development`, and
+`disabled`.
+
+`MCP_ALLOWED_ORIGINS` is a comma-separated exact-match list. Entries are
+trimmed. Empty entries are retained if present in a non-empty list but do not
+match a non-empty origin.
+
+Origin handling MUST follow this table:
+
+| Condition | Result |
+| --- | --- |
+| No `Origin` header | Bypass origin validation in every mode |
+| Exact configured origin | Allow |
+| `development` and a value beginning `http://` or `https://` plus `localhost:`, `127.0.0.1:`, or `[::1]:` | Allow |
+| `disabled` | Allow every origin |
+| Any other origin | HTTP 403 `Origin not allowed` |
+
+For an allowed non-empty origin, the response MUST echo that origin and set:
+
+```text
+Access-Control-Allow-Origin: <origin>
+Access-Control-Allow-Methods: GET, POST, OPTIONS
+Access-Control-Allow-Headers: Content-Type, Mcp-Session-Id, Authorization
+Access-Control-Max-Age: 3600
+```
+
+An allowed `OPTIONS` request MUST return HTTP 200 without invoking the MCP
+handler. Browser preflight does not advertise `TFE_TOKEN` or
+`TFE_SKIP_TLS_VERIFY` as allowed headers.
+
+Development matching is raw string-prefix matching, not URL or port
+validation. A malformed value, path-bearing value, or non-numeric port is still
+allowed if it has one of the accepted prefixes.
+
+### 3.4 MCP Host And Wire Validation
+
+By default, both MCP implementations perform built-in DNS-rebinding protection after the
+application's outer HTTP wrappers. When a request arrives through a loopback
+local address but its `Host` is not `localhost` or a loopback IP, the MCP
+handler returns HTTP 403 with `Forbidden: invalid Host header "<host>"`.
+Requests arriving through non-loopback local addresses are not subject to this
+Host check. Health and redirect routes bypass it.
+
+The two MCP HTTP implementations have additional wire differences:
+
+| Behavior | Primary endpoint | Official endpoint |
+| --- | --- | --- |
+| POST body limit | No explicit cap before `io.ReadAll` | 4 MiB by default; excess returns 413 |
+| POST content type | Requires media type `application/json`; invalid returns 400 | Requires `application/json`; invalid returns 415 unless compatibility-disabled |
+| POST `Accept` | No explicit requirement | Must include both `application/json` and `text/event-stream`; invalid returns 400 |
+| Stateful GET | Can generate/register a session when the session header is absent | Requires `Accept: text/event-stream` and an existing `Mcp-Session-Id` |
+
+The official SDK supports additional protocol-version checks and method rules
+owned by that dependency. The primary handler accepts POST, GET, DELETE, and
+HEAD at its endpoint; HEAD returns 200 and otherwise unsupported methods return
+404.
+
+### 3.5 TLS
+
+`MCP_TLS_CERT_FILE` and `MCP_TLS_KEY_FILE` MUST either both be absent or both be
+present. When present, both files MUST exist, be readable, and load as an X.509
+certificate/key pair. Invalid configuration MUST fail startup.
+
+TLS MUST use a minimum version of 1.2. The implementation configures X25519,
+P-256, P-384, and X25519MLKEM768 curve preferences and ECDHE AES-GCM or
+ChaCha20-Poly1305 TLS 1.2 cipher suites. Go controls TLS 1.3 suites.
+
+Without TLS, startup MUST fail for hosts other than `localhost`, `127.0.0.1`,
+`::1`, `[::1]`, and `0.0.0.0`, compared case-insensitively. In particular,
+`0.0.0.0` is treated as local and may be served over plaintext.
+
+## 4. Configuration Environment
+
+| Variable | Default | Effective behavior |
+| --- | --- | --- |
+| `TRANSPORT_MODE` | stdio | Exact `http` or `streamable-http` selects HTTP |
+| `TRANSPORT_HOST` | `127.0.0.1` | Non-empty value selects HTTP and sets listener host |
+| `TRANSPORT_PORT` | `8080` | Non-empty value selects HTTP and sets listener port |
+| `MCP_ENDPOINT` | `/mcp` | Non-empty value selects HTTP and sets endpoint |
+| `MCP_REDIRECT_ROOT_URL` | empty | Enables the catch-all 303 redirect |
+| `MCP_SESSION_MODE` | stateful | Case-insensitive exact `stateless` enables stateless mode |
+| `MCP_HEARTBEAT_INTERVAL` | `0` | Positive Go duration enables heartbeat only in environment-selected HTTP mode |
+| `MCP_ALLOWED_ORIGINS` | empty | Comma-separated exact CORS origins |
+| `MCP_CORS_MODE` | `strict` | Origin policy mode |
+| `MCP_TLS_CERT_FILE` | empty | Server certificate path |
+| `MCP_TLS_KEY_FILE` | empty | Server private-key path |
+| `MCP_RATE_LIMIT_GLOBAL` | `10:20` | Global `requests-per-second:burst` |
+| `MCP_RATE_LIMIT_SESSION` | `5:10` | Per-session `requests-per-second:burst` |
+| `MCP_ORGANIZATION_ALLOWLIST` | absent | Comma-separated organization gate; an explicitly empty value is invalid |
+| `MCP_FORWARD_CLIENT_IP` | empty | Exact `true` enables client-IP forwarding |
+| `MCP_REMOTE_IP_METHOD` | `RemoteAddr` | `RemoteAddr`, `X-Real-IP`, or `X-Forwarded-For` |
+| `MCP_XFF_TRUSTED_HOPS` | `0` | Positive trusted-proxy count for XFF selection |
+| `TFE_ADDRESS` | `https://app.terraform.io` | Server-side Terraform API address |
+| `TFE_TOKEN` | empty | Terraform API token fallback |
+| `TFE_SKIP_TLS_VERIFY` | false | Go boolean controlling outbound TLS verification |
+| `TF_MCP_SHARED_SECRET` | empty | Outbound `X-Tf-Mcp-Secret` header to Terraform APIs |
+| `ENABLE_TF_OPERATIONS` | false | Case-insensitive exact `true` enables selected operations |
+| `LOG_LEVEL` | `info` | Overrides CLI logging level |
+| `LOG_FORMAT` | `text` | Overrides CLI logging format |
+| `OTEL_METRICS_ENABLED` | false | Exact `true` enables HTTP metrics setup |
+| `OTEL_METRICS_ENDPOINT` | `localhost:4318` | OTLP/HTTP collector endpoint |
+| `OTEL_METRICS_EXPORT_INTERVAL` | `2s` | Parseable Go duration; zero/negative values make the OTel reader use its own 60-second default |
+| `OTEL_METRICS_SERVICE_NAME` | `terraform-mcp-server` | OTel service name |
+| `OTEL_METRICS_SERVICE_VERSION` | human version | OTel service version |
+| `INSTANA_ENABLED` | false | Exact `true` enables HTTP Instana instrumentation |
+| `INSTANA_SERVICE_NAME` | `terraform-mcp-server` | Instana service name |
+| `TF_X_OFFICIAL_SDK_ENABLED` | false | Exact `true` enables the experimental endpoint |
+| `MCPGODEBUG` | empty | Official SDK compatibility parameters as comma-separated `key=value` pairs |
+
+Outbound clients also honor Go's standard proxy environment and certificate
+environment, including `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`, and
+`SSL_CERT_FILE` where supported by the Go runtime.
+
+The official SDK parses `MCPGODEBUG` during package initialization even when
+the official endpoint is disabled. Any comma-separated item without `=` causes
+a startup panic. Relevant value-`1` switches include
+`disablelocalhostprotection`, `enableoriginverification`,
+`allowsessionsinstateless`, and `disablecontenttypecheck`; they respectively
+alter only the official SDK's Host protection, built-in origin verification,
+stateless session compatibility, and POST content-type validation.
+
+## 5. Tool Selection And Advertisement
+
+### 5.1 Toolsets
+
+The valid toolsets are:
+
+| Name | Contents |
+| --- | --- |
+| `registry` | Nine public Registry tools |
+| `registry-private` | Four TFE-client-dependent private Registry tools |
+| `terraform` | Forty-eight TFE-client-dependent Terraform tools |
+| `all` | Every selected toolset/tool mapping |
+| `default` | Expands to `registry` |
+
+The CLI flag default is `all`; this differs from the meaning of the special
+value `default`.
+
+Toolset names MUST be trimmed, deduplicated, and compared case-sensitively.
+Invalid names MUST produce a warning. They remain in the internal selection
+but map to no tools. An empty explicit toolset selection enables no tools,
+although resources remain available.
+
+Individual tool names MUST be trimmed, deduplicated, and compared
+case-sensitively against the complete 61-tool map. Invalid names produce a
+warning and are ignored. If no valid individual names remain, selection MUST
+fall back to the `default` toolset, but only when the non-empty `--tools` value
+actually entered individual-tool mode.
+
+### 5.2 Static And Dynamic Registration
+
+Selected public Registry tools MUST be registered during startup.
+
+Selected private Registry and Terraform tools MUST begin process-global
+registration when the first session constructs a TFE client. Construction
+requires a non-empty token but does not validate its authorization; an invalid
+token can trigger registration. `go-tfe` synchronously requests `/api/v2/ping`
+during construction: a transport failure prevents construction, while any
+received HTTP status, including 401 or 500, permits construction to return.
+Registration uses separate sequential
+`AddTool` calls, is not atomic, and can emit multiple list-change notifications.
+Another session can temporarily observe a partially registered catalog.
+
+The application deliberately keeps the tools advertised after all TFE sessions
+end. Every dynamic tool invocation after global registration MUST still check
+the calling session:
+
+- No session context returns a tool error requiring an active session.
+- A session without a valid TFE client returns a tool error explaining that a
+  valid token and configuration are required.
+- A cached client found for an unregistered session causes that session to be
+  registered before invocation continues.
+
+Before global registration, a direct call to one of these names returns the MCP
+protocol error `tool '<name>' not found`; it cannot reach the availability
+wrapper.
+
+The primary HTTP server attempts session initialization during registration,
+before `tools/list`, and before `tools/call`. This permits sessions routed
+between server instances to recreate local clients.
+
+### 5.3 Terraform Operations Gate
+
+`ENABLE_TF_OPERATIONS` is enabled when its case-insensitive value is exactly
+`true`. It controls only this behavior:
+
+| Behavior | Disabled | Enabled |
+| --- | --- | --- |
+| `delete_team` | Not registered | Registered if selected |
+| `delete_project` | Not registered | Registered if selected |
+| `delete_workspace_safely` | Not registered | Registered if selected |
+| `force_unlock_workspace` | Not registered | Registered if selected |
+| `action_run` | Not registered | Registered if selected |
+| `create_run` | Safe schema/handler | Full schema/handler |
+
+All other selected mutations remain available after client construction
+regardless of this flag.
+
+## 6. Session Clients And Credentials
+
+### 6.1 Primary Server Session Lifecycle
+
+Each initialized primary-server session MUST attempt to create:
+
+- A Terraform API client if a token can be found.
+- A public HTTP client regardless of Terraform authentication success.
+
+Stateful clients are cached by MCP session ID. A separate equality-check field
+stores a SHA-256 token hash, while the cached `go-tfe` client necessarily
+retains its configured raw token. If a later request for the same session
+carries a different token, the old cached client is deleted and a new one is
+created. Session teardown removes both clients, the TFE-session marker, and the
+per-session rate limiter.
+
+Client reuse compares only the token hash. Changing only
+`TFE_SKIP_TLS_VERIFY`, client IP, `TF_MCP_SHARED_SECRET`, or other client build
+settings does not rebuild the primary TFE client. The public HTTP client is
+reused solely by session ID and keeps its initial TLS setting. TFE client
+settings remain sticky until a token change or teardown recreates that client;
+the public client's TLS setting remains sticky until session teardown and is
+not changed by a token change.
+
+Stateless requests have an empty session ID and MUST create a new Terraform
+client for each TFE tool request. Public HTTP clients may be stored under the
+empty session ID by the current cache implementation.
+
+### 6.2 Credential Resolution
+
+For stdio and primary session initialization, Terraform configuration resolves
+in this order:
+
+| Value | Precedence |
+| --- | --- |
+| Address | Request context, then `TFE_ADDRESS`, then `https://app.terraform.io` |
+| Token | Request context, then `TFE_TOKEN`, then Terraform CLI credentials file |
+| Skip TLS verify | Request context, then `TFE_SKIP_TLS_VERIFY`, then false |
+
+On Unix, the credentials file is
+`~/.terraform.d/credentials.tfrc.json`. On Windows it is under
+`%APPDATA%/terraform.d`, with the platform implementation's home-directory
+fallback. The server selects `credentials[<TFE_ADDRESS hostname>].token`.
+Missing files, malformed JSON, missing host entries, and empty hostnames prevent
+creation of the TFE client but do not prevent public Registry tools from being
+used.
+
+`TFE_SKIP_TLS_VERIFY` is parsed with Go boolean syntax. Missing or invalid
+values become false. The same setting configures both the Terraform API client
+and the per-session public HTTP client.
+
+### 6.3 HTTP Request Configuration
+
+For primary Streamable HTTP requests, token precedence is:
+
+1. Exact case-sensitive `Authorization: Bearer <token>`.
+2. `TFE_TOKEN` request header.
+3. `TFE_TOKEN` query parameter.
+4. Server `TFE_TOKEN` environment variable.
+5. Terraform CLI credentials file during stateful session creation.
+
+A non-empty token query parameter MUST return HTTP 400 only when neither a
+bearer token nor a `TFE_TOKEN` header was already selected. If a higher-priority
+token exists, the query token is ignored rather than rejected.
+
+Clients MUST NOT set `TFE_ADDRESS` by request header or query parameter. Either
+non-empty form returns HTTP 403 before MCP handling, preventing token
+redirection. An explicitly empty header or query value is treated as absent.
+The address always comes from server configuration.
+
+`TFE_SKIP_TLS_VERIFY` may be supplied by request header, query parameter, or
+server environment in that order. Browser CORS preflight does not permit this
+custom header. In a stateful session, a changed value does not alter already
+cached clients.
+
+### 6.4 Outbound Requests
+
+Terraform API clients MUST enable retry of server errors and send:
+
+- `User-Agent: terraform-mcp-server/<human-version>`.
+- `X-Forwarded-For: <selected-client-ip>` when forwarding is enabled and an IP
+  is available.
+- `X-Tf-Mcp-Secret: <TF_MCP_SHARED_SECRET>` when configured.
+
+The shared secret and selected client IP apply only to the primary TFE client,
+not the experimental official-SDK client. They are captured when a stateful
+client is built; a later request with a different selected IP or secret does not
+update that client unless it is recreated.
+
+## 7. Organization Allowlist
+
+The allowlist comes from `MCP_ORGANIZATION_ALLOWLIST` when that environment
+variable exists; otherwise the HTTP CLI flag is used if explicitly supplied.
+Entries MUST be trimmed and lowercased. Empty entries are discarded. Duplicate
+entries are harmless. A configured value yielding no names, including an
+explicitly empty environment value, MUST fail startup.
+
+When configured, an organization-membership wrapper is installed for both the
+primary and official MCP endpoints. Request processing order is CORS/origin,
+Terraform-context extraction, then organization membership. Consequently an
+allowed `OPTIONS` preflight returns before authentication, a rejected origin
+returns 403 first, an address override returns 403 first, and a token query can
+return 400 before the allowlist's missing-bearer response.
+
+Requests that reach the membership wrapper follow these rules:
+
+- `Authorization` MUST contain the exact prefix `Bearer ` and a non-empty token.
+- A `TFE_TOKEN` header or server token does not satisfy this gate.
+- The supplied bearer token MUST be able to list at least one allowlisted
+  organization, compared case-insensitively.
+- Organization listing MUST page in groups of 100 until a match or end.
+- Missing bearer authentication returns HTTP 401.
+- An unauthorized Terraform token returns HTTP 401.
+- A valid token with no allowed organization returns HTTP 403.
+- Client initialization or membership-list failures return HTTP 502.
+- A request-provided Terraform address still returns HTTP 403.
+
+Every request reaching this gate creates a fresh uncached TFE client, including
+the synchronous ping, and then calls `Organizations.List`. That validation
+client receives the selected client IP and configured shared-secret headers,
+including when the request is for the official endpoint.
+
+After HTTP validation, primary tool middleware MUST reject a call when its
+arguments contain a non-empty `terraform_org_name` outside the allowlist. This
+is a tool error and comparison is case-insensitive after trimming.
+
+Tools without a `terraform_org_name` argument bypass the tool-level check.
+Consequently, ID-based operations are constrained by the token's backend
+permissions, not by an additional server-side lookup of the ID's organization.
+
+The experimental official server has no equivalent tool-level organization
+check. HTTP validation proves only that the request bearer can access at least
+one allowlisted organization. Its `list_workspaces` call can name another
+organization accessible to the official server's environment token, which can
+also differ from the bearer token.
+
+## 8. Client IP Forwarding
+
+Forwarding is disabled unless `MCP_FORWARD_CLIENT_IP` is exactly `true`.
+
+When enabled, the server MUST select a syntactically valid IPv4 or IPv6 address
+using `MCP_REMOTE_IP_METHOD`:
+
+| Method | Selection |
+| --- | --- |
+| `RemoteAddr` | Direct TCP peer; default and fallback for invalid method names |
+| `X-Real-IP` | Valid `X-Real-IP`, else direct TCP peer |
+| `X-Forwarded-For` | Entry immediately left of the configured trusted hops, else direct TCP peer |
+
+`MCP_XFF_TRUSTED_HOPS` must be a positive integer to affect XFF selection.
+Missing, invalid, zero, or negative values become zero, which makes XFF
+selection fail and fall back to the direct peer.
+
+The selected address is added to each public Registry request and to a primary
+Terraform client's headers when that client is constructed. Stateful Terraform
+client reuse can therefore retain an earlier request's address.
+
+## 9. Tool Invocation Semantics
+
+### 9.0 Input Schemas And Annotation Defaults
+
+The primary server advertises JSON Schemas but does not enable the MCP
+library's input-schema validator. It also does not enable output-schema
+validation, and no primary tool declares an `outputSchema`.
+
+Consequently, advertised required fields, types, enums, patterns, lengths,
+minimums, maximums, and defaults are advisory to clients. The server accepts
+unknown properties at the schema layer and does not inject schema defaults.
+Middleware or handlers can still inspect an undeclared property, notably
+`terraform_org_name` in allowlist middleware and `after` in pagination. Actual
+acceptance is defined by each handler and these accessor rules:
+
+| Accessor | Runtime behavior |
+| --- | --- |
+| `RequireString` | Requires an actual JSON string and errors when absent or another type |
+| `GetString` | Returns only an actual JSON string; otherwise returns its handler-supplied default |
+| `GetInt` | Accepts integers, truncates JSON numbers, parses decimal integer strings, and otherwise returns its default |
+| `GetBool` | Accepts booleans, Go-parseable boolean strings, and numeric zero/nonzero values; otherwise returns its default |
+| Shared pagination helper | Requires decoded JSON numbers as `float64`; wrong types error rather than coerce |
+
+Every primary `mcp.NewTool` starts with wire-visible annotation defaults
+`readOnlyHint: false`, `destructiveHint: true`, `idempotentHint: false`, and
+`openWorldHint: true`. Tool constructors override some of those values. An
+annotation described as not explicitly set in source still serializes with its
+default value.
+
+### 9.1 Results And Errors
+
+Primary tool handlers MUST normally return one text content item. JSON,
+JSON:API, Markdown, logs, and base64 payloads are all transported as text.
+
+Handler validation failures and upstream API failures MUST normally return a
+non-nil `CallToolResult` with `isError: true`, one text item, and no Go handler
+error. The displayed text is the compatibility-visible error.
+
+Rate-limit failures are exceptions: they MUST return no tool result and a
+protocol/handler error with one of these exact messages:
+
+```text
+rate limit exceeded: too many requests globally
+rate limit exceeded: too many requests from this session
+```
+
+Resource read failures also return resource protocol errors rather than tool
+error content.
+
+Before a dynamic tool is registered, an attempted call produces a tool-not-
+found protocol error. Unknown tools, rate-limited calls, and other failures
+before handler invocation do not pass through ordinary tool-result behavior.
+
+Handlers generally assume that a successful upstream response includes all
+relationships used by `go-tfe`. They do not install panic recovery or convert
+every structurally partial success into a tool error. Notable unchecked
+relationships occur in token permissions, workspace organization data, team
+access responses, run workspace summaries, and no-code module data.
+
+### 9.2 Shared Pagination
+
+Tools documented with shared pagination advertise optional JSON numbers:
+
+| Parameter | Schema | Runtime |
+| --- | --- | --- |
+| `page` | Minimum 1 | Default 1; zero also selects default |
+| `pageSize` | Minimum 1, maximum 100 | Default 30; zero also selects default |
+
+The runtime requires decoded values to be `float64`, truncates fractional
+values to integers, and does not enforce the advertised minimum or maximum.
+Wrong types become tool errors. A helper parses an unadvertised `after` string
+if present, but current list tools do not use it.
+
+### 9.3 Rate Limiting
+
+Tool calls over all transports share a process-global token-bucket limiter and
+use a second limiter when a non-empty session ID is available. Defaults are:
+
+| Scope | Sustained rate | Burst |
+| --- | ---: | ---: |
+| Global | 10 requests/second | 20 |
+| Session | 5 requests/second | 10 |
+
+Configuration syntax is `rps:burst`. Both values must parse and be positive;
+otherwise that scope retains its default. The global limiter is checked first.
+Stateless calls with an empty session ID skip the per-session limiter.
+
+### 9.4 Tool Logging
+
+Every primary tool call that passes the outer rate limiter and reaches the
+argument-logging middleware MUST log the tool name and complete argument map at
+info level. Values are not redacted. This includes variable values and any
+other secrets passed as tool arguments. Public Registry response bodies are
+additionally logged at trace level.
+
+The rate limiter is outside the argument logger. Rate-limited calls are not
+argument-logged. Calls rejected as unknown before middleware, including dynamic
+tools called before registration, are also not argument-logged. Some package-
+global logs bypass the configured server logger and remain on stderr.
+
+## 10. Public Registry HTTP Contract
+
+Public Registry requests MUST construct their initial URL at
+`https://registry.terraform.io` using hard-coded v1 or v2 paths and never use
+`TFE_ADDRESS`. The HTTP client retains Go's default redirect policy, so an HTTP
+redirect can move a request to another origin and up to ten redirects may be
+followed.
+
+The HTTP client MUST:
+
+- Use a ten-second timeout per retry attempt; the full retried operation can
+  exceed ten seconds.
+- Honor environment proxy configuration.
+- Use `TFE_SKIP_TLS_VERIFY` for TLS verification behavior.
+- Send the server user agent and optional selected client IP.
+- Retry up to three times only for HTTP 429 responses that include
+  `x-ratelimit-reset`.
+- Interpret a valid `x-ratelimit-reset` as a Unix timestamp and wait until it.
+  A malformed or past non-empty value still enables retry but produces zero or
+  non-positive backoff. A future timestamp can impose an arbitrarily long wait
+  outside the ten-second request timeout.
+
+Only HTTP 200 is accepted. A non-retried final non-200 response, regardless of
+its actual status, is exposed internally as `error: 404 Not Found` and normally
+becomes a tool or resource error. After exhausting retried 429 responses,
+`retryablehttp` instead returns a `giving up after 4 attempt(s)` error before
+the fake-404 check. The non-retried non-200 branch returns before closing its
+response body.
+
+Registry calls and guide-resource fetches do not attach the MCP request context
+to their outbound HTTP requests. MCP cancellation therefore does not directly
+cancel those calls. The per-attempt HTTP timeout does not bound retry backoff.
+Primary and official TFE clients use the same inner ten-second transport with
+up to three 429 retries. `go-tfe` adds an outer retry policy of up to 30 retries
+for 429 and transport failures and, because `RetryServerErrors` is enabled, 5xx
+responses. Qualifying failures can therefore cause nested retry amplification.
+
+## 11. Resources
+
+Resources are registered independently of tool filtering and Terraform
+authentication. They require an active MCP session so a public HTTP client can
+be obtained.
+
+### 11.1 Terraform Style Guide
+
+The resource metadata is:
+
+| Field | Value |
+| --- | --- |
+| URI | `/terraform/style-guide` |
+| Name | `Terraform Style Guide` |
+| Description | `Terraform Style Guide` |
+| MIME type | `text/markdown` |
+
+Reading it MUST fetch the fixed Terraform `v1.12.x` `style.mdx` document from
+HashiCorp's `web-unified-docs` repository. HTTP 200 returns exactly one text
+resource with the resource URI, `text/markdown`, and the unmodified body. Any
+network, non-200, or body-read failure fails the resource read.
+
+### 11.2 Module Development Guide
+
+The resource metadata is:
+
+| Field | Value |
+| --- | --- |
+| URI | `/terraform/module-development` |
+| Name | `Terraform Module Development Guide` |
+| Description | `Terraform Module Development Guide` |
+| MIME type | `text/markdown` |
+
+Reading it MUST sequentially fetch six Terraform `v1.12.x` documents and
+return six text resources in this order:
+
+| Result URI | Source document |
+| --- | --- |
+| `/terraform/module-development/index` | `modules/develop/index.mdx` |
+| `/terraform/module-development/composition` | `modules/develop/composition.mdx` |
+| `/terraform/module-development/structure` | `modules/develop/structure.mdx` |
+| `/terraform/module-development/providers` | `modules/develop/providers.mdx` |
+| `/terraform/module-development/publish` | `modules/develop/publish.mdx` |
+| `/terraform/module-development/refactoring` | `modules/develop/refactoring.mdx` |
+
+Each result uses `text/markdown` and the unmodified body. Any failed fetch
+aborts the entire read; partial content is not returned.
+
+### 11.3 Provider Resource Template
+
+The registered template is normalized by Go path joining to:
+
+```text
+registry:/providers/{namespace}/name/{name}/version/{version}
+```
+
+Its name is `Provider details`, description is `Describes details for a
+Terraform provider`, and advertised MIME type is `application/json`.
+
+On read, the handler extracts namespace, name, and version from URI path
+segments. Empty, `latest`, or unsupported version syntax resolves the latest
+public Registry version. It then resolves the provider-version ID and fetches
+provider overview documentation.
+
+Success MUST contain exactly one text resource whose MIME type is
+`text/markdown`, whose text is the concatenated overview documentation, and
+whose URI is the template string rather than the concrete requested URI. The
+returned MIME type intentionally differs from the advertised MIME type.
+
+## 12. Observability
+
+### 12.1 OpenTelemetry Metrics
+
+Metrics setup occurs only on Streamable HTTP startup. It is enabled only when
+`OTEL_METRICS_ENABLED` is exactly `true`. The OTLP/HTTP exporter connects to the
+configured endpoint without transport TLS. Exporter or meter initialization
+failure is logged and does not prevent server startup.
+
+The server creates these instruments:
+
+| Metric | Type | Behavior |
+| --- | --- | --- |
+| `mcp_tool_calls_total` | Counter | Incremented after each observed primary tool result |
+| `mcp_tool_errors_total` | Counter | Incremented only when the result is a `CallToolResult` with `isError: true` |
+| `mcp_tool_duration_seconds` | Histogram | Tool duration in seconds |
+| `mcp_client_type_total` | Counter | Incremented after initialization and again before tool calls when client info is available |
+
+Tool metrics include `tool.name`, `service.name`, and `service.version`.
+Client metrics include client name, version, title, description, service name,
+and service version. A protocol/handler error prevents the after-tool hook, so
+rate-limit failures, unknown tools, and similar protocol errors increment none
+of the custom tool call, error, or duration instruments. Only completed primary
+tool results reach these custom metrics.
+
+Tool start times are keyed only by formatted JSON-RPC request ID, without a
+session component. Concurrent sessions reusing the same ID can overwrite one
+another and produce incorrect durations. A protocol error skips cleanup of that
+ID's start entry, so unique errored IDs can remain in the process map.
+
+When the environment switch is enabled, `otelhttp` also wraps the entire HTTP
+mux and emits its standard HTTP server instrumentation. This includes health,
+redirect, authentication failures, and the experimental endpoint, even though
+the latter has no primary custom tool hooks.
+
+### 12.2 Instana
+
+When `INSTANA_ENABLED` is exactly `true`, HTTP startup MUST initialize an
+Instana collector using `INSTANA_SERVICE_NAME` or the default server name and
+wrap the entire HTTP mux for tracing. Stdio does not initialize Instana.
+
+## 13. Experimental Official SDK Endpoint
+
+When `TF_X_OFFICIAL_SDK_ENABLED` is exactly `true`, the HTTP server MUST mount a
+second MCP implementation at `<endpoint>/official` and its trailing-slash form.
+It MUST use the same outer CORS, Terraform-context, and organization-membership
+HTTP wrappers as the primary endpoint.
+
+The experimental server MUST:
+
+- Identify itself as `terraform-mcp-official` with the embedded base version.
+- Use the configured heartbeat as its SDK keepalive when positive.
+- Use the same stateful/stateless transport setting.
+- Expose `list_workspaces` only when that tool is selected.
+- Expose no resources, resource templates, prompts, instructions, elicitation,
+  primary rate limiting, primary tool logging, or primary session hooks.
+- Advertise the official SDK's default empty logging capability and advertise
+  tool list-change support when `list_workspaces` is registered.
+
+Its `list_workspaces` input contains required `terraform_org_name` and optional
+`project_id`, `search_query`, comma-separated `tags`, `exclude_tags`, and
+`wildcard_name`. It exposes no pagination input, makes one backend list request,
+and does not follow a next-page link. Its advertised description nevertheless
+claims pagination and refers to `get_workspace_details`, which this endpoint
+does not expose. Empty results are errors. A success contains both typed
+`structuredContent` and the official SDK's JSON text fallback. The `items`
+entries contain `id`, `workspace_name`, `description`, `environment`,
+`created_at`, and `execution_mode`.
+
+Missing credentials, backend failures, and empty results from the typed handler
+are converted by the official SDK into `isError: true` tool results with one
+text item rather than JSON-RPC protocol errors.
+
+The official implementation creates one process-wide Terraform client on its
+first tool call and reuses the first creation result, including an error. Due
+to a distinct private context-key type, it does not consume token/address/TLS
+values inserted by the primary Terraform-context middleware and therefore
+normally resolves those values from server environment only. It does not read
+the Terraform CLI credentials file and does not add the primary shared-secret
+or client-IP headers. The HTTP allowlist can consequently validate a request's
+bearer token while the tool itself uses a different environment token. There is
+no tool-level allowlist check on the requested `terraform_org_name`.
+
+## 14. Shutdown
+
+SIGINT and SIGTERM MUST cancel the server context. Stdio stops listening and
+returns. HTTP attempts graceful shutdown for up to five seconds. Stateful MCP
+session teardown invokes client and limiter cleanup when the transport emits
+the unregister hook.

--- a/spec/terraform-tools.md
+++ b/spec/terraform-tools.md
@@ -1,0 +1,935 @@
+# HCP Terraform And Terraform Enterprise Tool Behavior
+
+## 1. Scope And Shared Rules
+
+This document specifies the 48 tools in the `terraform` toolset. Every tool is
+dynamically registered and requires a constructed primary-server TFE client in
+the calling MCP session. Client construction does not prove token
+authorization. Backend permissions, edition, entitlements, and API version can
+make an otherwise valid call fail.
+
+All results are one MCP text content item. JSON and JSON:API mentioned below
+are serialized into text rather than returned as MCP `structuredContent`.
+None of these tools advertises an MCP output schema.
+
+The primary server does not enable input-schema validation. Advertised required
+fields, types, defaults, enums, ranges, lengths, and patterns are not enforced
+unless a handler or `go-tfe` repeats them. Unknown fields are not rejected by
+schema validation, though middleware and handlers can still inspect them.
+Handler behavior in the tables below is the runtime contract.
+
+Every tool advertises `idempotentHint: false` and `openWorldHint: true` because
+those are the MCP library defaults when constructors do not override them.
+Omitted read-only and destructive options similarly serialize as
+`readOnlyHint: false` and `destructiveHint: true`.
+
+Tools marked with shared pagination use `page` and `pageSize` as specified in
+[runtime.md](runtime.md#92-shared-pagination).
+
+## 2. Advertised Annotation Matrix
+
+| Tool | Annotation title | Read-only | Destructive | Open world |
+| --- | --- | --- | --- | --- |
+| `whoami` | `Get current Terraform identity` | true | false | true |
+| `get_token_permissions` | `Get permissions for current token` | true | false | true |
+| `list_terraform_orgs` | `List all Terraform organizations` | true | false | true |
+| `list_terraform_projects` | `List all Terraform projects` | true | false | true |
+| `create_project` | `Create a new Terraform project` | false | false | true |
+| `get_project` | `Get a Terraform project by ID` | true | false | true |
+| `delete_project` | `Delete a Terraform project by ID` | false | true | true |
+| `list_teams` | `List teams in a Terraform Cloud organization.` | true | false | true |
+| `get_team` | `Fetch full details for a single team by ID` | true | false | true |
+| `create_team` | `Create a new team in a Terraform organization` | false | false | true |
+| `add_team_member` | `Add member to a Terraform team` | false | false | true |
+| `grant_team_access` | `Grant team access to a workspace or project` | false | false | true |
+| `delete_team` | `Deletes a Terraform Team by "team_id"` | false | true | true |
+| `list_workspaces` | `List Terraform workspaces with queries` | true | false | true |
+| `get_workspace_details` | `Get detailed information about a Terraform workspace` | true | false | true |
+| `create_workspace` | `Create a new Terraform workspace` | false | false | true |
+| `create_no_code_workspace` | `Create a No Code module workspace` | false | true | true |
+| `update_workspace` | `Update an existing Terraform workspace` | false | false | true |
+| `delete_workspace_safely` | `Safely delete a Terraform workspace by ID` | false | true | true |
+| `force_unlock_workspace` | `Force unlock a Terraform workspace by ID` | false | true | true |
+| `list_runs` | `List Terraform runs` | true | false | true |
+| `get_run_details` | `Get detailed information about a Terraform run` | true | false | true |
+| `get_run_comments` | `Get all comments for a given Terraform run.` | true | false | true |
+| `create_run` safe | `Create a new Terraform run` | false | false | true |
+| `create_run` full | `Create a new Terraform run` | false | true | true |
+| `action_run` | `Apply, Discard or Cancel a Terraform run` | false | true | true |
+| `get_plan_details` | `Get detailed information about a Terraform plan` | true | false | true |
+| `get_plan_logs` | `Get logs for a Terraform plan` | true | false | true |
+| `get_plan_json_output` | `Get JSON output for a Terraform plan` | true | false | true |
+| `get_apply_details` | `Get detailed information about a Terraform apply` | true | false | true |
+| `get_apply_logs` | `Get logs for a Terraform apply` | true | false | true |
+| `get_sentinel_mock` | `Get Sentinel mock data for a Terraform plan` | true | false | true |
+| `list_workspace_variables` | unset | false | true | true |
+| `create_workspace_variable` | unset | false | true | true |
+| `update_workspace_variable` | unset | false | true | true |
+| `list_variable_sets` | unset | false | true | true |
+| `create_variable_set` | unset | false | true | true |
+| `create_variable_in_variable_set` | unset | false | true | true |
+| `delete_variable_in_variable_set` | unset | false | true | true |
+| `attach_variable_set_to_workspaces` | unset | false | true | true |
+| `detach_variable_set_from_workspaces` | unset | false | true | true |
+| `create_workspace_tags` | unset | false | true | true |
+| `read_workspace_tags` | unset | true | false | true |
+| `attach_policy_set_to_workspaces` | unset | false | true | true |
+| `list_workspace_policy_sets` | unset | true | true | true |
+| `list_stacks` | `List Terraform workspaces with queries` | true | false | true |
+| `get_stack_details` | `Get detailed information about a Terraform Stack` | true | false | true |
+| `list_state_versions` | `List all States Versions` | true | false | true |
+| `get_state_version` | `Gets StateVersion with state_version_id` | true | false | true |
+
+The matrix is descriptive metadata, not enforcement. For example,
+`create_workspace` mutates backend state despite `destructiveHint: false`, and
+`get_sentinel_mock` creates a plan-export object despite `readOnlyHint: true`.
+
+## 3. Identity And Organizations
+
+### 3.1 `whoami`
+
+Purpose: identify the user or service account represented by the active token.
+
+Input: no properties.
+
+Success is exact-shape JSON:
+
+```json
+{
+  "username": "<string>",
+  "email": "<string>",
+  "is_service_account": false
+}
+```
+
+API and serialization failures are tool errors.
+
+### 3.2 `get_token_permissions`
+
+Purpose: list enabled organization-level permissions for the active token.
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `terraform_org_name` | string | Required | Passed without trimming |
+
+Success is a JSON array containing only the human-readable names of mapped
+permissions whose backend values are true. No mapped permission returns `[]`.
+Ordering is not stable because the implementation iterates a Go map.
+Organization and API failures are tool errors.
+
+The mapped labels are:
+
+```text
+Create Teams
+Create Workspaces
+Create Workspace Migrations
+Deploy NoCode Modules
+Destroy
+Manage Auditing
+Manage NoCodeModules
+Manage Run Tasks
+Traverse
+Update
+Update API Tokens
+Update OAuth
+Update Sentinel
+Update HYOK Configuration
+View HYOK Feature Information
+Enable Stacks
+Create Projects
+```
+
+### 3.3 `list_terraform_orgs`
+
+Purpose: list organizations visible to the active token.
+
+Input: shared pagination only.
+
+Success is JSON with `items` and dependency-owned pagination fields. Every item
+contains `organization_name`, `organization_email`, and `created_at`. An empty
+page is a tool error with `no organizations to list`. API, pagination, and
+serialization failures are tool errors.
+
+## 4. Projects
+
+### 4.1 `list_terraform_projects`
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `terraform_org_name` | string | Required | Empty string is explicitly rejected |
+| `page`, `pageSize` | number | Shared pagination | Shared pagination behavior |
+
+Success is JSON with `items`, each containing `project_id` and `project_name`,
+plus dependency-owned pagination. An empty result succeeds with `items: []`.
+API, pagination, and serialization failures are tool errors.
+
+### 4.2 `create_project`
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `terraform_org_name` | string | Required | Trimmed |
+| `project_name` | string | Required; advertised length 3-40 and pattern `^[A-Za-z0-9_-][A-Za-z0-9 _-]*[A-Za-z0-9_-]$` | Trimmed; advertised length/pattern are not locally enforced |
+| `description` | string | Optional; advertised maximum length 256 | Trimmed; omitted when empty; advertised maximum is not locally enforced |
+| `default_execution_mode` | string | Optional; no schema enum | Trimmed/lowercased; non-empty value must be `local`, `agent`, or `remote` |
+
+Success is JSON containing only `project_id` and `project_name`. Validation,
+API, and serialization failures are tool errors.
+
+Here, validation includes the explicit execution-mode check, `go-tfe`'s local
+non-empty organization/name checks, and backend validation; the server does not
+enforce the advertised name/description length or pattern constraints.
+
+This tool creates backend state even though its destructive hint is false and
+does not require `ENABLE_TF_OPERATIONS`.
+
+### 4.3 `get_project`
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `project_id` | string | Required | Trimmed |
+
+Success is a JSON object that always contains `project_id`, `project_name`, and
+`is_unified`. It conditionally contains `description`,
+`default_execution_mode`, `auto_destroy_activity_duration`,
+`organization_name`, `default_agent_pool_id`, and `default_agent_pool_name`
+when those values or relationships exist. API and serialization failures are
+tool errors.
+
+### 4.4 `delete_project`
+
+Availability: registered only when `ENABLE_TF_OPERATIONS=true`.
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `project_id` | string | Required | Trimmed |
+
+The tool calls the backend project delete operation. Success is exact-form text
+`project "<id>" deleted`. Unknown projects, non-empty projects/stacks, missing
+permissions, and API failures are tool errors.
+
+## 5. Teams
+
+### 5.1 `list_teams`
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `terraform_org_name` | string | Required | Trimmed |
+| `team_names` | string | Optional | Comma-split; each exact name is trimmed |
+| `search_query` | string | Optional | Trimmed substring query |
+| `page`, `pageSize` | number | Shared pagination | Shared pagination behavior |
+
+Success is JSON with `items` and pagination. Each item contains `id`, `name`,
+`visibility`, and the exact JSON key `users-count`. No matching teams is a tool
+error. API, pagination, and serialization failures are tool errors.
+
+### 5.2 `get_team`
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `team_id` | string | Required | Trimmed |
+
+Success is the team's dependency-owned JSON:API `data` object without included
+resources. It can contain the team attributes and relationships exposed by the
+pinned `go-tfe` version. API and serialization failures are tool errors.
+
+### 5.3 `create_team`
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `terraform_org_name` | string | Required | Trimmed |
+| `team_name` | string | Required | Trimmed |
+| `visibility` | string | Optional; no schema enum/default | Trimmed/lowercased; non-empty value must be `secret` or `organization`; omission delegates to backend default |
+
+Success is JSON with `team_id`, `team_name`, and `visibility`.
+`user_count` is included only when non-zero. Validation, API, and serialization
+failures are tool errors.
+
+This mutation is available without `ENABLE_TF_OPERATIONS`.
+
+### 5.4 `add_team_member`
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `team_id` | string | Required | Trimmed |
+| `username` | string | Optional | Trimmed |
+| `organization_membership_id` | string | Optional | Trimmed |
+
+Exactly one of `username` and `organization_membership_id` MUST be non-empty.
+Username addition is subject to backend membership/invitation rules;
+organization membership IDs can represent pending invitations.
+
+Success is `Successfully added member to team "<team-id>"`. Invalid one-of
+input and API failures are tool errors.
+
+### 5.5 `grant_team_access`
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `team_id` | string | Required | Trimmed |
+| `access_level` | string | Required | Trimmed/lowercased |
+| `workspace_id` | string | Optional | Trimmed |
+| `project_id` | string | Optional | Trimmed |
+
+Exactly one target ID MUST be non-empty. Workspace access accepts `admin`,
+`read`, `write`, or `plan`. Project access accepts `admin`, `read`, `write`, or
+`maintain`. There is no `custom` access value.
+
+Workspace success is JSON with `id`, `team_id`, `workspace_id`, and `access`.
+Project success substitutes `project_id`. Invalid target/access combinations
+and API or serialization failures are tool errors.
+
+### 5.6 `delete_team`
+
+Availability: registered only when `ENABLE_TF_OPERATIONS=true`.
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `team_id` | string | Required | Trimmed |
+
+The backend deletion also removes associated memberships and access grants.
+Success is `Team "<id>" deleted`. API failures are tool errors.
+
+## 6. Workspaces
+
+### 6.1 `list_workspaces`
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `terraform_org_name` | string | Required | Trimmed |
+| `search_query` | string | Optional | Passed as search filter |
+| `project_id` | string | Optional | Passed as project filter |
+| `tags` | string | Optional | Comma-split and each tag trimmed |
+| `exclude_tags` | string | Optional | Comma-split and each tag trimmed |
+| `wildcard_name` | string | Optional | Passed as wildcard filter |
+| `page`, `pageSize` | number | Shared pagination | Shared pagination behavior |
+
+Success is JSON with `items` and pagination. Each item contains `id`,
+`workspace_name`, `description`, `environment`, `created_at`, and
+`execution_mode`. No matches, including a nonexistent organization, are tool
+errors. API, pagination, and serialization failures are tool errors.
+
+### 6.2 `get_workspace_details`
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `terraform_org_name` | string | Required | Trimmed |
+| `workspace_name` | string | Required | Trimmed |
+
+Success is JSON:API with primary type `tool`. Its attributes/relationships
+represent `success: true`, `workspace_id`, the nested dependency-owned
+workspace, workspace variables, and `readme`.
+
+The variable request reads one default backend page of direct workspace
+variables and does not include inherited variable-set values. The response
+field is incorrectly declared as a polymorphic relationship: it does not
+serialize variable IDs, keys, or values. A variable whose `Workspace`
+relationship is populated contributes that workspace resource identifier,
+potentially repeatedly; a variable without it contributes no relationship
+entry. An empty/nil collection, including one produced after a list failure, is
+omitted from JSON:API rather than serialized explicitly. The tool starts with
+an embedded CLI-run README whose organization and workspace placeholders are
+replaced. If the backend returns a non-empty workspace README, it replaces the
+embedded text. Backend README errors, nil readers, read errors, and empty
+content silently retain the fallback.
+
+Workspace lookup and serialization failures are tool errors.
+
+### 6.3 `create_workspace`
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `terraform_org_name` | string | Required | Trimmed |
+| `workspace_name` | string | Required | Trimmed |
+| `description` | string | Optional | Sent only when non-empty |
+| `terraform_version` | string | Optional | Sent only when non-empty |
+| `working_directory` | string | Optional | Sent only when non-empty |
+| `auto_apply` | string | Optional | Case-insensitive exact `true` becomes true; all other and omitted values become false |
+| `execution_mode` | string | Optional | Case-insensitive `remote`, `local`, or `agent`; omission leaves the API field unset |
+| `project_id` | string | Optional | Adds a project relationship when non-empty |
+| `vcs_repo_identifier` | string | Optional | Enables VCS configuration when non-empty |
+| `vcs_repo_branch` | string | Optional | Sent only with VCS configuration and when non-empty |
+| `vcs_repo_oauth_token_id` | string | Optional | Required at runtime when `vcs_repo_identifier` is non-empty |
+| `tags` | string | Optional | Comma-split, trimmed, and blank entries discarded |
+
+The create request MUST set source name `terraform-mcp-server` and always send
+the computed `auto_apply` value. Although the schema description says remote is
+the execution default, omission does not send an execution mode and delegates
+to backend behavior.
+
+Success is a JSON:API `tool` wrapper with `success: true`, `workspace_id`, and
+the nested workspace. It does not include variables or README. Duplicate names,
+invalid execution mode, incomplete VCS configuration, API failures, and
+serialization failures are tool errors.
+
+The tool creates backend state, is not operations-gated, and advertises
+`destructiveHint: false`.
+
+### 6.4 `create_no_code_workspace`
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `no_code_module_id` | string | Required | Must begin `nocode-`; not trimmed |
+| `workspace_name` | string | Required | Not trimmed |
+| `project_id` | string | Required | Not trimmed |
+| `auto_apply` | boolean | Optional; default false | Accepts booleans, Go-parseable boolean strings, and numeric zero/nonzero values; otherwise defaults false |
+
+The tool MUST read the project, no-code module with variable options, backing
+registry module, and private module metadata before creating the workspace.
+
+It MUST issue one MCP elicitation request whose object schema contains every
+metadata input and marks every one required, regardless of the metadata's
+`required` flag. Type mapping is:
+
+| Terraform metadata type | Elicitation type | Created value |
+| --- | --- | --- |
+| `string` | string | Non-empty string |
+| `number` | number | String form of float, integer, or accepted string response |
+| `bool` | boolean | `true` or `false` string |
+| Any other type | string | String value under the current mapping |
+
+No-code variable options become elicitation enums. Invalid numeric or boolean
+option strings are dropped. If an options list exists but every value fails
+conversion, the property receives `"enum": null` rather than omitting the enum.
+The handler does not validate an accepted response against enum membership.
+Every created variable uses Terraform category. Metadata sensitivity is not
+propagated to the created variable.
+
+An accepted elicitation response MUST contain every requested key with the
+handler's expected runtime type. String variables reject empty strings. Number
+variables accept floats, integers, and arbitrary strings, including empty and
+non-numeric strings; they are not numerically revalidated. Decline produces
+`workspace creation declined by user`; cancel produces `workspace creation
+cancelled by user`. Missing values, wrong non-number types, unexpected actions,
+lookup failures, and API failures are tool errors.
+
+Success is a JSON:API `tool` wrapper with `success`, `workspace_id`, and nested
+workspace. This destructive mutation is not gated by
+`ENABLE_TF_OPERATIONS`.
+
+### 6.5 `update_workspace`
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `terraform_org_name` | string | Required | Trimmed |
+| `workspace_name` | string | Required | Trimmed |
+| `new_name` | string | Optional | Sent only when non-empty |
+| `description` | string | Optional | Sent only when non-empty; cannot clear the field |
+| `terraform_version` | string | Optional | Sent only when non-empty |
+| `working_directory` | string | Optional | Sent only when non-empty; cannot clear the field |
+| `auto_apply` | string | Optional | A supplied non-empty case-insensitive `true` is true; every other supplied non-empty value is false |
+| `execution_mode` | string | Optional | Case-insensitive `remote`, `local`, or `agent` |
+| `queue_all_runs` | string | Optional | Same string-boolean conversion |
+| `speculative_enabled` | string | Optional | Same string-boolean conversion |
+| `trigger_prefixes` | string | Optional | Non-empty value is comma-split and trimmed |
+| `file_triggers_enabled` | string | Optional | Same string-boolean conversion |
+| `tags` | string | Optional | Ignored whenever non-empty; emits a warning |
+
+Empty optional strings are omitted from the update. Trigger prefixes cannot be
+cleared: the branch intended to send an empty list is unreachable. Supplying an
+unrecognized non-empty boolean string writes false rather than rejecting it. A
+call with no non-empty optional values still invokes the backend update API with
+an empty update object.
+
+Success is direct dependency-owned JSON:API serialization of the updated
+workspace. Invalid execution mode, API failures, and serialization failures are
+tool errors. This mutation is not operations-gated and advertises
+`destructiveHint: false`.
+
+### 6.6 `delete_workspace_safely`
+
+Availability: registered only when `ENABLE_TF_OPERATIONS=true`.
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `workspace_id` | string | Required | Trimmed |
+
+The tool MUST read the workspace and then call the backend safe-delete-by-ID
+operation. It performs no local run-status, force-unlock, dry-run, or ID-prefix
+logic. The backend rejects deletion while managed resources remain.
+
+Success is a JSON:API `tool` wrapper built from the pre-deletion workspace with
+`success: true` and `workspace_id`. Lookup, safe-delete, and serialization
+failures are tool errors.
+
+### 6.7 `force_unlock_workspace`
+
+Availability: registered only when `ENABLE_TF_OPERATIONS=true`.
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `workspace_id` | string | Required | Trimmed |
+
+The tool MUST read the workspace and reject it if `locked` is false. A locked
+workspace is passed to the backend force-unlock operation. Success is
+`Workspace "<id>" is now unlocked`. Lookup, already-unlocked, permission, and
+API failures are tool errors.
+
+## 7. Runs, Plans, Applies, And Sentinel
+
+### 7.1 `list_runs`
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `terraform_org_name` | string | Required | Trimmed |
+| `workspace_name` | string | Optional | Non-empty selects workspace-scoped listing |
+| `vcs_username` | string | Optional | Passed as backend user filter |
+| `status` | array of strings | Optional; item enum below | A schema-conforming array is ignored because the handler reads only strings; an unadvertised string is used as the filter |
+| `page`, `pageSize` | number | Shared pagination | Shared pagination behavior |
+
+The status item enum is:
+
+```text
+pending, fetching, fetching_completed, pre_plan_running, pre_plan_completed,
+queuing, plan_queued, planning, planned, cost_estimating, cost_estimated,
+policy_checking, policy_override, policy_soft_failed, policy_checked,
+confirmed, post_plan_running, post_plan_completed, planned_and_finished,
+planned_and_saved, apply_queued, applying, applied, discarded, errored,
+canceled, force_canceled
+```
+
+Compatibility note: a decoded JSON array is not a string, so the accessor
+deterministically returns its empty default and omits status filtering.
+
+Without `workspace_name`, the tool lists organization runs. With it, the tool
+first resolves the workspace then lists its runs. Success is JSON with `items`
+and pagination. Every item contains `id`, `status`, `message`, `source`,
+`created_at`, `has_changes`, `is_destroy`, `plan_only`, `refresh_only`, and
+`workspace_name`. Empty results succeed with `items: []`. Lookup, API,
+pagination, and serialization failures are tool errors.
+
+Workspace-scoped output uses backend pagination. Organization-scoped output
+copies only current, previous, and next page into a full pagination structure,
+so its total count and total pages serialize as zero even when items exist.
+
+### 7.2 `get_run_details`
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `run_id` | string | Required | Passed without trimming |
+
+Success is dependency-owned JSON:API for the run without included resources.
+Lookup, API, and serialization failures are tool errors.
+
+### 7.3 `get_run_comments`
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `run_id` | string | Required | Trimmed and all leading `#` characters removed |
+
+Success is JSON:
+
+```json
+{"items":[{"id":"<comment-id>","body":"<body>"}]}
+```
+
+No comments succeeds with `items: []`. API and serialization failures are tool
+errors. The handler makes one backend list request and omits pagination, so it
+does not guarantee every comment when the API paginates.
+
+### 7.4 `create_run`
+
+The registered variant depends on `ENABLE_TF_OPERATIONS`.
+
+Common input:
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `terraform_org_name` | string | Required | Trimmed |
+| `workspace_name` | string | Required | Trimmed |
+| `run_type` | string | Optional; default `plan_and_apply`; enum varies | Defaults to `plan_and_apply` |
+| `message` | string | Optional; safe schema default is the standard message | Both handlers default to `Triggered via Terraform MCP Server`; an explicit empty string omits the API message |
+
+Safe run types:
+
+| Value | API option |
+| --- | --- |
+| `plan_and_apply` | `auto_apply=false` |
+| `refresh_state` | `refresh_only=true` |
+| `plan_only` | `plan_only=true` |
+| `allow_empty_apply` | `allow_empty_apply=true` |
+
+The full variant adds:
+
+| Value | API option |
+| --- | --- |
+| `auto_approve` | `auto_apply=true` |
+| `is_destroy` | `is_destroy=true` |
+
+The tool MUST resolve the workspace and reject a locked workspace with:
+
+```text
+workspace "<name>" is locked and cannot accept new runs. Use the force_unlock_workspace tool to unlock first
+```
+
+Because schemas are not validated, an unknown string `run_type` reaches the
+handler and creates a generic run with none of the switch-specific options.
+
+Success is dependency-owned run JSON:API returned immediately after creation;
+the tool does not poll planning. The safe variant serializes included resources
+while the full variant explicitly omits included resources. Lookup, API, and
+serialization failures are tool errors.
+
+### 7.5 `action_run`
+
+Availability: registered only when `ENABLE_TF_OPERATIONS=true`.
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `run_action` | string | Required; enum `apply`, `discard`, `cancel` | Selects one backend action |
+| `run_id` | string | Required | Passed to the backend |
+| `comment` | string | Optional | Omission defaults to `Triggered via Terraform MCP Server`; an explicit empty string is sent empty |
+
+Success returns immediately after the backend action:
+
+| Action | Success text |
+| --- | --- |
+| `apply` | Begins `Run approved and applied successfully` and advises calling `get_run_details` |
+| `discard` | `Run discarded successfully` |
+| `cancel` | `Run canceled successfully` |
+
+Invalid actions and backend failures are tool errors. The tool does not wait
+for apply completion.
+
+### 7.6 `get_plan_details`
+
+Required string input: `plan_id`. The handler does not trim or validate it;
+`go-tfe` rejects an empty ID locally before HTTP.
+
+Success is dependency-owned plan JSON:API without included resources. Lookup,
+API, and serialization failures are tool errors.
+
+### 7.7 `get_plan_logs`
+
+Required string input: `plan_id`. The handler does not trim or validate it;
+`go-tfe` rejects an empty ID locally before HTTP.
+
+The `go-tfe` log reader can poll until the plan reaches a completed state and
+uses retry backoff up to two seconds. It strips STX (`0x02`) and ETX (`0x03`)
+framing bytes, so success is the decoded log stream rather than necessarily the
+backend bytes byte-for-byte. A successful empty stream returns empty text. API
+and stream-read failures are tool errors. Polling can exceed the HTTP server's
+30-second write timeout.
+
+### 7.8 `get_plan_json_output`
+
+Required string input: `plan_id`. The handler does not trim or validate it;
+`go-tfe` rejects an empty ID locally before HTTP.
+
+Success is the raw backend plan JSON byte-for-byte as text. The server does not
+parse or validate it, and a successful empty response becomes empty text. API
+failures are tool errors.
+
+### 7.9 `get_apply_details`
+
+Required string input: `apply_id`. The handler does not trim or validate it;
+`go-tfe` rejects an empty ID locally before HTTP.
+
+Success is dependency-owned apply JSON:API without included resources. Lookup,
+API, and serialization failures are tool errors.
+
+### 7.10 `get_apply_logs`
+
+Required string input: `apply_id`. The handler does not trim or validate it;
+`go-tfe` rejects an empty ID locally before HTTP.
+
+The tool MUST read apply status before requesting logs. For `errored`,
+`finished`, or `canceled`, the `go-tfe` log reader returns text after stripping
+STX/ETX framing bytes. A successful empty stream becomes empty text.
+
+For every nonterminal status, the result is a successful non-error message:
+
+```text
+Apply <id> is currently in status "<status>". Wait for the status to change to a terminal state (finished, errored, canceled) before calling again.
+```
+
+Lookup, log API, and stream-read failures are tool errors.
+
+The backend/library also recognizes `unreachable` as completed, but this
+handler does not; it returns the same successful wait message for that status.
+
+### 7.11 `get_sentinel_mock`
+
+Required string input: `plan_id`. It is passed through without trimming or
+local non-empty validation.
+
+The tool MUST create a `sentinel-mock-bundle-v0` plan export, then poll its
+status at most 30 times with a two-second wait after each pending or queued
+status. Context cancellation interrupts a wait.
+
+On `finished`, it downloads the tar.gz bytes and returns JSON text with exact
+fields:
+
+```json
+{
+  "plan_id": "<plan-id>",
+  "plan_export_id": "<export-id>",
+  "data_type": "sentinel-mock-bundle-v0",
+  "format": "base64-tar-gz",
+  "data": "<standard-base64>"
+}
+```
+
+Export `errored`, `canceled`, `expired`, unexpected status, timeout, context
+cancellation, API failure, and download failure are tool errors.
+
+The maximum polling period is roughly 60 seconds, while the default HTTP write
+timeout is 30 seconds. A long-running call over Streamable HTTP can therefore
+lose its transport response before tool polling completes.
+
+## 8. Workspace Variables
+
+These tools do not explicitly advertise titles or behavior hints.
+
+### 8.1 `list_workspace_variables`
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `terraform_org_name` | string | Required | Passed without trimming |
+| `workspace_name` | string | Required | Passed without trimming |
+| `page`, `pageSize` | number | Shared pagination | Applied to API request |
+
+The tool resolves the workspace and returns JSON:API serialization of the
+direct workspace-variable slice, normally a top-level `data` array. Inherited
+variable-set values are not included. Backend pagination is not included in the
+output. An empty list succeeds. Lookup, API, pagination, and serialization
+failures are tool errors.
+
+### 8.2 `create_workspace_variable`
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `terraform_org_name` | string | Required | Passed without trimming |
+| `workspace_name` | string | Required | Passed without trimming |
+| `key` | string | Required | Sent as key |
+| `value` | string | Required | Sent as value |
+| `description` | string | Optional; default empty | Always sent, including empty |
+| `category` | string | Optional; enum `terraform`, `env`; default `env` | Exact `terraform` selects Terraform; every other handler value selects environment |
+| `sensitive` | boolean | Optional; default false | Accepts booleans, Go-parseable boolean strings, and numeric zero/nonzero values; always sent |
+| `hcl` | boolean | Optional; default false | Same coercion; always sent |
+
+Success is `Created variable <key> with ID <id>`. Workspace lookup and API
+failures are tool errors.
+
+The complete argument map, including `value`, is logged at info level by global
+tool middleware.
+
+### 8.3 `update_workspace_variable`
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `terraform_org_name` | string | Required | Passed without trimming |
+| `workspace_name` | string | Required | Passed without trimming |
+| `variable_id` | string | Required | Sent as variable ID |
+| `key` | string | Required | Always sent |
+| `value` | string | Required | Always sent |
+| `sensitive` | boolean | Optional; default false | A schema-conforming boolean is ignored; only an unadvertised non-empty string is acted upon |
+| `hcl` | boolean | Optional; default false | A schema-conforming boolean is ignored; only an unadvertised non-empty string is acted upon |
+| `description` | string | Optional | Sent only when non-empty; cannot clear description |
+
+Compatibility note: the boolean schema and string accessor disagree.
+Schema-conforming booleans deterministically return the accessor's empty
+default and are omitted from the update. The unadvertised exact string `true`
+sends true; any other non-empty string sends false.
+
+Success is `Updated variable <key> with ID <id>`. Workspace lookup and API
+failures are tool errors. The complete argument map, including `value`, is
+logged at info level.
+
+## 9. Variable Sets
+
+These tools do not explicitly advertise titles or behavior hints. None is
+gated by `ENABLE_TF_OPERATIONS`.
+
+### 9.1 `list_variable_sets`
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `terraform_org_name` | string | Required | Passed without trimming |
+| `query` | string | Optional | Defaults to empty |
+| `page`, `pageSize` | number | Shared pagination | Applied to API request |
+
+Success is JSON:API serialization of the variable-set slice without included
+resources. Backend pagination is omitted. An empty list succeeds. API,
+pagination, and serialization failures are tool errors.
+
+### 9.2 `create_variable_set`
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `terraform_org_name` | string | Required | Passed without trimming |
+| `name` | string | Required | Sent as name |
+| `description` | string | Optional | Defaults to empty and is always sent |
+| `global` | boolean | Optional; default false | Accepts booleans, Go-parseable boolean strings, and numeric zero/nonzero values; always sent |
+
+Success is `Successfully created variable set <name> with ID <id>`. API
+failures are tool errors.
+
+### 9.3 `create_variable_in_variable_set`
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `variable_set_id` | string | Required | Sent as set ID |
+| `key` | string | Required | Sent as key |
+| `value` | string | Required | Sent as value |
+| `description` | string | Optional | Defaults to empty and is always sent |
+| `category` | string | Optional; enum `terraform`, `env`; default `terraform` | Exact `env` selects environment; every other handler value selects Terraform |
+| `hcl` | boolean | Optional; default false | Accepts booleans, Go-parseable boolean strings, and numeric zero/nonzero values; always sent |
+| `sensitive` | boolean | Optional; default false | Same coercion; always sent |
+
+Success is `Successfully created variable <key> with ID <id> in variable set
+<set-id>`. API failures are tool errors. The unredacted `value` is logged by
+global tool middleware.
+
+### 9.4 `delete_variable_in_variable_set`
+
+Required string inputs: `variable_set_id` and `variable_id`.
+
+Success is `Successfully deleted variable <variable-id> from variable set
+<set-id>`. API failures are tool errors. This destructive operation is neither
+operations-gated nor explicitly annotated; clients receive the MCP library's
+default `destructiveHint: true`.
+
+### 9.5 `attach_variable_set_to_workspaces`
+
+Required string inputs: `variable_set_id` and comma-separated `workspace_ids`.
+
+The handler MUST split on commas and trim each ID but MUST NOT remove empty
+segments. For example, `ws-a,,ws-b` creates three workspace references, one
+with an empty ID. `go-tfe` validates every ID before making an HTTP request, so
+any empty segment deterministically produces a local dependency error.
+
+Success is `Successfully attached variable set <id> to <N> workspaces`. A
+successful count cannot include an empty segment. Local validation and API
+failures are tool errors.
+
+### 9.6 `detach_variable_set_from_workspaces`
+
+Input parsing is identical to the attach tool, including retaining empty
+segments and `go-tfe` rejection of them. Success is `Successfully detached
+variable set <id> from <N> workspaces`. Local validation and API failures are
+tool errors.
+
+## 10. Workspace Tags And Policy Sets
+
+### 10.1 `create_workspace_tags`
+
+Required string inputs: `terraform_org_name`, `workspace_name`, and `tags`.
+
+The tool comma-splits and trims `tags`. A plain item becomes a tag binding with
+only a key. An item containing `:` splits on the first colon; the trimmed left
+side is the key and the trimmed right side is the value. Blank items and items
+with blank keys are discarded. An all-blank value submits an empty binding
+list to `go-tfe`, which rejects it locally with `TagBindings are required`
+before an HTTP request.
+
+Success is `Added <N> tags to workspace <name>`. Workspace lookup and API
+failures are tool errors. This mutation has no explicit behavior options and
+therefore receives the library defaults, including `destructiveHint: true`.
+
+### 10.2 `read_workspace_tags`
+
+Required string inputs: `terraform_org_name` and `workspace_name`.
+
+The tool separately fetches legacy tags and tag bindings. Success begins:
+
+```text
+Workspace <name> has <N> tags: <comma-separated names>
+```
+
+If bindings exist, it appends `Workspace <name> has <N> tag bindings:
+<comma-separated key or key:value values>` with no inserted space or newline
+between the two sentences. Empty collections succeed. Workspace or either list
+API failure is a tool error. Each collection comes from one backend request;
+the handler does not follow pagination.
+
+### 10.3 `attach_policy_set_to_workspaces`
+
+Required string inputs: `policy_set_id` and comma-separated `workspace_ids`.
+
+The handler trims and discards empty workspace IDs. If no valid IDs remain, it
+returns a tool error. Global policy sets cannot be attached through the backend
+API. Success is `Successfully attached policy set <id> to <N> workspace(s)`.
+API failures are tool errors. This mutation has no explicit behavior
+options, receives the default `destructiveHint: true`, and is not
+operations-gated.
+
+### 10.4 `list_workspace_policy_sets`
+
+Required string inputs: `terraform_org_name` and `workspace_id`.
+
+The tool MUST fetch all organization policy-set pages in groups of 100 with
+workspace relationships included. It selects global sets and sets directly
+related to the workspace.
+
+The tool never reads or validates the workspace itself. A nonexistent
+`workspace_id` can therefore return all global policy sets as successful
+matches.
+
+A non-empty success is an indented JSON array. Every object contains `id`,
+`name`, `description`, `kind`, `global`, and `reason`; reason is `global` or
+`directly attached`. No matching sets return successful plain text `No policy
+sets are attached to workspace <id>` rather than an empty array. API and
+serialization failures are tool errors.
+
+The constructor explicitly marks this tool read-only but does not override the
+library's destructive default, so clients receive both `readOnlyHint: true` and
+`destructiveHint: true`.
+
+## 11. Stacks
+
+### 11.1 `list_stacks`
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `terraform_org_name` | string | Required | Trimmed |
+| `search_query` | string | Optional | Trimmed |
+| `project_id` | string | Optional | Trimmed |
+| `page`, `pageSize` | number | Shared pagination | Applied to API request |
+
+Success is JSON with `items` and pagination. Each item uses the exact keys `ID`
+with uppercase letters, `name`, and `description`. A backend pagination
+`TotalCount` of zero is a tool error, including a valid no-match search. A page
+with no items can still succeed if total count is non-zero. API, pagination,
+and serialization failures are tool errors.
+
+The advertised title incorrectly refers to workspaces; clients observe the
+title shown in the annotation matrix.
+
+### 11.2 `get_stack_details`
+
+Required string input: `stack_id`, trimmed at runtime.
+
+Success is dependency-owned stack JSON:API without included resources. Lookup,
+API, and serialization failures are tool errors.
+
+## 12. State Versions
+
+### 12.1 `list_state_versions`
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `terraform_org_name` | string | Required | Trimmed |
+| `workspace_name` | string | Required | Trimmed |
+| `page`, `pageSize` | number | Shared pagination | Applied to API request |
+
+Success is JSON with `items` and pagination. Each item contains `id`,
+`created_at`, `serial`, `terraform_version`, `vcs_commit_sha`,
+`vcs_commit_url`, and `state_version`. An empty page is a tool error. API,
+pagination, and serialization failures are tool errors.
+
+### 12.2 `get_state_version`
+
+| Name | Type | Schema | Runtime behavior |
+| --- | --- | --- | --- |
+| `state_version_id` | string | Optional | Trimmed; all leading `#` characters removed |
+| `workspace_id` | string | Optional | Trimmed; all leading `#` characters removed |
+
+At least one identifier MUST be non-empty at runtime. If both are present,
+`state_version_id` takes precedence and reads that exact version. Otherwise the
+tool reads the workspace's current state version.
+
+Success is direct `encoding/json` serialization of the dependency-owned
+`go-tfe.StateVersion` object, not JSON:API. Because that type primarily carries
+JSON:API rather than `encoding/json` tags, output uses exported Go field names
+such as `ID`, `CreatedAt`, and `DownloadURL` and can include hosted-state URLs.
+Missing identifiers, API failures, and serialization failures are tool errors.


### PR DESCRIPTION
## Summary

- Add an implementation-derived behavioral specification under `spec/`.
- Document runtime, transport, authentication, security, resources, and observability behavior.
- Cover all 13 Registry tools and all 48 HCP Terraform/TFE tools.

@leefowlercu tried this out, take a look.

## Testing

- `go test ./pkg/... ./cmd/terraform-mcp-server`