### PR TITLE
Add context-cost badge (2,061 tokens, reproducibly measured)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ The Terraform MCP Server is a [Model Context Protocol (MCP)](https://modelcontex
 server that integrates seamlessly with [Terraform Registry](https://developer.hashicorp.com/terraform/registry/api-docs) and [HCP Terraform](https://developer.hashicorp.com/terraform/cloud-docs/api-docs) APIs, enabling advanced
 automation and interaction capabilities for Infrastructure as Code (IaC) development.
 
+[![context cost](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fathakur3%2Fmcp-context-cost%2Fmain%2Fbadges%2Fterraform.json)](https://athakur3.github.io/mcp-context-cost/METHODOLOGY)
+
 ## Table of Contents
 
 <table width="100%">


### PR DESCRIPTION
One line: a shields.io badge showing what terraform-mcp-server's tool schemas cost in context tokens — currently **2,061 tokens across 9 tools** (largest: `search_providers` at 484), measured 2026-08-16 from the official Docker image. For context, the median across 57 popular MCP servers we measured is 2,636.

The badge JSON lives in [our repo](https://github.com/athakur3/mcp-context-cost) and refreshes weekly; the number links to a reproducible methodology — raw `tools/list` capture + pinned `o200k_base` tokenizer, re-derivable in five lines from [results/terraform/measurement.json](https://github.com/athakur3/mcp-context-cost/blob/main/results/terraform/measurement.json).

If you'd rather not carry this, close freely — no hard feelings. To own the number in your own CI instead: sd2k/mcp-tokens-action (badge support proposed in sd2k/mcp-tokens-action#5).