### PR TITLE
fix `create_no_code_workspace` bug and add hcpt tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ FEATURES
 
 FIXES
 
-* `get_apply_logs` now checks the apply status before attempting to stream logs. If the apply is not yet in a terminal state (`finished`, `errored`, `canceled`), the tool returns an informative message instead of timing out.
+* `get_apply_logs` now checks the apply status before attempting to stream logs. If the apply is not yet in a terminal state (`finished`, `errored`, `canceled`), the tool returns an informative message instead of timing out. [468](https://github.com/hashicorp/terraform-mcp-server/pull/468)
+* Fix `create_no_code_workspace` elicitation to require only module inputs marked as required, allowing optional inputs to be omitted so Terraform module defaults are applied. [482](https://github.com/hashicorp/terraform-mcp-server/pull/482)
 
 # 1.2.0
 

--- a/pkg/tools/tfe/create_no_code_workspace.go
+++ b/pkg/tools/tfe/create_no_code_workspace.go
@@ -7,13 +7,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"path"
 	"strconv"
 	"strings"
 
 	"github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-mcp-server/pkg/client"
-	"github.com/hashicorp/terraform-mcp-server/pkg/utils"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	log "github.com/sirupsen/logrus"
@@ -52,6 +52,28 @@ func CreateNoCodeWorkspace(logger *log.Logger, mcpServer *server.MCPServer) serv
 }
 
 func createNoCodeWorkspaceHandler(ctx context.Context, request mcp.CallToolRequest, logger *log.Logger, mcpServer *server.MCPServer) (*mcp.CallToolResult, error) {
+	noCodeModuleID, err := request.RequireString("no_code_module_id")
+	if err != nil {
+		return ToolError(logger, "missing required input: no_code_module_id", err)
+	}
+	workspaceName, err := request.RequireString("workspace_name")
+	if err != nil {
+		return ToolError(logger, "missing required input: workspace_name", err)
+	}
+	projectID, err := request.RequireString("project_id")
+	if err != nil {
+		return ToolError(logger, "missing required input: project_id", err)
+	}
+
+	noCodeModuleID = strings.TrimSpace(noCodeModuleID)
+	workspaceName = strings.TrimSpace(workspaceName)
+	projectID = strings.TrimSpace(projectID)
+	autoApply := request.GetBool("auto_apply", false)
+
+	if !strings.HasPrefix(noCodeModuleID, "nocode-") {
+		return ToolError(logger, "no_code_module_id must start with 'nocode-'", nil)
+	}
+
 	tfeClient, err := client.GetTfeClientFromContext(ctx, logger)
 	if err != nil {
 		return ToolError(logger, "failed to get Terraform client", err)
@@ -60,37 +82,30 @@ func createNoCodeWorkspaceHandler(ctx context.Context, request mcp.CallToolReque
 		return ToolError(logger, "failed to get Terraform client - ensure TFE_TOKEN and TFE_ADDRESS are configured", nil)
 	}
 
-	params, err := extractRequestParams(request)
+	project, noCodeModule, moduleMetadata, err := fetchModuleData(ctx, tfeClient, projectID, noCodeModuleID)
 	if err != nil {
 		return ToolError(logger, err.Error(), nil)
 	}
 
-	if !strings.HasPrefix(params.noCodeModuleID, "nocode-") {
-		return ToolError(logger, "no_code_module_id must start with 'nocode-'", nil)
-	}
+	// parse the returned module meta data to get required variable names for the module and all other variabels information correctly
+	elicitationSchema := buildElicitationSchema(moduleMetadata, noCodeModule)
 
-	project, noCodeModule, moduleMetadata, err := fetchModuleData(ctx, tfeClient, params.projectID, params.noCodeModuleID)
+	// return client response for the elicitation message
+	result, err := requestVariableValues(ctx, mcpServer, noCodeModuleID, elicitationSchema)
 	if err != nil {
 		return ToolError(logger, err.Error(), nil)
 	}
 
-	elicitationProperties, requestedVars := buildElicitationSchema(moduleMetadata, noCodeModule)
-
-	result, err := requestVariableValues(ctx, mcpServer, params.noCodeModuleID, elicitationProperties, requestedVars)
+	variables, err := processElicitationResponse(result, elicitationSchema)
 	if err != nil {
 		return ToolError(logger, err.Error(), nil)
 	}
 
-	variables, err := processElicitationResponse(result, requestedVars, elicitationProperties)
-	if err != nil {
-		return ToolError(logger, err.Error(), nil)
-	}
-
-	workspace, err := tfeClient.RegistryNoCodeModules.CreateWorkspace(ctx, params.noCodeModuleID, &tfe.RegistryNoCodeModuleCreateWorkspaceOptions{
-		Name:      params.workspaceName,
+	workspace, err := tfeClient.RegistryNoCodeModules.CreateWorkspace(ctx, noCodeModuleID, &tfe.RegistryNoCodeModuleCreateWorkspaceOptions{
+		Name:      workspaceName,
 		Project:   project,
 		Variables: variables,
-		AutoApply: &params.autoApply,
+		AutoApply: &autoApply,
 	})
 	if err != nil {
 		return ToolError(logger, "failed to create No Code module workspace", err)
@@ -103,37 +118,6 @@ func createNoCodeWorkspaceHandler(ctx context.Context, request mcp.CallToolReque
 	}
 
 	return mcp.NewToolResultText(buf.String()), nil
-}
-
-type workspaceParams struct {
-	noCodeModuleID string
-	workspaceName  string
-	projectID      string
-	autoApply      bool
-}
-
-func extractRequestParams(request mcp.CallToolRequest) (*workspaceParams, error) {
-	noCodeModuleID, err := request.RequireString("no_code_module_id")
-	if err != nil {
-		return nil, fmt.Errorf("missing required input: no_code_module_id")
-	}
-
-	workspaceName, err := request.RequireString("workspace_name")
-	if err != nil {
-		return nil, fmt.Errorf("missing required input: workspace_name")
-	}
-
-	projectID, err := request.RequireString("project_id")
-	if err != nil {
-		return nil, fmt.Errorf("missing required input: project_id")
-	}
-
-	return &workspaceParams{
-		noCodeModuleID: noCodeModuleID,
-		workspaceName:  workspaceName,
-		projectID:      projectID,
-		autoApply:      request.GetBool("auto_apply", false),
-	}, nil
 }
 
 func fetchModuleData(ctx context.Context, tfeClient *tfe.Client, projectID, noCodeModuleID string) (*tfe.Project, *tfe.RegistryNoCodeModule, *client.ModuleMetadata, error) {
@@ -155,58 +139,70 @@ func fetchModuleData(ctx context.Context, tfeClient *tfe.Client, projectID, noCo
 	}
 
 	metadataPath := path.Join("/api/registry/private/v2/modules", registryModule.Namespace, registryModule.Name, registryModule.Provider, "metadata", noCodeModule.VersionPin)
-	metadataData, err := utils.MakeCustomGetRequestRaw(ctx, tfeClient, metadataPath, map[string][]string{"organization_name": {noCodeModule.Organization.Name}})
+	metadataRequest, err := tfeClient.NewRequestWithAdditionalQueryParams(
+		http.MethodGet,
+		metadataPath,
+		nil,
+		map[string][]string{"organization_name": {noCodeModule.Organization.Name}},
+	)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to fetch module metadata: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to create module metadata request: %w", err)
 	}
 
 	var moduleMetadata client.ModuleMetadata
-	if err := json.Unmarshal(metadataData, &moduleMetadata); err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to parse module metadata: %w", err)
+	if err := metadataRequest.DoJSON(ctx, &moduleMetadata); err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to fetch module metadata: %w", err)
 	}
 
 	return project, noCodeModule, &moduleMetadata, nil
 }
 
-func buildElicitationSchema(moduleMetadata *client.ModuleMetadata, noCodeModule *tfe.RegistryNoCodeModule) (map[string]any, []string) {
-	elicitationProperties := make(map[string]any)
-	requestedVars := make([]string, 0, len(moduleMetadata.Data.Attributes.InputVariables))
-
-	for _, inputVar := range moduleMetadata.Data.Attributes.InputVariables {
-		property := buildPropertySchema(inputVar, noCodeModule)
-		elicitationProperties[inputVar.Name] = property
-		requestedVars = append(requestedVars, inputVar.Name)
-	}
-
-	return elicitationProperties, requestedVars
+type moduleElicitationSchema struct {
+	properties    map[string]any
+	variableNames []string
+	requiredNames []string
+	requiredSet   map[string]struct{}
 }
 
-func buildPropertySchema(inputVar struct {
-	Name        string `json:"name"`
-	Type        string `json:"type"`
-	Description string `json:"description"`
-	Required    bool   `json:"required"`
-	Sensitive   bool   `json:"sensitive"`
-}, noCodeModule *tfe.RegistryNoCodeModule) map[string]any {
-	property := map[string]any{
-		"title":       inputVar.Name,
-		"description": inputVar.Description,
-		"type":        mapTerraformTypeToJSON(inputVar.Type),
+func buildElicitationSchema(moduleMetadata *client.ModuleMetadata, noCodeModule *tfe.RegistryNoCodeModule) *moduleElicitationSchema {
+	inputCount := len(moduleMetadata.Data.Attributes.InputVariables)
+	schema := &moduleElicitationSchema{
+		properties:    make(map[string]any, inputCount),
+		variableNames: make([]string, 0, inputCount),
+		requiredNames: make([]string, 0, inputCount),
+		requiredSet:   make(map[string]struct{}, inputCount),
 	}
 
-	if enumOptions := findEnumOptions(inputVar.Name, inputVar.Type, noCodeModule.VariableOptions); enumOptions != nil {
-		property["enum"] = enumOptions
+	for _, inputVar := range moduleMetadata.Data.Attributes.InputVariables {
+		property := map[string]any{
+			"title":       inputVar.Name,
+			"description": inputVar.Description,
+			"type":        mapTerraformTypeToJSON(inputVar.Type),
+		}
+		if enumOptions := findEnumOptions(inputVar.Name, inputVar.Type, noCodeModule.VariableOptions); enumOptions != nil {
+			property["enum"] = enumOptions
+		}
+
+		schema.properties[inputVar.Name] = property
+		schema.variableNames = append(schema.variableNames, inputVar.Name)
+		if inputVar.Required {
+			schema.requiredNames = append(schema.requiredNames, inputVar.Name)
+			schema.requiredSet[inputVar.Name] = struct{}{}
+		}
 	}
 
-	return property
+	return schema
+}
+
+func (s *moduleElicitationSchema) isRequired(variableName string) bool {
+	_, required := s.requiredSet[variableName]
+	return required
 }
 
 func mapTerraformTypeToJSON(tfType string) string {
 	switch tfType {
-	case "string":
-		return "string"
-	case "number":
-		return "number"
+	case "string", "number":
+		return tfType
 	case "bool":
 		return "boolean"
 	default:
@@ -258,14 +254,14 @@ func convertToBoolEnum(options []string) []bool {
 	return nil
 }
 
-func requestVariableValues(ctx context.Context, mcpServer *server.MCPServer, moduleID string, properties map[string]any, required []string) (*mcp.ElicitationResult, error) {
+func requestVariableValues(ctx context.Context, mcpServer *server.MCPServer, moduleID string, schema *moduleElicitationSchema) (*mcp.ElicitationResult, error) {
 	request := mcp.ElicitationRequest{
 		Params: mcp.ElicitationParams{
-			Message: fmt.Sprintf("The No Code module '%s' requires %d variable(s) to create the workspace. Please provide values for the required variables.", moduleID, len(required)),
+			Message: fmt.Sprintf("The No Code module '%s' requires %d variable(s) to create the workspace. Please provide values for the required variables.", moduleID, len(schema.requiredNames)),
 			RequestedSchema: map[string]any{
 				"type":       "object",
-				"properties": properties,
-				"required":   required,
+				"properties": schema.properties,
+				"required":   schema.requiredNames,
 			},
 		},
 	}
@@ -278,28 +274,42 @@ func requestVariableValues(ctx context.Context, mcpServer *server.MCPServer, mod
 	return result, nil
 }
 
-func processElicitationResponse(result *mcp.ElicitationResult, requestedVars []string, elicitationProperties map[string]any) ([]*tfe.Variable, error) {
+func processElicitationResponse(result *mcp.ElicitationResult, schema *moduleElicitationSchema) ([]*tfe.Variable, error) {
 	switch result.Action {
 	case mcp.ElicitationResponseActionDecline:
 		return nil, fmt.Errorf("workspace creation declined by user")
 	case mcp.ElicitationResponseActionCancel:
 		return nil, fmt.Errorf("workspace creation cancelled by user")
 	case mcp.ElicitationResponseActionAccept:
-		return extractVariablesFromResponse(result.Content, requestedVars, elicitationProperties)
+		return extractVariablesFromResponse(result.Content, schema)
 	default:
 		return nil, fmt.Errorf("unexpected elicitation response action: %s", result.Action)
 	}
 }
 
-func extractVariablesFromResponse(content any, requestedVars []string, elicitationProperties map[string]any) ([]*tfe.Variable, error) {
+func extractVariablesFromResponse(content any, schema *moduleElicitationSchema) ([]*tfe.Variable, error) {
 	data, ok := content.(map[string]any)
 	if !ok {
 		return nil, fmt.Errorf("elicitation response content is not a map, got %T", content)
 	}
 
-	variables := make([]*tfe.Variable, 0, len(requestedVars))
-	for _, varName := range requestedVars {
-		variable, err := createVariable(varName, data, elicitationProperties)
+	variables := make([]*tfe.Variable, 0, len(schema.variableNames))
+	for _, varName := range schema.variableNames {
+		valueRaw, exists := data[varName]
+		if !exists {
+			if schema.isRequired(varName) {
+				return nil, fmt.Errorf("required variable '%s' is missing from response", varName)
+			}
+			continue
+		}
+
+		// A blank optional form field means that the caller did not override the
+		// module value. Omit it from the API request so Terraform uses its default.
+		if strValue, isString := valueRaw.(string); isString && strValue == "" && !schema.isRequired(varName) {
+			continue
+		}
+
+		variable, err := createVariable(varName, valueRaw, schema.properties)
 		if err != nil {
 			return nil, err
 		}
@@ -309,12 +319,7 @@ func extractVariablesFromResponse(content any, requestedVars []string, elicitati
 	return variables, nil
 }
 
-func createVariable(varName string, data map[string]any, elicitationProperties map[string]any) (*tfe.Variable, error) {
-	valueRaw, exists := data[varName]
-	if !exists {
-		return nil, fmt.Errorf("required variable '%s' is missing from response", varName)
-	}
-
+func createVariable(varName string, valueRaw any, elicitationProperties map[string]any) (*tfe.Variable, error) {
 	propertyDef, ok := elicitationProperties[varName].(map[string]any)
 	if !ok {
 		return nil, fmt.Errorf("invalid property definition for variable '%s'", varName)

--- a/pkg/tools/tfe/create_no_code_workspace.go
+++ b/pkg/tools/tfe/create_no_code_workspace.go
@@ -87,7 +87,7 @@ func createNoCodeWorkspaceHandler(ctx context.Context, request mcp.CallToolReque
 		return ToolError(logger, err.Error(), nil)
 	}
 
-	// parse the returned module meta data to get required variable names for the module and all other variabels information correctly
+	// build the elicitation schema from the module's metadata and configured variable options
 	elicitationSchema := buildElicitationSchema(moduleMetadata, noCodeModule)
 
 	// return client response for the elicitation message

--- a/pkg/tools/tfe/create_no_code_workspace_test.go
+++ b/pkg/tools/tfe/create_no_code_workspace_test.go
@@ -51,68 +51,27 @@ func TestCreateNoCodeWorkspace(t *testing.T) {
 	})
 }
 
-func TestBuildElicitationSchemaOnlyRequiresRequiredVariables(t *testing.T) {
+func TestBuildElicitationSchema(t *testing.T) {
 	moduleMetadata := testNoCodeModuleMetadata(t)
 
 	schema := buildElicitationSchema(moduleMetadata, &tfe.RegistryNoCodeModule{})
 
 	assert.Equal(t, []string{"name"}, schema.requiredNames)
-	require.Len(t, schema.properties, 4)
+	require.Len(t, schema.properties, 2)
 	assert.Contains(t, schema.properties, "name")
 	assert.Contains(t, schema.properties, "description")
-	assert.Contains(t, schema.properties, "enabled")
-	assert.Contains(t, schema.properties, "count")
 }
 
-func TestExtractVariablesFromResponseHonorsOptionalVariables(t *testing.T) {
+func TestExtractVariablesFromResponse(t *testing.T) {
 	moduleMetadata := testNoCodeModuleMetadata(t)
 	schema := buildElicitationSchema(moduleMetadata, &tfe.RegistryNoCodeModule{})
 
-	t.Run("omitted optional variables use module defaults", func(t *testing.T) {
-		variables, err := extractVariablesFromResponse(map[string]any{"name": "example"}, schema)
+	variables, err := extractVariablesFromResponse(map[string]any{"name": "example"}, schema)
 
-		require.NoError(t, err)
-		require.Len(t, variables, 1)
-		assert.Equal(t, "name", variables[0].Key)
-		assert.Equal(t, "example", variables[0].Value)
-	})
-
-	t.Run("empty optional string uses module default", func(t *testing.T) {
-		variables, err := extractVariablesFromResponse(
-			map[string]any{"name": "example", "description": ""},
-			schema,
-		)
-
-		require.NoError(t, err)
-		require.Len(t, variables, 1)
-		assert.Equal(t, "name", variables[0].Key)
-	})
-
-	t.Run("false and zero optional values are preserved", func(t *testing.T) {
-		variables, err := extractVariablesFromResponse(
-			map[string]any{"name": "example", "enabled": false, "count": float64(0)},
-			schema,
-		)
-
-		require.NoError(t, err)
-		require.Len(t, variables, 3)
-		assert.Equal(t, "enabled", variables[1].Key)
-		assert.Equal(t, "false", variables[1].Value)
-		assert.Equal(t, "count", variables[2].Key)
-		assert.Equal(t, "0", variables[2].Value)
-	})
-
-	t.Run("missing required variable remains invalid", func(t *testing.T) {
-		_, err := extractVariablesFromResponse(map[string]any{}, schema)
-
-		require.EqualError(t, err, "required variable 'name' is missing from response")
-	})
-
-	t.Run("empty required string remains invalid", func(t *testing.T) {
-		_, err := extractVariablesFromResponse(map[string]any{"name": ""}, schema)
-
-		require.EqualError(t, err, "variable 'name' cannot be empty")
-	})
+	require.NoError(t, err)
+	require.Len(t, variables, 1)
+	assert.Equal(t, "name", variables[0].Key)
+	assert.Equal(t, "example", variables[0].Value)
 }
 
 func testNoCodeModuleMetadata(t *testing.T) *client.ModuleMetadata {
@@ -123,9 +82,7 @@ func testNoCodeModuleMetadata(t *testing.T) *client.ModuleMetadata {
 			"attributes": {
 				"input-variables": [
 					{"name": "name", "type": "string", "required": true},
-					{"name": "description", "type": "string", "required": false},
-					{"name": "enabled", "type": "bool", "required": false},
-					{"name": "count", "type": "number", "required": false}
+					{"name": "description", "type": "string", "required": false}
 				]
 			}
 		}

--- a/pkg/tools/tfe/create_no_code_workspace_test.go
+++ b/pkg/tools/tfe/create_no_code_workspace_test.go
@@ -4,11 +4,15 @@
 package tools
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-mcp-server/pkg/client"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateNoCodeWorkspace(t *testing.T) {
@@ -28,16 +32,15 @@ func TestCreateNoCodeWorkspace(t *testing.T) {
 		// Check required parameters
 		assert.Contains(t, tool.Tool.InputSchema.Required, "no_code_module_id")
 		assert.Contains(t, tool.Tool.InputSchema.Required, "workspace_name")
+		assert.Contains(t, tool.Tool.InputSchema.Required, "project_id")
 
-		// Check that it accepts open world parameters (for dynamic variables)
-		// The tool should be configured to accept additional parameters beyond those defined
+		// Check the declared tool inputs.
 		assert.NotNil(t, tool.Tool.InputSchema.Properties)
 		assert.Contains(t, tool.Tool.InputSchema.Properties, "no_code_module_id")
 		assert.Contains(t, tool.Tool.InputSchema.Properties, "workspace_name")
 		assert.Contains(t, tool.Tool.InputSchema.Properties, "auto_apply")
 
-		// Verify the tool has elicitation capabilities through its configuration
-		// The WithOpenWorldHintAnnotation(true) allows for dynamic parameter acceptance
+		// The tool interacts with an external HCP Terraform organization.
 		annotations := tool.Tool.Annotations
 		assert.NotNil(t, annotations)
 		assert.NotNil(t, annotations.OpenWorldHint)
@@ -46,4 +49,89 @@ func TestCreateNoCodeWorkspace(t *testing.T) {
 		// Handler should not be nil
 		assert.NotNil(t, tool.Handler)
 	})
+}
+
+func TestBuildElicitationSchemaOnlyRequiresRequiredVariables(t *testing.T) {
+	moduleMetadata := testNoCodeModuleMetadata(t)
+
+	schema := buildElicitationSchema(moduleMetadata, &tfe.RegistryNoCodeModule{})
+
+	assert.Equal(t, []string{"name"}, schema.requiredNames)
+	require.Len(t, schema.properties, 4)
+	assert.Contains(t, schema.properties, "name")
+	assert.Contains(t, schema.properties, "description")
+	assert.Contains(t, schema.properties, "enabled")
+	assert.Contains(t, schema.properties, "count")
+}
+
+func TestExtractVariablesFromResponseHonorsOptionalVariables(t *testing.T) {
+	moduleMetadata := testNoCodeModuleMetadata(t)
+	schema := buildElicitationSchema(moduleMetadata, &tfe.RegistryNoCodeModule{})
+
+	t.Run("omitted optional variables use module defaults", func(t *testing.T) {
+		variables, err := extractVariablesFromResponse(map[string]any{"name": "example"}, schema)
+
+		require.NoError(t, err)
+		require.Len(t, variables, 1)
+		assert.Equal(t, "name", variables[0].Key)
+		assert.Equal(t, "example", variables[0].Value)
+	})
+
+	t.Run("empty optional string uses module default", func(t *testing.T) {
+		variables, err := extractVariablesFromResponse(
+			map[string]any{"name": "example", "description": ""},
+			schema,
+		)
+
+		require.NoError(t, err)
+		require.Len(t, variables, 1)
+		assert.Equal(t, "name", variables[0].Key)
+	})
+
+	t.Run("false and zero optional values are preserved", func(t *testing.T) {
+		variables, err := extractVariablesFromResponse(
+			map[string]any{"name": "example", "enabled": false, "count": float64(0)},
+			schema,
+		)
+
+		require.NoError(t, err)
+		require.Len(t, variables, 3)
+		assert.Equal(t, "enabled", variables[1].Key)
+		assert.Equal(t, "false", variables[1].Value)
+		assert.Equal(t, "count", variables[2].Key)
+		assert.Equal(t, "0", variables[2].Value)
+	})
+
+	t.Run("missing required variable remains invalid", func(t *testing.T) {
+		_, err := extractVariablesFromResponse(map[string]any{}, schema)
+
+		require.EqualError(t, err, "required variable 'name' is missing from response")
+	})
+
+	t.Run("empty required string remains invalid", func(t *testing.T) {
+		_, err := extractVariablesFromResponse(map[string]any{"name": ""}, schema)
+
+		require.EqualError(t, err, "variable 'name' cannot be empty")
+	})
+}
+
+func testNoCodeModuleMetadata(t *testing.T) *client.ModuleMetadata {
+	t.Helper()
+
+	metadataJSON := []byte(`{
+		"data": {
+			"attributes": {
+				"input-variables": [
+					{"name": "name", "type": "string", "required": true},
+					{"name": "description", "type": "string", "required": false},
+					{"name": "enabled", "type": "bool", "required": false},
+					{"name": "count", "type": "number", "required": false}
+				]
+			}
+		}
+	}`)
+
+	var moduleMetadata client.ModuleMetadata
+	require.NoError(t, json.Unmarshal(metadataJSON, &moduleMetadata))
+	return &moduleMetadata
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -115,6 +115,7 @@ func GetEnv(key, fallback string) string {
 	return fallback
 }
 
+// TODO: could be deprecated if raw bytes return for a future endpoint is no longer needed
 // This function is used for custom GET requests using the TFE client.
 func MakeCustomGetRequestRaw(ctx context.Context, client *tfe.Client, path string, additionalQueryParams map[string][]string) ([]byte, error) {
 	req, err := client.NewRequestWithAdditionalQueryParams("GET", path, nil, additionalQueryParams)

--- a/test/terraform/terraform_test.go
+++ b/test/terraform/terraform_test.go
@@ -55,10 +55,18 @@ func init() {
 	tfeUserEmail = os.Getenv("TFE_USER_EMAIL")
 	enableTfOperations = os.Getenv("ENABLE_TF_OPERATIONS")
 
+	// ElicitationHandler is used to provide default values for required parameters during no_code workspace creation.
 	testingClient = mcp.NewClient(&mcp.Implementation{
 		Name:    "terraform-mcp-server-test-harness",
 		Version: "v0.0.0",
-	}, nil)
+	}, &mcp.ClientOptions{
+		ElicitationHandler: func(context.Context, *mcp.ElicitRequest) (*mcp.ElicitResult, error) {
+			return &mcp.ElicitResult{
+				Action:  "accept",
+				Content: map[string]any{"name": "integration-test"},
+			}, nil
+		},
+	})
 }
 
 func newTestingSession(t *testing.T) *mcp.ClientSession {

--- a/test/terraform/testdata/no_code_workspace_module/README.md
+++ b/test/terraform/testdata/no_code_workspace_module/README.md
@@ -1,0 +1,5 @@
+# No-code workspace integration fixture
+
+This module has one required input and one optional input with a default. It is
+used to verify that `create_no_code_workspace` does not require the optional
+input during elicitation.

--- a/test/terraform/testdata/no_code_workspace_module/main.tf
+++ b/test/terraform/testdata/no_code_workspace_module/main.tf
@@ -1,0 +1,20 @@
+variable "name" {
+  description = "Required name used by the no-code workspace integration test."
+  type        = string
+}
+
+variable "description" {
+  description = "Optional description used to verify that module defaults are honored."
+  type        = string
+  default     = ""
+}
+
+output "name" {
+  description = "The supplied name."
+  value       = var.name
+}
+
+output "description" {
+  description = "The optional description."
+  value       = var.description
+}

--- a/test/terraform/workspace_test.go
+++ b/test/terraform/workspace_test.go
@@ -1,7 +1,10 @@
 package terraform
 
 import (
+	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-tfe"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -9,6 +12,92 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 )
+
+func TestCreateNoCodeWorkspace(t *testing.T) {
+	requireTfOperations(t)
+
+	s := newTestingSession(t)
+	defer s.Close()
+
+	client := tfeClient(t)
+
+	project, err := client.Projects.Create(t.Context(), tfeOrgName, tfe.ProjectCreateOptions{
+		Name: randomName("nocode-project-"),
+	})
+	require.NoError(t, err, "failed to create test project")
+	defer client.Projects.Delete(t.Context(), project.ID)
+
+	module, err := client.RegistryModules.Create(t.Context(), tfeOrgName, tfe.RegistryModuleCreateOptions{
+		Name:         tfe.String(randomName("nocode-module-")),
+		Provider:     tfe.String("testprovider"),
+		RegistryName: tfe.PrivateRegistry,
+	})
+	require.NoError(t, err, "failed to create test private module")
+
+	moduleID := tfe.RegistryModuleID{
+		Organization: tfeOrgName,
+		Namespace:    module.Namespace,
+		Name:         module.Name,
+		Provider:     module.Provider,
+		RegistryName: tfe.PrivateRegistry,
+	}
+	defer client.RegistryModules.DeleteProvider(t.Context(), moduleID)
+
+	const moduleVersion = "1.0.0"
+	version, err := client.RegistryModules.CreateVersion(t.Context(), moduleID, tfe.RegistryModuleCreateVersionOptions{
+		Version: tfe.String(moduleVersion),
+	})
+	require.NoError(t, err, "failed to create test private module version")
+	require.NoError(t, client.RegistryModules.Upload(t.Context(), *version, "testdata/no_code_workspace_module"), "failed to upload test private module")
+
+	waitFor(t, 2*time.Minute, fmt.Sprintf("private module %q version %s to finish processing", module.Name, moduleVersion), func(ctx context.Context) (*tfe.TerraformRegistryModule, error) {
+		registryModule, err := client.RegistryModules.ReadTerraformRegistryModule(ctx, moduleID, moduleVersion)
+		if err != nil {
+			return nil, err
+		}
+		if registryModule == nil || len(registryModule.Root.Inputs) != 2 || len(registryModule.Root.Outputs) != 2 {
+			return nil, nil
+		}
+		return registryModule, nil
+	})
+
+	noCodeModule, err := client.RegistryNoCodeModules.Create(t.Context(), tfeOrgName, tfe.RegistryNoCodeModuleCreateOptions{
+		RegistryModule: module,
+		Enabled:        tfe.Bool(true),
+		VersionPin:     moduleVersion,
+	})
+	require.NoError(t, err, "failed to enable the test module for no-code provisioning")
+	defer client.RegistryNoCodeModules.Delete(t.Context(), noCodeModule.ID)
+
+	workspaceName := randomName("nocode_workspace_")
+	// No-code workspace creation starts a run. Force-delete this test-owned
+	// workspace so a pending manual-apply run cannot block cleanup.
+	defer client.Workspaces.Delete(t.Context(), tfeOrgName, workspaceName)
+
+	result, resultText := callTool(t, s, "create_no_code_workspace", map[string]any{
+		"no_code_module_id": noCodeModule.ID,
+		"workspace_name":    workspaceName,
+		"project_id":        project.ID,
+		"auto_apply":        false,
+	})
+	require.False(t, result.IsError, "create_no_code_workspace should not return an error: %s", resultText)
+	require.NotEmpty(t, resultText, "create_no_code_workspace result should not be empty")
+
+	workspaceID := gjson.Get(resultText, "data.attributes.workspace_id").String()
+	require.NotEmpty(t, workspaceID, "create_no_code_workspace should return a workspace_id")
+
+	workspace, err := client.Workspaces.ReadByID(t.Context(), workspaceID)
+	require.NoError(t, err, "created no-code workspace could not be read through the TFE API")
+	assert.Equal(t, workspaceName, workspace.Name)
+	assert.False(t, workspace.AutoApply)
+	assert.Equal(t, project.ID, workspace.Project.ID)
+
+	variables, err := client.Variables.List(t.Context(), workspaceID, nil)
+	require.NoError(t, err, "failed to list variables for the created no-code workspace")
+	require.Len(t, variables.Items, 1, "only the required module input should be set on the workspace")
+	assert.Equal(t, "name", variables.Items[0].Key)
+	assert.Equal(t, "integration-test", variables.Items[0].Value)
+}
 
 func TestWorkspaceHappyPath(t *testing.T) {
 	requireTfOperations(t)


### PR DESCRIPTION
## Summary

- Fix `create_no_code_workspace` so optional module inputs are not required during MCP elicitation.
Previously, every module input was included in the elicitation schema's `required` list, and every response field was expected to be present. This prevented HCP Terraform from applying defaults for optional module variables.
- add `create_no_code_workspace` unit tests and integration test.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
