### PR TITLE
State inspection tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ FEATURES
 * [New Tool] `add_team_member` Adds a single member to a Terraform Cloud/Enterprise team. Requires `team_id`; accepts either `username` (accepted-invite users only) or `organization_membership_id` (works for pending and accepted invites). Exactly one must be provided.
 * [New Tool] `grant_team_access` Grants a team access to a workspace or project by ID. Requires `team_id`, `access_level`, and either `workspace_id` or `project_id` (mutually exclusive). Valid access levels for workspaces: `admin`, `read`, `write`, `plan`, `custom`. Valid access levels for projects: `admin`, `read`, `write`, `maintain`, `custom`.
 * [New Tool] `delete_team` Permanently deletes a Terraform team by its `team_id`. Requires `team_id` (e.g. `team-abc123def456`). This is a destructive operation and must set `ENABLE_TF_OPERATIONS=true`.
+* [New Tool] `get_state_summary` Generates a high-level summary of a workspace's current Terraform state — resource counts by type and module, output names, Terraform version, and state serial — without any resource attributes. Requires `terraform_org_name` and `workspace_name`. [437](https://github.com/hashicorp/terraform-mcp-server/issues/437)
+* [New Tool] `list_state_resources` Lists resource addresses, types, and modules in a workspace's current Terraform state, with optional `type_filter`/`module_filter`, without dumping attributes. Requires `terraform_org_name` and `workspace_name`. [437](https://github.com/hashicorp/terraform-mcp-server/pull/484)
+* [New Tool] `get_state_resource` Fetches complete, redacted attributes for a single resource in a workspace's current Terraform state by its address (e.g. `aws_s3_bucket.assets`). Requires `terraform_org_name`, `workspace_name`, and `address`. [437](https://github.com/hashicorp/terraform-mcp-server/pull/484)
+* [New Tool] `search_state_attributes` Searches for a substring across resource attribute values in a workspace's current Terraform state and returns only the matching resources and fields. Requires `terraform_org_name`, `workspace_name`, and `query`; optional `resource_type`. [437](https://github.com/hashicorp/terraform-mcp-server/pull/484)
 
 FIXES
 

--- a/pkg/tools/dynamic_tool.go
+++ b/pkg/tools/dynamic_tool.go
@@ -381,6 +381,27 @@ func (r *DynamicToolRegistry) registerTFETools() {
 		r.mcpServer.AddTool(tool.Tool, tool.Handler)
 	}
 
+	// Terraform State-Inspection Toolset
+	if toolsets.IsToolEnabled("list_state_resources", r.enabledToolsets) {
+		tool := r.createDynamicTFETool("list_state_resources", tfeTools.ListStateResources)
+		r.mcpServer.AddTool(tool.Tool, tool.Handler)
+	}
+
+	if toolsets.IsToolEnabled("get_state_resource", r.enabledToolsets) {
+		tool := r.createDynamicTFETool("get_state_resource", tfeTools.GetStateResource)
+		r.mcpServer.AddTool(tool.Tool, tool.Handler)
+	}
+
+	if toolsets.IsToolEnabled("search_state_attributes", r.enabledToolsets) {
+		tool := r.createDynamicTFETool("search_state_attributes", tfeTools.SearchStateAttributes)
+		r.mcpServer.AddTool(tool.Tool, tool.Handler)
+	}
+
+	if toolsets.IsToolEnabled("get_state_summary", r.enabledToolsets) {
+		tool := r.createDynamicTFETool("get_state_summary", tfeTools.GetStateSummary)
+		r.mcpServer.AddTool(tool.Tool, tool.Handler)
+	}
+
 	// Terraform Toolset - Comments
 	if toolsets.IsToolEnabled("get_run_comments", r.enabledToolsets) {
 		tool := r.createDynamicTFETool("get_run_comments", tfeTools.GetRunComments)

--- a/pkg/tools/tfe/get_state_resource.go
+++ b/pkg/tools/tfe/get_state_resource.go
@@ -1,0 +1,82 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	log "github.com/sirupsen/logrus"
+)
+
+// GetStateResource creates a tool to fetch a single resource's full attributes from a
+// workspace's current state.
+func GetStateResource(logger *log.Logger) server.ServerTool {
+	return server.ServerTool{
+		Tool: mcp.NewTool("get_state_resource",
+			mcp.WithDescription("Get complete details for a single resource in a workspace's current Terraform state, "+
+				"identified by its state address (e.g. \"aws_s3_bucket.assets\" or \"module.vpc.aws_vpc.main\"). "+
+				"Values flagged sensitive in state are redacted; unflagged secrets may still appear, so review "+
+				"output before sharing. Use list_state_resources first if you don't know the exact address."),
+			mcp.WithTitleAnnotation("Get Terraform State Resource"),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithDestructiveHintAnnotation(false),
+			mcp.WithOpenWorldHintAnnotation(true),
+			mcp.WithString("terraform_org_name",
+				mcp.Required(),
+				mcp.Description(terraformOrgNameDescription),
+			),
+			mcp.WithString("workspace_name",
+				mcp.Required(),
+				mcp.Description("The name of the workspace to read state from"),
+			),
+			mcp.WithString("address",
+				mcp.Required(),
+				mcp.Description(`Full resource address from state, e.g. "aws_s3_bucket.assets" or "module.vpc.aws_vpc.main"`),
+			),
+		),
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return getStateResourceHandler(ctx, request, logger)
+		},
+	}
+}
+
+// getStateResourceHandler handles tool logics and functionality
+func getStateResourceHandler(ctx context.Context, request mcp.CallToolRequest, logger *log.Logger) (*mcp.CallToolResult, error) {
+	orgName, err := request.RequireString("terraform_org_name")
+	if err != nil {
+		return ToolError(logger, "missing required input: terraform_org_name", err)
+	}
+	workspaceName, err := request.RequireString("workspace_name")
+	if err != nil {
+		return ToolError(logger, "missing required input: workspace_name", err)
+	}
+	address, err := request.RequireString("address")
+	if err != nil {
+		return ToolError(logger, "missing required input: address", err)
+	}
+	orgName = strings.TrimSpace(orgName)
+	workspaceName = strings.TrimSpace(workspaceName)
+	address = strings.TrimSpace(address)
+
+	state, err := resolveWorkspaceState(ctx, orgName, workspaceName, logger)
+	if err != nil {
+		return ToolError(logger, "loading Terraform state", err)
+	}
+
+	for _, r := range extractResources(state) {
+		if r.Address == address {
+			data, err := json.MarshalIndent(r, "", "  ")
+			if err != nil {
+				return ToolError(logger, "marshaling resource", err)
+			}
+			return mcp.NewToolResultText(string(data)), nil
+		}
+	}
+
+	return ToolErrorf(logger, "resource %q not found in workspace '%s' state — use list_state_resources to see available addresses", address, workspaceName)
+}

--- a/pkg/tools/tfe/get_state_summary.go
+++ b/pkg/tools/tfe/get_state_summary.go
@@ -1,0 +1,133 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tools
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	log "github.com/sirupsen/logrus"
+)
+
+// GetStateSummary creates a tool to generate a high-level summary of a workspace's current
+// Terraform state.
+func GetStateSummary(logger *log.Logger) server.ServerTool {
+	return server.ServerTool{
+		Tool: mcp.NewTool("get_state_summary",
+			mcp.WithDescription("Generate a high-level summary of a workspace's current Terraform state, including "+
+				"resource counts by type and module, output names, Terraform version, and state serial number — "+
+				"without the resources' attributes. Useful as a first pass before diving into specific resources."),
+			mcp.WithTitleAnnotation("Summarize Terraform State"),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithDestructiveHintAnnotation(false),
+			mcp.WithOpenWorldHintAnnotation(true),
+			mcp.WithString("terraform_org_name",
+				mcp.Required(),
+				mcp.Description(terraformOrgNameDescription),
+			),
+			mcp.WithString("workspace_name",
+				mcp.Required(),
+				mcp.Description("The name of the workspace to read state from"),
+			),
+		),
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return getStateSummaryHandler(ctx, request, logger)
+		},
+	}
+}
+
+// getStateSummaryHandler handles tool logics and functionality
+func getStateSummaryHandler(ctx context.Context, request mcp.CallToolRequest, logger *log.Logger) (*mcp.CallToolResult, error) {
+	orgName, err := request.RequireString("terraform_org_name")
+	if err != nil {
+		return ToolError(logger, "missing required input: terraform_org_name", err)
+	}
+	workspaceName, err := request.RequireString("workspace_name")
+	if err != nil {
+		return ToolError(logger, "missing required input: workspace_name", err)
+	}
+	orgName = strings.TrimSpace(orgName)
+	workspaceName = strings.TrimSpace(workspaceName)
+
+	state, err := resolveWorkspaceState(ctx, orgName, workspaceName, logger)
+	if err != nil {
+		return ToolError(logger, "loading Terraform state", err)
+	}
+
+	resources := extractResources(state)
+
+	typeCounts := make(map[string]int)
+	moduleCounts := make(map[string]int)
+	for _, r := range resources {
+		typeCounts[r.Type]++
+		moduleCounts[r.Module]++
+	}
+
+	types := make([]string, 0, len(typeCounts))
+	for t := range typeCounts {
+		types = append(types, t)
+	}
+	sort.Strings(types)
+
+	modules := make([]string, 0, len(moduleCounts))
+	for m := range moduleCounts {
+		modules = append(modules, m)
+	}
+	sort.Strings(modules)
+
+	var lines []string
+	lines = append(lines, "# Terraform State Summary")
+	lines = append(lines, "")
+	lines = append(lines, fmt.Sprintf("Workspace:         %s / %s", orgName, workspaceName))
+	lines = append(lines, fmt.Sprintf("Terraform version: %s", state.TerraformVersion))
+	lines = append(lines, fmt.Sprintf("State serial:      %d", state.Serial))
+	lines = append(lines, fmt.Sprintf("State lineage:     %s", state.Lineage))
+	lines = append(lines, fmt.Sprintf("Total resources:   %d", len(resources)))
+	lines = append(lines, fmt.Sprintf("Total outputs:     %d", len(state.Outputs)))
+	lines = append(lines, "")
+
+	if len(types) > 0 {
+		lines = append(lines, "## Resource Types")
+		for _, t := range types {
+			lines = append(lines, fmt.Sprintf("  %-50s %d", t, typeCounts[t]))
+		}
+		lines = append(lines, "")
+	}
+
+	if len(modules) > 1 || (len(modules) == 1 && modules[0] != "(root)") {
+		lines = append(lines, "## Modules")
+		for _, m := range modules {
+			lines = append(lines, fmt.Sprintf("  %-50s %d resources", m, moduleCounts[m]))
+		}
+		lines = append(lines, "")
+	}
+
+	if len(state.Outputs) > 0 {
+		lines = append(lines, "## Outputs")
+		outputNames := make([]string, 0, len(state.Outputs))
+		for name := range state.Outputs {
+			outputNames = append(outputNames, name)
+		}
+		sort.Strings(outputNames)
+		for _, name := range outputNames {
+			out := state.Outputs[name]
+			suffix := ""
+			if out.Sensitive {
+				suffix = " (sensitive)"
+			}
+			typeStr := ""
+			if out.Type != nil {
+				typeStr = fmt.Sprintf(" [%v]", out.Type)
+			}
+			lines = append(lines, fmt.Sprintf("  %s%s%s", name, typeStr, suffix))
+		}
+		lines = append(lines, "")
+	}
+
+	return mcp.NewToolResultText(strings.Join(lines, "\n")), nil
+}

--- a/pkg/tools/tfe/list_state_resources.go
+++ b/pkg/tools/tfe/list_state_resources.go
@@ -1,0 +1,106 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	log "github.com/sirupsen/logrus"
+)
+
+// resourceSummary is a slimmed-down resource listing (no attributes) for token efficiency.
+type resourceSummary struct {
+	Address      string   `json:"address"`
+	Type         string   `json:"type"`
+	Name         string   `json:"name"`
+	Module       string   `json:"module"`
+	Mode         string   `json:"mode"`
+	Provider     string   `json:"provider"`
+	Dependencies []string `json:"dependencies"`
+}
+
+// ListStateResources creates a tool to list resource addresses in a workspace's current
+// state, optionally filtered by type or module, without dumping full attributes.
+func ListStateResources(logger *log.Logger) server.ServerTool {
+	return server.ServerTool{
+		Tool: mcp.NewTool("list_state_resources",
+			mcp.WithDescription("List resources in a workspace's current Terraform state with their addresses, types, "+
+				"modules, and dependency counts, without their attributes. Supports optional filtering by resource type "+
+				"or module path, e.g. to answer \"list all the S3 buckets\" without dumping the whole state."),
+			mcp.WithTitleAnnotation("List Terraform State Resources"),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithDestructiveHintAnnotation(false),
+			mcp.WithOpenWorldHintAnnotation(true),
+			mcp.WithString("terraform_org_name",
+				mcp.Required(),
+				mcp.Description(terraformOrgNameDescription),
+			),
+			mcp.WithString("workspace_name",
+				mcp.Required(),
+				mcp.Description("The name of the workspace to read state from"),
+			),
+			mcp.WithString("type_filter",
+				mcp.Description("Only include resources whose type contains this substring (case-insensitive), e.g. 'aws_s3_bucket'"),
+			),
+			mcp.WithString("module_filter",
+				mcp.Description("Only include resources in a specific module path, e.g. 'module.vpc'"),
+			),
+		),
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return listStateResourcesHandler(ctx, request, logger)
+		},
+	}
+}
+
+// listStateResourcesHandler handles tool logics and functionality
+func listStateResourcesHandler(ctx context.Context, request mcp.CallToolRequest, logger *log.Logger) (*mcp.CallToolResult, error) {
+	orgName, err := request.RequireString("terraform_org_name")
+	if err != nil {
+		return ToolError(logger, "missing required input: terraform_org_name", err)
+	}
+	workspaceName, err := request.RequireString("workspace_name")
+	if err != nil {
+		return ToolError(logger, "missing required input: workspace_name", err)
+	}
+	orgName = strings.TrimSpace(orgName)
+	workspaceName = strings.TrimSpace(workspaceName)
+	typeFilter := GetTrimmedString(request, "type_filter", "")
+	moduleFilter := GetTrimmedString(request, "module_filter", "")
+
+	state, err := resolveWorkspaceState(ctx, orgName, workspaceName, logger)
+	if err != nil {
+		return ToolError(logger, "loading Terraform state", err)
+	}
+
+	resources := extractResources(state)
+
+	summaries := make([]resourceSummary, 0, len(resources))
+	for _, r := range resources {
+		if typeFilter != "" && !strings.Contains(strings.ToLower(r.Type), strings.ToLower(typeFilter)) {
+			continue
+		}
+		if moduleFilter != "" && !strings.Contains(r.Module, moduleFilter) {
+			continue
+		}
+		summaries = append(summaries, resourceSummary{
+			Address:      r.Address,
+			Type:         r.Type,
+			Name:         r.Name,
+			Module:       r.Module,
+			Mode:         r.Mode,
+			Provider:     r.Provider,
+			Dependencies: r.Dependencies,
+		})
+	}
+
+	data, err := json.MarshalIndent(summaries, "", "  ")
+	if err != nil {
+		return ToolError(logger, "marshaling response", err)
+	}
+	return mcp.NewToolResultText(string(data)), nil
+}

--- a/pkg/tools/tfe/search_state_attributes.go
+++ b/pkg/tools/tfe/search_state_attributes.go
@@ -1,0 +1,151 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	log "github.com/sirupsen/logrus"
+)
+
+// stateAttributeMatch is one resource whose attributes matched a search query.
+type stateAttributeMatch struct {
+	Address string                 `json:"address"`
+	Type    string                 `json:"type"`
+	Module  string                 `json:"module"`
+	Matches map[string]interface{} `json:"matches"`
+}
+
+// SearchStateAttributes creates a tool to search attribute values across all resources in
+// a workspace's current state.
+func SearchStateAttributes(logger *log.Logger) server.ServerTool {
+	return server.ServerTool{
+		Tool: mcp.NewTool("search_state_attributes",
+			mcp.WithDescription("Search for a substring across all resource attribute values in a workspace's current "+
+				"Terraform state. Returns matching resources with just the attribute key/value pairs that matched, not "+
+				"the full state. Useful for finding resources that reference a specific ARN, IP, name, or identifier "+
+				"without fetching the entire state."),
+			mcp.WithTitleAnnotation("Search Terraform State Attributes"),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithDestructiveHintAnnotation(false),
+			mcp.WithOpenWorldHintAnnotation(true),
+			mcp.WithString("terraform_org_name",
+				mcp.Required(),
+				mcp.Description(terraformOrgNameDescription),
+			),
+			mcp.WithString("workspace_name",
+				mcp.Required(),
+				mcp.Description("The name of the workspace to read state from"),
+			),
+			mcp.WithString("query",
+				mcp.Required(),
+				mcp.Description("Substring to search for in attribute values (case-insensitive)"),
+			),
+			mcp.WithString("resource_type",
+				mcp.Description("Restrict the search to resources of this type, e.g. 'aws_s3_bucket'"),
+			),
+		),
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return searchStateAttributesHandler(ctx, request, logger)
+		},
+	}
+}
+
+// searchStateAttributesHandler handles tool logics and functionality
+func searchStateAttributesHandler(ctx context.Context, request mcp.CallToolRequest, logger *log.Logger) (*mcp.CallToolResult, error) {
+	orgName, err := request.RequireString("terraform_org_name")
+	if err != nil {
+		return ToolError(logger, "missing required input: terraform_org_name", err)
+	}
+	workspaceName, err := request.RequireString("workspace_name")
+	if err != nil {
+		return ToolError(logger, "missing required input: workspace_name", err)
+	}
+	query, err := request.RequireString("query")
+	if err != nil {
+		return ToolError(logger, "missing required input: query", err)
+	}
+	orgName = strings.TrimSpace(orgName)
+	workspaceName = strings.TrimSpace(workspaceName)
+	query = strings.ToLower(strings.TrimSpace(query))
+	resourceType := GetTrimmedString(request, "resource_type", "")
+
+	state, err := resolveWorkspaceState(ctx, orgName, workspaceName, logger)
+	if err != nil {
+		return ToolError(logger, "loading Terraform state", err)
+	}
+
+	var results []stateAttributeMatch
+	for _, r := range extractResources(state) {
+		if resourceType != "" && !strings.EqualFold(r.Type, resourceType) {
+			continue
+		}
+		if matched := searchAttrValues(r.Attributes, query); len(matched) > 0 {
+			results = append(results, stateAttributeMatch{
+				Address: r.Address,
+				Type:    r.Type,
+				Module:  r.Module,
+				Matches: matched,
+			})
+		}
+	}
+	if results == nil {
+		results = []stateAttributeMatch{}
+	}
+
+	data, err := json.MarshalIndent(map[string]interface{}{
+		"query":   query,
+		"count":   len(results),
+		"results": results,
+	}, "", "  ")
+	if err != nil {
+		return ToolError(logger, "marshaling response", err)
+	}
+	return mcp.NewToolResultText(string(data)), nil
+}
+
+// searchAttrValues recursively searches attribute values for query, returning matching key/value pairs.
+func searchAttrValues(attrs map[string]interface{}, query string) map[string]interface{} {
+	matches := make(map[string]interface{})
+	for k, v := range attrs {
+		if m := searchOneValue(v, query); m != nil {
+			matches[k] = m
+		}
+	}
+	return matches
+}
+
+// searchOneValue searches a single attribute value, descending into nested maps and slices.
+func searchOneValue(v interface{}, query string) interface{} {
+	switch val := v.(type) {
+	case string:
+		if strings.Contains(strings.ToLower(val), query) {
+			return val
+		}
+	case map[string]interface{}:
+		if sub := searchAttrValues(val, query); len(sub) > 0 {
+			return sub
+		}
+	case []interface{}:
+		var hits []interface{}
+		for _, e := range val {
+			if m := searchOneValue(e, query); m != nil {
+				hits = append(hits, m)
+			}
+		}
+		if len(hits) > 0 {
+			return hits
+		}
+	default:
+		if strings.Contains(strings.ToLower(fmt.Sprintf("%v", val)), query) {
+			return val
+		}
+	}
+	return nil
+}

--- a/pkg/tools/tfe/search_state_attributes_test.go
+++ b/pkg/tools/tfe/search_state_attributes_test.go
@@ -1,0 +1,41 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tools
+
+import "testing"
+
+func TestSearchAttrValuesRecursesArrays(t *testing.T) {
+	attrs := map[string]interface{}{
+		"rules": []interface{}{
+			map[string]interface{}{"cidr": "10.0.0.0/8", "note": "internal"},
+			map[string]interface{}{"cidr": "1.2.3.4/32", "note": "match-here"},
+		},
+	}
+
+	matches := searchAttrValues(attrs, "match-here")
+	rules, ok := matches["rules"].([]interface{})
+	if !ok {
+		t.Fatalf("expected rules array in matches, got %T", matches["rules"])
+	}
+	if len(rules) != 1 {
+		t.Fatalf("expected only the matching element, got %d", len(rules))
+	}
+	entry := rules[0].(map[string]interface{})
+	if entry["note"] != "match-here" {
+		t.Errorf("wrong element returned: %v", entry)
+	}
+}
+
+// TestSearchAttrValuesNoFalseArrayLeak verifies a non-matching array yields no match (and
+// therefore cannot leak unrelated raw array contents).
+func TestSearchAttrValuesNoFalseArrayLeak(t *testing.T) {
+	attrs := map[string]interface{}{
+		"rules": []interface{}{
+			map[string]interface{}{"secret": "do-not-leak"},
+		},
+	}
+	if m := searchAttrValues(attrs, "unrelated-query"); len(m) != 0 {
+		t.Errorf("expected no matches, got %v", m)
+	}
+}

--- a/pkg/tools/tfe/state_extract.go
+++ b/pkg/tools/tfe/state_extract.go
@@ -1,0 +1,130 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-mcp-server/pkg/client"
+	log "github.com/sirupsen/logrus"
+)
+
+const defaultStateMaxSizeMB = 200
+
+// stateMaxSizeBytes returns the maximum accepted size of a downloaded state file.
+func stateMaxSizeBytes() int64 {
+	mb := defaultStateMaxSizeMB
+	if v := os.Getenv("TF_STATE_MAX_SIZE_MB"); v != "" {
+		if parsed, err := strconv.Atoi(v); err == nil && parsed > 0 {
+			mb = parsed
+		}
+	}
+	return int64(mb) * 1024 * 1024
+}
+
+// loadWorkspaceState downloads and parses the current state version for the given org/workspace.
+func loadWorkspaceState(ctx context.Context, tfeClient *tfe.Client, orgName, workspaceName string) (*terraformState, error) {
+	workspace, err := tfeClient.Workspaces.Read(ctx, orgName, workspaceName)
+	if err != nil {
+		return nil, fmt.Errorf("workspace '%s' not found in org '%s': %w", workspaceName, orgName, err)
+	}
+
+	sv, err := tfeClient.StateVersions.ReadCurrent(ctx, workspace.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read current state version: %w", err)
+	}
+	if sv.DownloadURL == "" {
+		return nil, fmt.Errorf("workspace '%s' has no state to download yet", workspaceName)
+	}
+
+	raw, err := tfeClient.StateVersions.Download(ctx, sv.DownloadURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download state: %w", err)
+	}
+	if maxBytes := stateMaxSizeBytes(); int64(len(raw)) > maxBytes {
+		return nil, fmt.Errorf("state file is %d bytes, exceeding the %d byte limit (set %s to override)",
+			len(raw), maxBytes, "TF_STATE_MAX_SIZE_MB")
+	}
+
+	var state terraformState
+	if err := json.Unmarshal(raw, &state); err != nil {
+		return nil, fmt.Errorf("failed to parse state JSON: %w", err)
+	}
+	return &state, nil
+}
+
+// resolveWorkspaceState returns the current parsed state for the given org/workspace.
+func resolveWorkspaceState(ctx context.Context, orgName, workspaceName string, logger *log.Logger) (*terraformState, error) {
+	tfeClient, err := client.GetTfeClientFromContext(ctx, logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get Terraform client - ensure TFE_TOKEN and TFE_ADDRESS are configured: %w", err)
+	}
+
+	return loadWorkspaceState(ctx, tfeClient, orgName, workspaceName)
+}
+
+// extractResources flattens all resource instances from state, applying redaction.
+func extractResources(state *terraformState) []extractedResource {
+	var out []extractedResource
+	for _, res := range state.Resources {
+		for _, inst := range res.Instances {
+			attrs, err := redactSensitiveAttrs(inst.Attributes, inst.SensitiveAttributes)
+			if err != nil {
+				// Fail closed: never return raw attributes if they could not be copied/redacted.
+				attrs = map[string]interface{}{"_redaction_error": "[REDACTED - could not safely process attributes]"}
+			}
+			module := res.Module
+			if module == "" {
+				module = "(root)"
+			}
+			deps := inst.Dependencies
+			if deps == nil {
+				deps = []string{}
+			}
+			sa := inst.SensitiveAttributes
+			if sa == nil {
+				sa = []interface{}{}
+			}
+			out = append(out, extractedResource{
+				Address:             buildResourceAddress(res, inst),
+				Type:                res.Type,
+				Name:                res.Name,
+				Module:              module,
+				Mode:                res.Mode,
+				Provider:            res.Provider,
+				Attributes:          attrs,
+				SensitiveAttributes: sa,
+				Dependencies:        deps,
+			})
+		}
+	}
+	return out
+}
+
+func buildResourceAddress(res stateResource, inst stateInstance) string {
+	prefix := ""
+	if res.Module != "" {
+		prefix = res.Module + "."
+	}
+	if res.Mode == "data" {
+		prefix += "data."
+	}
+	base := fmt.Sprintf("%s%s.%s", prefix, res.Type, res.Name)
+	if inst.IndexKey == nil {
+		return base
+	}
+	switch v := inst.IndexKey.(type) {
+	case string:
+		return fmt.Sprintf(`%s["%s"]`, base, v)
+	case float64:
+		return fmt.Sprintf("%s[%d]", base, int(v))
+	default:
+		return fmt.Sprintf("%s[%v]", base, v)
+	}
+}

--- a/pkg/tools/tfe/state_extract_test.go
+++ b/pkg/tools/tfe/state_extract_test.go
@@ -1,0 +1,93 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tools
+
+import (
+	"testing"
+)
+
+func TestBuildResourceAddress(t *testing.T) {
+	cases := []struct {
+		name string
+		res  stateResource
+		inst stateInstance
+		want string
+	}{
+		{
+			name: "simple managed resource",
+			res:  stateResource{Type: "aws_s3_bucket", Name: "assets", Mode: "managed"},
+			inst: stateInstance{},
+			want: "aws_s3_bucket.assets",
+		},
+		{
+			name: "data source",
+			res:  stateResource{Type: "aws_ami", Name: "ubuntu", Mode: "data"},
+			inst: stateInstance{},
+			want: "data.aws_ami.ubuntu",
+		},
+		{
+			name: "in a module",
+			res:  stateResource{Type: "aws_vpc", Name: "main", Mode: "managed", Module: "module.network"},
+			inst: stateInstance{},
+			want: "module.network.aws_vpc.main",
+		},
+		{
+			name: "for_each string key",
+			res:  stateResource{Type: "aws_iam_role", Name: "svc", Mode: "managed"},
+			inst: stateInstance{IndexKey: "reader"},
+			want: `aws_iam_role.svc["reader"]`,
+		},
+		{
+			name: "count numeric index",
+			res:  stateResource{Type: "aws_instance", Name: "web", Mode: "managed"},
+			inst: stateInstance{IndexKey: float64(2)},
+			want: "aws_instance.web[2]",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildResourceAddress(tc.res, tc.inst)
+			if got != tc.want {
+				t.Errorf("buildResourceAddress() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExtractResourcesDefaultsRootModule(t *testing.T) {
+	state := parseTestState(t, `{
+		"version": 4,
+		"resources": [{
+			"mode": "managed", "type": "aws_vpc", "name": "main", "provider": "p",
+			"instances": [{"attributes": {"id": "vpc-1"}}]
+		}]
+	}`)
+
+	resources := extractResources(state)
+	if len(resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(resources))
+	}
+	if resources[0].Module != "(root)" {
+		t.Errorf("expected root module resource to be labeled \"(root)\", got %q", resources[0].Module)
+	}
+}
+
+func TestStateMaxSizeBytesDefaultAndOverride(t *testing.T) {
+	t.Setenv("TF_STATE_MAX_SIZE_MB", "")
+	if got, want := stateMaxSizeBytes(), int64(defaultStateMaxSizeMB)*1024*1024; got != want {
+		t.Errorf("default stateMaxSizeBytes() = %d, want %d", got, want)
+	}
+
+	t.Setenv("TF_STATE_MAX_SIZE_MB", "5")
+	if got, want := stateMaxSizeBytes(), int64(5)*1024*1024; got != want {
+		t.Errorf("overridden stateMaxSizeBytes() = %d, want %d", got, want)
+	}
+
+	// Invalid values fall back to the default rather than erroring.
+	t.Setenv("TF_STATE_MAX_SIZE_MB", "not-a-number")
+	if got, want := stateMaxSizeBytes(), int64(defaultStateMaxSizeMB)*1024*1024; got != want {
+		t.Errorf("invalid-env stateMaxSizeBytes() = %d, want %d", got, want)
+	}
+}

--- a/pkg/tools/tfe/state_redact.go
+++ b/pkg/tools/tfe/state_redact.go
@@ -1,0 +1,114 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tools
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+const redactedSensitive = "[REDACTED - sensitive]"
+
+// redactSensitiveAttrs returns a copy of attrs with every path named in sensitivePaths
+// (the instance's "sensitive_attributes" manifest from state) overwritten with a
+// redaction marker. The input map is never mutated.
+func redactSensitiveAttrs(attrs map[string]interface{}, sensitivePaths []interface{}) (map[string]interface{}, error) {
+	result, err := deepCopyMap(attrs)
+	if err != nil {
+		return nil, err
+	}
+	if len(sensitivePaths) == 0 || len(result) == 0 {
+		return result, nil
+	}
+	for _, raw := range sensitivePaths {
+		steps := pathSteps(raw)
+		if len(steps) > 0 {
+			setAtPath(result, steps)
+		}
+	}
+	return result, nil
+}
+
+// pathSteps converts one sensitive_attributes entry into an ordered list of steps,
+// each a string (map key) or an int (list index).
+func pathSteps(raw interface{}) []interface{} {
+	switch p := raw.(type) {
+	case string: // legacy flat-key form
+		if p == "" {
+			return nil
+		}
+		return []interface{}{p}
+	case []interface{}:
+		steps := make([]interface{}, 0, len(p))
+		for _, seg := range p {
+			steps = append(steps, normalizeStep(seg))
+		}
+		return steps
+	}
+	return nil
+}
+
+func normalizeStep(seg interface{}) interface{} {
+	switch s := seg.(type) {
+	case string:
+		return s
+	case float64:
+		return int(s)
+	case map[string]interface{}:
+		switch v := s["value"].(type) {
+		case string:
+			return v
+		case float64:
+			return int(v)
+		}
+	}
+	return fmt.Sprintf("\x00unmatched:%v", seg)
+}
+
+// setAtPath redacts the value at steps within obj, descending maps and slices.
+func setAtPath(obj interface{}, steps []interface{}) {
+	if len(steps) == 0 || obj == nil {
+		return
+	}
+	last := len(steps) == 1
+	switch c := obj.(type) {
+	case map[string]interface{}:
+		key, ok := steps[0].(string)
+		if !ok {
+			return
+		}
+		if last {
+			if _, exists := c[key]; exists {
+				c[key] = redactedSensitive
+			}
+			return
+		}
+		setAtPath(c[key], steps[1:])
+	case []interface{}:
+		idx, ok := steps[0].(int)
+		if !ok || idx < 0 || idx >= len(c) {
+			return
+		}
+		if last {
+			c[idx] = redactedSensitive
+			return
+		}
+		setAtPath(c[idx], steps[1:])
+	}
+}
+
+func deepCopyMap(m map[string]interface{}) (map[string]interface{}, error) {
+	if m == nil {
+		return nil, nil
+	}
+	data, err := json.Marshal(m)
+	if err != nil {
+		return nil, fmt.Errorf("copying attributes for redaction: %w", err)
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, fmt.Errorf("copying attributes for redaction: %w", err)
+	}
+	return out, nil
+}

--- a/pkg/tools/tfe/state_redact_test.go
+++ b/pkg/tools/tfe/state_redact_test.go
@@ -1,0 +1,137 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tools
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// parseTestState parses a state v4 JSON document for tests.
+func parseTestState(t *testing.T, doc string) *terraformState {
+	t.Helper()
+	var s terraformState
+	if err := json.Unmarshal([]byte(doc), &s); err != nil {
+		t.Fatalf("parsing test state: %v", err)
+	}
+	return &s
+}
+
+func TestManifestRedactionRealCtyPaths(t *testing.T) {
+	state := parseTestState(t, `{
+		"version": 4,
+		"resources": [{
+			"mode": "managed",
+			"type": "aws_db_instance",
+			"name": "main",
+			"provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+			"instances": [{
+				"attributes": {"id": "db-1", "password": "hunter2"},
+				"sensitive_attributes": [[{"type": "get_attr", "value": "password"}]]
+			}]
+		}]
+	}`)
+
+	resources := extractResources(state)
+	if len(resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(resources))
+	}
+	got := resources[0].Attributes["password"]
+	if got != redactedSensitive {
+		t.Fatalf("password not redacted via cty path: got %v, want %q", got, redactedSensitive)
+	}
+	if resources[0].Attributes["id"] != "db-1" {
+		t.Fatalf("non-sensitive attribute was altered: %v", resources[0].Attributes["id"])
+	}
+}
+
+// TestManifestRedactionLegacyAndNested verifies the legacy flat-string form and a nested map path.
+func TestManifestRedactionLegacyAndNested(t *testing.T) {
+	state := parseTestState(t, `{
+		"version": 4,
+		"resources": [{
+			"mode": "managed", "type": "x", "name": "y", "provider": "p",
+			"instances": [{
+				"attributes": {"token": "abc", "creds": {"secret": "s3cr3t", "user": "u"}},
+				"sensitive_attributes": [
+					"token",
+					[{"type": "get_attr", "value": "creds"}, {"type": "get_attr", "value": "secret"}]
+				]
+			}]
+		}]
+	}`)
+
+	attrs := extractResources(state)[0].Attributes
+	if attrs["token"] != redactedSensitive {
+		t.Errorf("legacy flat-key redaction failed: %v", attrs["token"])
+	}
+	creds := attrs["creds"].(map[string]interface{})
+	if creds["secret"] != redactedSensitive {
+		t.Errorf("nested path redaction failed: %v", creds["secret"])
+	}
+	if creds["user"] != "u" {
+		t.Errorf("sibling value should be untouched: %v", creds["user"])
+	}
+}
+
+func TestManifestRedactionListIndex(t *testing.T) {
+	state := parseTestState(t, `{
+		"version": 4,
+		"resources": [{
+			"mode": "managed", "type": "x", "name": "y", "provider": "p",
+			"instances": [{
+				"attributes": {"rules": [{"name": "ok"}, {"name": "secret-value"}]},
+				"sensitive_attributes": [[
+					{"type": "get_attr", "value": "rules"},
+					{"type": "index", "value": 1},
+					{"type": "get_attr", "value": "name"}
+				]]
+			}]
+		}]
+	}`)
+
+	rules := extractResources(state)[0].Attributes["rules"].([]interface{})
+	if rules[1].(map[string]interface{})["name"] != redactedSensitive {
+		t.Errorf("list-index redaction failed: %v", rules[1])
+	}
+	if rules[0].(map[string]interface{})["name"] != "ok" {
+		t.Errorf("sibling list element should be untouched: %v", rules[0])
+	}
+}
+
+// TestDeepCopyMapFailClosedSemantics verifies the deep copy does not alias the original.
+func TestDeepCopyMapFailClosedSemantics(t *testing.T) {
+	orig := map[string]interface{}{"a": map[string]interface{}{"b": "c"}}
+	cp, err := deepCopyMap(orig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cp["a"].(map[string]interface{})["b"] = "mutated"
+	if orig["a"].(map[string]interface{})["b"] != "c" {
+		t.Errorf("deepCopyMap aliased the original map")
+	}
+
+	if out, err := deepCopyMap(nil); out != nil || err != nil {
+		t.Errorf("deepCopyMap(nil) should return (nil, nil), got (%v, %v)", out, err)
+	}
+}
+
+// TestRedactionDoesNotMutateInput verifies the source state's attributes are untouched by extraction.
+func TestRedactionDoesNotMutateInput(t *testing.T) {
+	state := parseTestState(t, `{
+		"version": 4,
+		"resources": [{
+			"mode": "managed", "type": "x", "name": "y", "provider": "p",
+			"instances": [{
+				"attributes": {"password": "hunter2"},
+				"sensitive_attributes": [[{"type": "get_attr", "value": "password"}]]
+			}]
+		}]
+	}`)
+
+	_ = extractResources(state)
+	if state.Resources[0].Instances[0].Attributes["password"] != "hunter2" {
+		t.Errorf("source state was mutated by redaction: %v", state.Resources[0].Instances[0].Attributes["password"])
+	}
+}

--- a/pkg/tools/tfe/state_types.go
+++ b/pkg/tools/tfe/state_types.go
@@ -1,0 +1,52 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tools
+
+// terraformState represents a Terraform state file (v4 format).
+type terraformState struct {
+	Version          int                    `json:"version"`
+	TerraformVersion string                 `json:"terraform_version"`
+	Serial           int64                  `json:"serial"`
+	Lineage          string                 `json:"lineage"`
+	Outputs          map[string]stateOutput `json:"outputs"`
+	Resources        []stateResource        `json:"resources"`
+}
+
+// stateOutput represents a single Terraform output value.
+type stateOutput struct {
+	Value     interface{} `json:"value"`
+	Type      interface{} `json:"type"`
+	Sensitive bool        `json:"sensitive"`
+}
+
+// stateResource represents a resource block in Terraform state.
+type stateResource struct {
+	Mode      string          `json:"mode"`
+	Type      string          `json:"type"`
+	Name      string          `json:"name"`
+	Module    string          `json:"module"`
+	Provider  string          `json:"provider"`
+	Instances []stateInstance `json:"instances"`
+}
+
+// stateInstance represents one instance of a resource.
+type stateInstance struct {
+	IndexKey            interface{}            `json:"index_key"`
+	Attributes          map[string]interface{} `json:"attributes"`
+	SensitiveAttributes []interface{}          `json:"sensitive_attributes"`
+	Dependencies        []string               `json:"dependencies"`
+}
+
+// extractedResource is a flattened, redacted resource instance with a computed address.
+type extractedResource struct {
+	Address             string                 `json:"address"`
+	Type                string                 `json:"type"`
+	Name                string                 `json:"name"`
+	Module              string                 `json:"module"`
+	Mode                string                 `json:"mode"`
+	Provider            string                 `json:"provider"`
+	Attributes          map[string]interface{} `json:"attributes"`
+	SensitiveAttributes []interface{}          `json:"sensitive_attributes"`
+	Dependencies        []string               `json:"dependencies"`
+}

--- a/pkg/toolsets/mapping.go
+++ b/pkg/toolsets/mapping.go
@@ -92,6 +92,12 @@ var ToolToToolset = map[string]string{
 	// Terraform tools - State Versions
 	"list_state_versions": Terraform,
 	"get_state_version":   Terraform,
+
+	// Terraform tools - State Inspection
+	"list_state_resources":    Terraform,
+	"get_state_resource":      Terraform,
+	"search_state_attributes": Terraform,
+	"get_state_summary":       Terraform,
 }
 
 // GetToolsetForTool returns the toolset name for a given tool name


### PR DESCRIPTION
### Description
In #191 there was some work to review the state, but that was closed. Theres use cases to review state as documented in #437. This PR intends to solve the use cases:

- "show me all my S3 buckets" (`list_state_resources`)
- "what's in this workspace" (`get_state_summary`)
- "Whats the config of `aws_s3_bucket.assets` (`get_state_resource`)
- "which resources are tagged environment=prod" (`search_state_attributes`)

For security controls, sensitive_attributes should be replaced with `[REDACTED - sensitive]`. I was going back and forth if this should be the case, but figured passwords probably shouldn't be available to the LLM.

Closes #437

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
