### PR TITLE
Fix build and test workflow runs being duplicated on PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,22 +3,15 @@
 
 name: build
 
-# We now default to running this workflow on every push to every branch.
-# This provides fast feedback when build issues occur, so they can be
-# fixed prior to being merged to the main branch.
-#
-# If you want to opt out of this, and only run the build on certain branches
-# please refer to the documentation on branch filtering here:
-#
-#   https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore
-#
+# Validate pull requests and pushes to long-lived branches without running both
+# events for each update to a feature branch.
+
 on:
   workflow_dispatch:
   push:
     branches:
       - main
       - release/**
-      - feature/**
   pull_request:
     branches:
       - main

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -4,6 +4,9 @@
 name: E2E Tests
 on:
   push:
+    branches:
+      - main
+      - release/**
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/hcpt_test.yml
+++ b/.github/workflows/hcpt_test.yml
@@ -4,6 +4,9 @@
 name: HCPT Test 
 on:
   push:
+    branches:
+      - main
+      - release/**
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/loadtest.yml
+++ b/.github/workflows/loadtest.yml
@@ -4,6 +4,9 @@ name: Load Test
 
 on:
   push:
+    branches:
+      - main
+      - release/**
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -4,6 +4,9 @@
 name: Unit Tests
 on:
   push:
+    branches:
+      - main
+      - release/**
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary

build and test was running twice on every PR:

- Limit push-triggered build and test workflows to main and release branches.
- Retain pull request validation without running the same workflows twice for each PR branch update.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.