### PR TITLE
feat(tfe): expose private registry submodule details in `get_private_module_details`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 1.3.1
+
+IMPROVEMENTS
+
+* `get_private_module_details` now reports every submodule published with a private module, each with its own inputs, outputs, dependencies, provider dependencies, resources, and README, matching the detail already provided for the root module. The root module section is now labelled and its README is reported alongside its own inputs and outputs.
+* `get_private_module_details` now reports the module version its details were read from, and the generated usage snippet pins that version instead of the first entry in the module's version statuses, which may be a version whose ingress is still pending or has failed.
+* `get_private_module_details` now requests the registry's latest-version route directly when `private_module_version` is omitted, instead of sending a request with an empty version segment.
+
 # 1.3.0
 
 FEATURES
@@ -13,9 +21,6 @@ FEATURES
 
 FIXES
 
-* `get_private_module_details` now reports every submodule published with a private module, each with its own inputs, outputs, dependencies, provider dependencies, resources, and README, matching the detail already provided for the root module. The root module section is now labelled and its README is reported alongside its own inputs and outputs.
-* `get_private_module_details` now reports the module version its details were read from, and the generated usage snippet pins that version instead of the first entry in the module's version statuses, which may be a version whose ingress is still pending or has failed.
-* `get_private_module_details` now requests the registry's latest-version route directly when `private_module_version` is omitted, instead of sending a request with an empty version segment.
 * `get_apply_logs` now checks the apply status before attempting to stream logs. If the apply is not yet in a terminal state (`finished`, `errored`, `canceled`), the tool returns an informative message instead of timing out. [468](https://github.com/hashicorp/terraform-mcp-server/pull/468)
 * Fix `create_no_code_workspace` elicitation to require only module inputs marked as required, allowing optional inputs to be omitted so Terraform module defaults are applied. [482](https://github.com/hashicorp/terraform-mcp-server/pull/482)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ FEATURES
 
 FIXES
 
+* `get_private_module_details` now reports every submodule published with a private module, each with its own inputs, outputs, dependencies, provider dependencies, resources, and README, matching the detail already provided for the root module. The root module section is now labelled and its README is reported alongside its own inputs and outputs.
+* `get_private_module_details` now reports the module version its details were read from, and the generated usage snippet pins that version instead of the first entry in the module's version statuses, which may be a version whose ingress is still pending or has failed.
+* `get_private_module_details` now requests the registry's latest-version route directly when `private_module_version` is omitted, instead of sending a request with an empty version segment.
 * `get_apply_logs` now checks the apply status before attempting to stream logs. If the apply is not yet in a terminal state (`finished`, `errored`, `canceled`), the tool returns an informative message instead of timing out. [468](https://github.com/hashicorp/terraform-mcp-server/pull/468)
 * Fix `create_no_code_workspace` elicitation to require only module inputs marked as required, allowing optional inputs to be omitted so Terraform module defaults are applied. [482](https://github.com/hashicorp/terraform-mcp-server/pull/482)
 

--- a/pkg/tools/tfe/get_private_module_details.go
+++ b/pkg/tools/tfe/get_private_module_details.go
@@ -6,6 +6,7 @@ package tools
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"path"
 	"regexp"
 	"strings"
@@ -94,14 +95,14 @@ func getPrivateModuleDetailsHandler(ctx context.Context, request mcp.CallToolReq
 	}).Info("Getting private module details")
 
 	var module *tfe.RegistryModule
-	var terraformRegistryModule *tfe.TerraformRegistryModule
+	var terraformRegistryModule *client.TerraformModuleVersionDetails
 
 	module, err = tfeClient.RegistryModules.Read(ctx, tfeModuleID)
 	if err != nil {
 		return ToolErrorf(logger, "module not found: %s - use search_private_modules to find valid module IDs", moduleID)
 	}
 
-	terraformRegistryModule, err = tfeClient.RegistryModules.ReadTerraformRegistryModule(ctx, tfeModuleID, moduleVersion)
+	terraformRegistryModule, err = readTerraformRegistryModuleDetails(ctx, tfeClient, tfeModuleID, moduleVersion)
 	if err != nil {
 		logger.WithError(err).Warn("failed to get detailed module information from Terraform Registry, continuing with basic info")
 	}
@@ -109,8 +110,37 @@ func getPrivateModuleDetailsHandler(ctx context.Context, request mcp.CallToolReq
 	return buildPrivateModuleDetailsResponse(module, terraformRegistryModule, tfeClient.BaseURL().Host, logger), nil
 }
 
+func readTerraformRegistryModuleDetails(ctx context.Context, tfeClient *tfe.Client, moduleID tfe.RegistryModuleID, moduleVersion string) (*client.TerraformModuleVersionDetails, error) {
+	u := fmt.Sprintf("/api/registry/v1/modules/%s/%s/%s/%s",
+		url.PathEscape(moduleID.Namespace),
+		url.PathEscape(moduleID.Name),
+		url.PathEscape(moduleID.Provider),
+		url.PathEscape(moduleVersion),
+	)
+	if moduleID.RegistryName == tfe.PublicRegistry {
+		u = fmt.Sprintf("/api/registry/public/v1/modules/%s/%s/%s/%s",
+			url.PathEscape(moduleID.Namespace),
+			url.PathEscape(moduleID.Name),
+			url.PathEscape(moduleID.Provider),
+			url.PathEscape(moduleVersion),
+		)
+	}
+
+	req, err := tfeClient.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	module := &client.TerraformModuleVersionDetails{}
+	if err := req.DoJSON(ctx, module); err != nil {
+		return nil, err
+	}
+
+	return module, nil
+}
+
 func buildPrivateModuleDetailsResponse(registryModule *tfe.RegistryModule,
-	terraformRegistryModule *tfe.TerraformRegistryModule,
+	terraformRegistryModule *client.TerraformModuleVersionDetails,
 	tfeHostAddress string,
 	logger *log.Logger) *mcp.CallToolResult {
 
@@ -149,65 +179,18 @@ func buildPrivateModuleDetailsResponse(registryModule *tfe.RegistryModule,
 	}
 	builder.WriteString("\n")
 
-	if terraformRegistryModule != nil && len(terraformRegistryModule.Root.Inputs) > 0 {
-		builder.WriteString("Inputs:\n")
-		builder.WriteString(strings.Repeat("-", 20) + "\n")
-		builder.WriteString("| Name | Type | Description | Default | Required |\n")
-		builder.WriteString("|------|------|-------------|---------|----------|\n")
-		for _, input := range terraformRegistryModule.Root.Inputs {
-			builder.WriteString(fmt.Sprintf("| %s | %s | %s | `%s` | %t |\n",
-				input.Name,
-				input.Type,
-				input.Description,
-				input.Default,
-				input.Required,
-			))
-		}
-		builder.WriteString("\n")
-	}
+	if terraformRegistryModule != nil {
+		writeModulePartDetails(&builder, terraformRegistryModule.Root)
 
-	if terraformRegistryModule != nil && len(terraformRegistryModule.Root.Outputs) > 0 {
-		builder.WriteString("Outputs:\n")
-		builder.WriteString(strings.Repeat("-", 20) + "\n")
-		builder.WriteString("| Name | Description |\n")
-		builder.WriteString("|------|-------------|\n")
-		for _, output := range terraformRegistryModule.Root.Outputs {
-			builder.WriteString(fmt.Sprintf("| %s | %s |\n",
-				output.Name,
-				output.Description,
-			))
+		if len(terraformRegistryModule.Submodules) > 0 {
+			builder.WriteString("Submodules:\n")
+			for _, submodule := range terraformRegistryModule.Submodules {
+				builder.WriteString(fmt.Sprintf("Submodule: %s\n", submodule.Name))
+				builder.WriteString(fmt.Sprintf("- Path: %s\n\n", submodule.Path))
+				writeModulePartDetails(&builder, submodule)
+				writeModulePartReadme(&builder, submodule)
+			}
 		}
-		builder.WriteString("\n")
-	}
-
-	if terraformRegistryModule != nil && len(terraformRegistryModule.Root.ProviderDependencies) > 0 {
-		builder.WriteString("Provider Dependencies:\n")
-		builder.WriteString(strings.Repeat("-", 20) + "\n")
-		builder.WriteString("| Name | Namespace | Source | Version |\n")
-		builder.WriteString("|------|-----------|--------|----------|\n")
-		for _, dep := range terraformRegistryModule.Root.ProviderDependencies {
-			builder.WriteString(fmt.Sprintf("| %s | %s | %s | %s |\n",
-				dep.Name,
-				dep.Namespace,
-				dep.Source,
-				dep.Version,
-			))
-		}
-		builder.WriteString("\n")
-	}
-
-	if terraformRegistryModule != nil && len(terraformRegistryModule.Root.Resources) > 0 {
-		builder.WriteString("Resources:\n")
-		builder.WriteString(strings.Repeat("-", 20) + "\n")
-		builder.WriteString("| Name | Type |\n")
-		builder.WriteString("|------|------|\n")
-		for _, resource := range terraformRegistryModule.Root.Resources {
-			builder.WriteString(fmt.Sprintf("| %s | %s |\n",
-				resource.Name,
-				resource.Type,
-			))
-		}
-		builder.WriteString("\n")
 	}
 
 	if registryModule.Organization != nil {
@@ -258,6 +241,92 @@ func buildPrivateModuleDetailsResponse(registryModule *tfe.RegistryModule,
 	}).Info("Successfully retrieved private module details")
 
 	return mcp.NewToolResultText(builder.String())
+}
+
+func writeModulePartDetails(builder *strings.Builder, modulePart client.ModulePart) {
+	if len(modulePart.Inputs) > 0 {
+		builder.WriteString("Inputs:\n")
+		builder.WriteString(strings.Repeat("-", 20) + "\n")
+		builder.WriteString("| Name | Type | Description | Default | Required |\n")
+		builder.WriteString("|------|------|-------------|---------|----------|\n")
+		for _, input := range modulePart.Inputs {
+			builder.WriteString(fmt.Sprintf("| %s | %s | %s | `%s` | %t |\n",
+				input.Name,
+				input.Type,
+				input.Description,
+				formatModuleInputDefault(input.Default),
+				input.Required,
+			))
+		}
+		builder.WriteString("\n")
+	}
+
+	if len(modulePart.Outputs) > 0 {
+		builder.WriteString("Outputs:\n")
+		builder.WriteString(strings.Repeat("-", 20) + "\n")
+		builder.WriteString("| Name | Description |\n")
+		builder.WriteString("|------|-------------|\n")
+		for _, output := range modulePart.Outputs {
+			builder.WriteString(fmt.Sprintf("| %s | %s |\n",
+				output.Name,
+				output.Description,
+			))
+		}
+		builder.WriteString("\n")
+	}
+
+	if len(modulePart.ProviderDependencies) > 0 {
+		builder.WriteString("Provider Dependencies:\n")
+		builder.WriteString(strings.Repeat("-", 20) + "\n")
+		builder.WriteString("| Name | Namespace | Source | Version |\n")
+		builder.WriteString("|------|-----------|--------|----------|\n")
+		for _, dep := range modulePart.ProviderDependencies {
+			builder.WriteString(fmt.Sprintf("| %s | %s | %s | %s |\n",
+				dep.Name,
+				dep.Namespace,
+				dep.Source,
+				dep.Version,
+			))
+		}
+		builder.WriteString("\n")
+	}
+
+	if len(modulePart.Resources) > 0 {
+		builder.WriteString("Resources:\n")
+		builder.WriteString(strings.Repeat("-", 20) + "\n")
+		builder.WriteString("| Name | Type |\n")
+		builder.WriteString("|------|------|\n")
+		for _, resource := range modulePart.Resources {
+			builder.WriteString(fmt.Sprintf("| %s | %s |\n",
+				resource.Name,
+				resource.Type,
+			))
+		}
+		builder.WriteString("\n")
+	}
+}
+
+func formatModuleInputDefault(value any) string {
+	if value == nil {
+		return ""
+	}
+	return fmt.Sprint(value)
+}
+
+func writeModulePartReadme(builder *strings.Builder, modulePart client.ModulePart) {
+	if modulePart.Readme == "" {
+		return
+	}
+
+	cleanedReadme := removeReadmeSections(modulePart.Readme)
+	if cleanedReadme == "" {
+		return
+	}
+
+	builder.WriteString("README:\n")
+	builder.WriteString(strings.Repeat("-", 20) + "\n")
+	builder.WriteString(cleanedReadme)
+	builder.WriteString("\n\n")
 }
 
 func removeReadmeSections(readme string) string {

--- a/pkg/tools/tfe/get_private_module_details.go
+++ b/pkg/tools/tfe/get_private_module_details.go
@@ -64,8 +64,8 @@ func getPrivateModuleDetailsHandler(ctx context.Context, request mcp.CallToolReq
 	}
 	moduleID = strings.TrimSpace(moduleID)
 
-	registryName := strings.TrimSpace(request.GetString("registry_name", "private"))
-	moduleVersion := strings.TrimSpace(request.GetString("private_module_version", ""))
+	registryName := GetTrimmedString(request, "registry_name", "private")
+	moduleVersion := GetTrimmedString(request, "private_module_version", "")
 
 	tfeClient, err := client.GetTfeClientFromContext(ctx, logger)
 	if err != nil {
@@ -107,18 +107,6 @@ func getPrivateModuleDetailsHandler(ctx context.Context, request mcp.CallToolReq
 	return buildPrivateModuleDetailsResponse(module, terraformRegistryModule, tfeClient.BaseURL().Host, logger), nil
 }
 
-// latestModuleVersion returns the first successfully published version, skipping
-// any still processing or failed. Used as a fallback when the registry API does
-// not return a version alongside the module details.
-func latestModuleVersion(registryModule *tfe.RegistryModule) string {
-	for _, versionStatus := range registryModule.VersionStatuses {
-		if versionStatus.Status == tfe.RegistryModuleVersionStatusOk {
-			return versionStatus.Version
-		}
-	}
-	return ""
-}
-
 func readTerraformRegistryModuleDetails(ctx context.Context, tfeClient *tfe.Client, moduleID tfe.RegistryModuleID, moduleVersion string) (*client.TerraformModuleVersionDetails, error) {
 	basePath := "/api/registry/v1/modules"
 	if moduleID.RegistryName == tfe.PublicRegistry {
@@ -132,7 +120,8 @@ func readTerraformRegistryModuleDetails(ctx context.Context, tfeClient *tfe.Clie
 		url.PathEscape(moduleID.Provider),
 	)
 
-	// Omit the version segment to request the latest version — the documented form of the route.
+	// The registry uses /{namespace}/{name}/{provider} for the latest version
+	// and appends /{version} when a specific version is requested.
 	if moduleVersion != "" {
 		u += "/" + url.PathEscape(moduleVersion)
 	}
@@ -154,9 +143,9 @@ func buildPrivateModuleDetailsResponse(registryModule *tfe.RegistryModule, terra
 
 	registryPath := path.Join(tfeHostAddress, registryModule.Namespace, registryModule.Name, registryModule.Provider)
 
-	// Use the version the registry returned content for, so the usage snippet and
-	// the inputs/outputs always refer to the same version.
-	moduleVersion := latestModuleVersion(registryModule)
+	// Use the exact version represented by the details response so the generated
+	// Terraform usage example matches the inputs, outputs, and submodules below.
+	moduleVersion := ""
 	if terraformRegistryModule != nil && terraformRegistryModule.Version != "" {
 		moduleVersion = terraformRegistryModule.Version
 	}
@@ -268,7 +257,8 @@ func modulePartHasDetails(modulePart client.ModulePart) bool {
 func writeModulePartDetails(builder *strings.Builder, modulePart client.ModulePart) {
 	if len(modulePart.Inputs) > 0 {
 		builder.WriteString("Inputs:\n")
-		builder.WriteString(strings.Repeat("-", 20) + "\n")
+		builder.WriteString(strings.Repeat("-", 20))
+		builder.WriteByte('\n')
 		builder.WriteString("| Name | Type | Description | Default | Required |\n")
 		builder.WriteString("|------|------|-------------|---------|----------|\n")
 		for _, input := range modulePart.Inputs {
@@ -285,7 +275,8 @@ func writeModulePartDetails(builder *strings.Builder, modulePart client.ModulePa
 
 	if len(modulePart.Outputs) > 0 {
 		builder.WriteString("Outputs:\n")
-		builder.WriteString(strings.Repeat("-", 20) + "\n")
+		builder.WriteString(strings.Repeat("-", 20))
+		builder.WriteByte('\n')
 		builder.WriteString("| Name | Description |\n")
 		builder.WriteString("|------|-------------|\n")
 		for _, output := range modulePart.Outputs {
@@ -299,7 +290,8 @@ func writeModulePartDetails(builder *strings.Builder, modulePart client.ModulePa
 
 	if len(modulePart.Dependencies) > 0 {
 		builder.WriteString("Dependencies:\n")
-		builder.WriteString(strings.Repeat("-", 20) + "\n")
+		builder.WriteString(strings.Repeat("-", 20))
+		builder.WriteByte('\n')
 		builder.WriteString("| Name | Source | Version |\n")
 		builder.WriteString("|------|--------|---------|\n")
 		for _, dep := range modulePart.Dependencies {
@@ -314,7 +306,8 @@ func writeModulePartDetails(builder *strings.Builder, modulePart client.ModulePa
 
 	if len(modulePart.ProviderDependencies) > 0 {
 		builder.WriteString("Provider Dependencies:\n")
-		builder.WriteString(strings.Repeat("-", 20) + "\n")
+		builder.WriteString(strings.Repeat("-", 20))
+		builder.WriteByte('\n')
 		builder.WriteString("| Name | Namespace | Source | Version |\n")
 		builder.WriteString("|------|-----------|--------|----------|\n")
 		for _, dep := range modulePart.ProviderDependencies {
@@ -330,7 +323,8 @@ func writeModulePartDetails(builder *strings.Builder, modulePart client.ModulePa
 
 	if len(modulePart.Resources) > 0 {
 		builder.WriteString("Resources:\n")
-		builder.WriteString(strings.Repeat("-", 20) + "\n")
+		builder.WriteString(strings.Repeat("-", 20))
+		builder.WriteByte('\n')
 		builder.WriteString("| Name | Type |\n")
 		builder.WriteString("|------|------|\n")
 		for _, resource := range modulePart.Resources {
@@ -361,7 +355,8 @@ func writeModulePartReadme(builder *strings.Builder, modulePart client.ModulePar
 	}
 
 	builder.WriteString("README:\n")
-	builder.WriteString(strings.Repeat("-", 20) + "\n")
+	builder.WriteString(strings.Repeat("-", 20))
+	builder.WriteByte('\n')
 	builder.WriteString(cleanedReadme)
 	builder.WriteString("\n\n")
 }

--- a/pkg/tools/tfe/get_private_module_details.go
+++ b/pkg/tools/tfe/get_private_module_details.go
@@ -52,17 +52,14 @@ func GetPrivateModuleDetails(logger *log.Logger) server.ServerTool {
 }
 
 func getPrivateModuleDetailsHandler(ctx context.Context, request mcp.CallToolRequest, logger *log.Logger) (*mcp.CallToolResult, error) {
-	terraformOrgName, err := request.RequireString("terraform_org_name")
+	terraformOrgName, err := RequireTrimmedString(request, "terraform_org_name")
 	if err != nil {
 		return ToolError(logger, "missing required input: terraform_org_name", err)
 	}
-	terraformOrgName = strings.TrimSpace(terraformOrgName)
-
-	moduleID, err := request.RequireString("private_module_id")
+	moduleID, err := RequireTrimmedString(request, "private_module_id")
 	if err != nil {
 		return ToolError(logger, "missing required input: private_module_id", err)
 	}
-	moduleID = strings.TrimSpace(moduleID)
 
 	registryName := GetTrimmedString(request, "registry_name", "private")
 	moduleVersion := GetTrimmedString(request, "private_module_version", "")

--- a/pkg/tools/tfe/get_private_module_details.go
+++ b/pkg/tools/tfe/get_private_module_details.go
@@ -23,9 +23,7 @@ import (
 func GetPrivateModuleDetails(logger *log.Logger) server.ServerTool {
 	return server.ServerTool{
 		Tool: mcp.NewTool("get_private_module_details",
-			mcp.WithDescription(`This tool retrieves detailed information about a specific private module in your Terraform Cloud/Enterprise organization.
-It provides comprehensive details including inputs, outputs, dependencies, versions, and usage examples. The private_module_id format is 'module-namespace/module-name/module-provider-name'.
-This can be obtained by calling 'search_private_modules' first to obtain the exact private_module_id required to use this tool. This tool requires a valid Terraform token to be configured.`),
+			mcp.WithDescription(`This tool retrieves detailed information about a specific private module in your Terraform Cloud/Enterprise organization. It provides comprehensive details including inputs, outputs, dependencies, versions, and usage examples. The private_module_id format is 'module-namespace/module-name/module-provider-name'. This can be obtained by calling 'search_private_modules' first to obtain the exact private_module_id required to use this tool. This tool requires a valid Terraform token to be configured.`),
 			mcp.WithTitleAnnotation("Get detailed information about a private module"),
 			mcp.WithOpenWorldHintAnnotation(true),
 			mcp.WithReadOnlyHintAnnotation(true),
@@ -36,8 +34,7 @@ This can be obtained by calling 'search_private_modules' first to obtain the exa
 			),
 			mcp.WithString("private_module_id",
 				mcp.Required(),
-				mcp.Description(`The private module ID should be in the format 'module-namespace/module-name/module-provider-name' (for example, 'my-tfc-org/vpc/aws' or 'my-module-namespace/vm/azurerm').
-The module-namespace is usually the name of the Terraform organization. Obtain this ID by calling 'search_private_modules'.`),
+				mcp.Description(`The private module ID should be in the format 'module-namespace/module-name/module-provider-name' (for example, 'my-tfc-org/vpc/aws' or 'my-module-namespace/vm/azurerm'). The module-namespace is usually the name of the Terraform organization. Obtain this ID by calling 'search_private_modules'.`),
 			),
 			mcp.WithString("registry_name",
 				mcp.Description("The type of Terraform registry to search within Terraform Cloud/Enterprise (e.g., 'private', 'public')"),
@@ -139,10 +136,7 @@ func readTerraformRegistryModuleDetails(ctx context.Context, tfeClient *tfe.Clie
 	return module, nil
 }
 
-func buildPrivateModuleDetailsResponse(registryModule *tfe.RegistryModule,
-	terraformRegistryModule *client.TerraformModuleVersionDetails,
-	tfeHostAddress string,
-	logger *log.Logger) *mcp.CallToolResult {
+func buildPrivateModuleDetailsResponse(registryModule *tfe.RegistryModule, terraformRegistryModule *client.TerraformModuleVersionDetails, tfeHostAddress string, logger *log.Logger) *mcp.CallToolResult {
 
 	registryPath := path.Join(tfeHostAddress, registryModule.Namespace, registryModule.Name, registryModule.Provider)
 
@@ -150,14 +144,12 @@ func buildPrivateModuleDetailsResponse(registryModule *tfe.RegistryModule,
 	builder.WriteString("Usage:\n")
 	builder.WriteString("To use this private module in your Terraform configuration:\n\n")
 	builder.WriteString("```hcl\n")
-	builder.WriteString(fmt.Sprintf("module \"%s\" {\n", registryModule.Name))
-	builder.WriteString(fmt.Sprintf("  source = \"%s\"\n", registryPath))
+	builder.WriteString(fmt.Sprintf("module %q {\n", registryModule.Name))
+	builder.WriteString(fmt.Sprintf("  source = %q\n", registryPath))
 
 	if len(registryModule.VersionStatuses) > 0 {
-		for _, versionStatus := range registryModule.VersionStatuses {
-			builder.WriteString(fmt.Sprintf("  version = \"%s\"\n", versionStatus.Version))
-			break
-		}
+		version := registryModule.VersionStatuses[0].Version
+		builder.WriteString(fmt.Sprintf("  version = %q\n", version))
 	}
 
 	builder.WriteString("\n")

--- a/pkg/tools/tfe/get_private_module_details.go
+++ b/pkg/tools/tfe/get_private_module_details.go
@@ -23,7 +23,7 @@ import (
 func GetPrivateModuleDetails(logger *log.Logger) server.ServerTool {
 	return server.ServerTool{
 		Tool: mcp.NewTool("get_private_module_details",
-			mcp.WithDescription(`This tool retrieves detailed information about a specific private module in your Terraform Cloud/Enterprise organization. It provides comprehensive details including inputs, outputs, dependencies, versions, and usage examples. The private_module_id format is 'module-namespace/module-name/module-provider-name'. This can be obtained by calling 'search_private_modules' first to obtain the exact private_module_id required to use this tool. This tool requires a valid Terraform token to be configured.`),
+			mcp.WithDescription(`This tool retrieves detailed information about a specific private module in your Terraform Cloud/Enterprise organization. It provides comprehensive details including inputs, outputs, dependencies, versions, and usage examples. It also reports every submodule (nested module) published with the module, each with its own inputs, outputs, provider dependencies, resources, and README. The private_module_id format is 'module-namespace/module-name/module-provider-name'. This can be obtained by calling 'search_private_modules' first to obtain the exact private_module_id required to use this tool. This tool requires a valid Terraform token to be configured.`),
 			mcp.WithTitleAnnotation("Get detailed information about a private module"),
 			mcp.WithOpenWorldHintAnnotation(true),
 			mcp.WithReadOnlyHintAnnotation(true),
@@ -107,20 +107,34 @@ func getPrivateModuleDetailsHandler(ctx context.Context, request mcp.CallToolReq
 	return buildPrivateModuleDetailsResponse(module, terraformRegistryModule, tfeClient.BaseURL().Host, logger), nil
 }
 
+// latestModuleVersion returns the first successfully published version, skipping
+// any still processing or failed. Used as a fallback when the registry API does
+// not return a version alongside the module details.
+func latestModuleVersion(registryModule *tfe.RegistryModule) string {
+	for _, versionStatus := range registryModule.VersionStatuses {
+		if versionStatus.Status == tfe.RegistryModuleVersionStatusOk {
+			return versionStatus.Version
+		}
+	}
+	return ""
+}
+
 func readTerraformRegistryModuleDetails(ctx context.Context, tfeClient *tfe.Client, moduleID tfe.RegistryModuleID, moduleVersion string) (*client.TerraformModuleVersionDetails, error) {
-	u := fmt.Sprintf("/api/registry/v1/modules/%s/%s/%s/%s",
+	basePath := "/api/registry/v1/modules"
+	if moduleID.RegistryName == tfe.PublicRegistry {
+		basePath = "/api/registry/public/v1/modules"
+	}
+
+	u := fmt.Sprintf("%s/%s/%s/%s",
+		basePath,
 		url.PathEscape(moduleID.Namespace),
 		url.PathEscape(moduleID.Name),
 		url.PathEscape(moduleID.Provider),
-		url.PathEscape(moduleVersion),
 	)
-	if moduleID.RegistryName == tfe.PublicRegistry {
-		u = fmt.Sprintf("/api/registry/public/v1/modules/%s/%s/%s/%s",
-			url.PathEscape(moduleID.Namespace),
-			url.PathEscape(moduleID.Name),
-			url.PathEscape(moduleID.Provider),
-			url.PathEscape(moduleVersion),
-		)
+
+	// Omit the version segment to request the latest version — the documented form of the route.
+	if moduleVersion != "" {
+		u += "/" + url.PathEscape(moduleVersion)
 	}
 
 	req, err := tfeClient.NewRequest("GET", u, nil)
@@ -140,6 +154,13 @@ func buildPrivateModuleDetailsResponse(registryModule *tfe.RegistryModule, terra
 
 	registryPath := path.Join(tfeHostAddress, registryModule.Namespace, registryModule.Name, registryModule.Provider)
 
+	// Use the version the registry returned content for, so the usage snippet and
+	// the inputs/outputs always refer to the same version.
+	moduleVersion := latestModuleVersion(registryModule)
+	if terraformRegistryModule != nil && terraformRegistryModule.Version != "" {
+		moduleVersion = terraformRegistryModule.Version
+	}
+
 	var builder strings.Builder
 	builder.WriteString("Usage:\n")
 	builder.WriteString("To use this private module in your Terraform configuration:\n\n")
@@ -147,9 +168,8 @@ func buildPrivateModuleDetailsResponse(registryModule *tfe.RegistryModule, terra
 	builder.WriteString(fmt.Sprintf("module %q {\n", registryModule.Name))
 	builder.WriteString(fmt.Sprintf("  source = %q\n", registryPath))
 
-	if len(registryModule.VersionStatuses) > 0 {
-		version := registryModule.VersionStatuses[0].Version
-		builder.WriteString(fmt.Sprintf("  version = %q\n", version))
+	if moduleVersion != "" {
+		builder.WriteString(fmt.Sprintf("  version = %q\n", moduleVersion))
 	}
 
 	builder.WriteString("\n")
@@ -162,6 +182,9 @@ func buildPrivateModuleDetailsResponse(registryModule *tfe.RegistryModule, terra
 	builder.WriteString(fmt.Sprintf("- Namespace: %s\n", registryModule.Namespace))
 	builder.WriteString(fmt.Sprintf("- Provider: %s\n", registryModule.Provider))
 	builder.WriteString(fmt.Sprintf("- Registry: %s\n", registryModule.RegistryName))
+	if moduleVersion != "" {
+		builder.WriteString(fmt.Sprintf("- Version: %s\n", moduleVersion))
+	}
 	builder.WriteString(fmt.Sprintf("- Created: %s\n", registryModule.CreatedAt))
 	builder.WriteString(fmt.Sprintf("- Updated: %s\n", registryModule.UpdatedAt))
 	builder.WriteString(fmt.Sprintf("- No Code Module: %t\n", registryModule.NoCode))
@@ -172,16 +195,19 @@ func buildPrivateModuleDetailsResponse(registryModule *tfe.RegistryModule, terra
 	builder.WriteString("\n")
 
 	if terraformRegistryModule != nil {
-		writeModulePartDetails(&builder, terraformRegistryModule.Root)
+		if modulePartHasDetails(terraformRegistryModule.Root) {
+			builder.WriteString("Root Module:\n")
+			writeModulePartDetails(&builder, terraformRegistryModule.Root)
+			writeModulePartReadme(&builder, terraformRegistryModule.Root)
+		}
 
-		if len(terraformRegistryModule.Submodules) > 0 {
-			builder.WriteString("Submodules:\n")
-			for _, submodule := range terraformRegistryModule.Submodules {
-				builder.WriteString(fmt.Sprintf("Submodule: %s\n", submodule.Name))
-				builder.WriteString(fmt.Sprintf("- Path: %s\n\n", submodule.Path))
-				writeModulePartDetails(&builder, submodule)
-				writeModulePartReadme(&builder, submodule)
-			}
+		// Submodules are reported the same way as the root module so that each one
+		// documents its own inputs, outputs, dependencies, resources, and README.
+		for _, submodule := range terraformRegistryModule.Submodules {
+			builder.WriteString(fmt.Sprintf("Submodule: %s\n", submodule.Name))
+			builder.WriteString(fmt.Sprintf("- Path: %s\n\n", submodule.Path))
+			writeModulePartDetails(&builder, submodule)
+			writeModulePartReadme(&builder, submodule)
 		}
 	}
 
@@ -216,13 +242,6 @@ func buildPrivateModuleDetailsResponse(registryModule *tfe.RegistryModule, terra
 		builder.WriteString("\n")
 	}
 
-	if terraformRegistryModule != nil && terraformRegistryModule.Root.Readme != "" {
-		cleanedReadme := removeReadmeSections(terraformRegistryModule.Root.Readme)
-		builder.WriteString("README:\n")
-		builder.WriteString(strings.Repeat("-", 20) + "\n")
-		builder.WriteString(cleanedReadme)
-	}
-
 	logger.WithFields(log.Fields{
 		"private_module_id":        registryModule.ID,
 		"private_module_namespace": registryModule.Namespace,
@@ -233,6 +252,17 @@ func buildPrivateModuleDetailsResponse(registryModule *tfe.RegistryModule, terra
 	}).Info("Successfully retrieved private module details")
 
 	return mcp.NewToolResultText(builder.String())
+}
+
+// modulePartHasDetails reports whether a module part has anything worth writing,
+// so that a heading is never emitted for a part the registry reported as empty.
+func modulePartHasDetails(modulePart client.ModulePart) bool {
+	return len(modulePart.Inputs) > 0 ||
+		len(modulePart.Outputs) > 0 ||
+		len(modulePart.Dependencies) > 0 ||
+		len(modulePart.ProviderDependencies) > 0 ||
+		len(modulePart.Resources) > 0 ||
+		modulePart.Readme != ""
 }
 
 func writeModulePartDetails(builder *strings.Builder, modulePart client.ModulePart) {
@@ -262,6 +292,21 @@ func writeModulePartDetails(builder *strings.Builder, modulePart client.ModulePa
 			builder.WriteString(fmt.Sprintf("| %s | %s |\n",
 				output.Name,
 				output.Description,
+			))
+		}
+		builder.WriteString("\n")
+	}
+
+	if len(modulePart.Dependencies) > 0 {
+		builder.WriteString("Dependencies:\n")
+		builder.WriteString(strings.Repeat("-", 20) + "\n")
+		builder.WriteString("| Name | Source | Version |\n")
+		builder.WriteString("|------|--------|---------|\n")
+		for _, dep := range modulePart.Dependencies {
+			builder.WriteString(fmt.Sprintf("| %s | %s | %s |\n",
+				dep.Name,
+				dep.Source,
+				dep.Version,
 			))
 		}
 		builder.WriteString("\n")

--- a/test/terraform/private_registry_test.go
+++ b/test/terraform/private_registry_test.go
@@ -68,12 +68,24 @@ func TestPrivateRegistryModules(t *testing.T) {
 			return nil, err
 		}
 
-		ready := len(module.Root.Inputs) > 0 && len(module.Root.Outputs) > 0 && module.Root.Readme != "" &&
-			len(module.Submodules) > 0 && len(module.Submodules[0].Inputs) > 0 && len(module.Submodules[0].Outputs) > 0 &&
-			len(module.Submodules[0].ProviderDependencies) > 0 && len(module.Submodules[0].Resources) > 0 && module.Submodules[0].Readme != ""
-		if !ready {
-			return nil, nil
+		// Report what is still missing so that a timeout says which part of the
+		// module never finished processing instead of only that we timed out.
+		if len(module.Root.Inputs) == 0 || len(module.Root.Outputs) == 0 || module.Root.Readme == "" {
+			return nil, fmt.Errorf("root module not processed yet: inputs=%d outputs=%d readme=%t",
+				len(module.Root.Inputs), len(module.Root.Outputs), module.Root.Readme != "")
 		}
+		if len(module.Submodules) == 0 {
+			return nil, fmt.Errorf("no submodules reported yet for %q", moduleLocator.Name)
+		}
+
+		submodule := module.Submodules[0]
+		if len(submodule.Inputs) == 0 || len(submodule.Outputs) == 0 ||
+			len(submodule.ProviderDependencies) == 0 || len(submodule.Resources) == 0 || submodule.Readme == "" {
+			return nil, fmt.Errorf("submodule %q not processed yet: inputs=%d outputs=%d provider_dependencies=%d resources=%d readme=%t",
+				submodule.Name, len(submodule.Inputs), len(submodule.Outputs),
+				len(submodule.ProviderDependencies), len(submodule.Resources), submodule.Readme != "")
+		}
+
 		return module, nil
 	})
 
@@ -120,13 +132,24 @@ func TestPrivateRegistryModules(t *testing.T) {
 
 		// TODO: update this after MCP SKD migration
 		assert.Contains(t, resultText, expectedModuleAddress)
+
+		require.NotEmpty(t, registryDetails.Root.Inputs, "the root module should report inputs")
+		require.NotEmpty(t, registryDetails.Root.Outputs, "the root module should report outputs")
+		assert.Contains(t, resultText, "Root Module:")
 		assert.Contains(t, resultText, registryDetails.Root.Inputs[0].Name)
 		assert.Contains(t, resultText, registryDetails.Root.Inputs[0].Description)
 		assert.Contains(t, resultText, registryDetails.Root.Outputs[0].Name)
 		assert.Contains(t, resultText, registryDetails.Root.Outputs[0].Description)
 		assert.Contains(t, resultText, strings.TrimSpace(registryDetails.Root.Readme))
 
+		// Submodules must be reported the same way as the root module.
+		require.NotEmpty(t, registryDetails.Submodules, "the module should report submodules")
 		submodule := registryDetails.Submodules[0]
+		require.NotEmpty(t, submodule.Inputs, "the submodule should report inputs")
+		require.NotEmpty(t, submodule.Outputs, "the submodule should report outputs")
+		require.NotEmpty(t, submodule.ProviderDependencies, "the submodule should report provider dependencies")
+		require.NotEmpty(t, submodule.Resources, "the submodule should report resources")
+
 		assert.Contains(t, resultText, "Submodule: "+submodule.Name)
 		assert.Contains(t, resultText, submodule.Path)
 		assert.Contains(t, resultText, submodule.Inputs[0].Name)

--- a/test/terraform/private_registry_test.go
+++ b/test/terraform/private_registry_test.go
@@ -3,11 +3,13 @@ package terraform
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/hashicorp/go-tfe"
+	mcpclient "github.com/hashicorp/terraform-mcp-server/pkg/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -48,15 +50,27 @@ func TestPrivateRegistryModules(t *testing.T) {
 	require.NoError(t, err, "failed to create test private module version")
 	require.NoError(t, client.RegistryModules.Upload(t.Context(), *version, "testdata/private_registry_module"), "failed to upload test private module")
 
-	// Module source is processed asynchronously after upload. Wait until its
-	// inputs, outputs, and README are available through the registry API.
-	registryDetails := waitFor(t, 2*time.Minute, fmt.Sprintf("private module %q version %s to finish processing", moduleLocator.Name, moduleVersion), func(ctx context.Context) (*tfe.TerraformRegistryModule, error) {
-		module, err := client.RegistryModules.ReadTerraformRegistryModule(ctx, moduleLocator, moduleVersion)
+	// Module source is processed asynchronously after upload. Wait until the root
+	// module and submodule details are available through the registry API.
+	registryDetails := waitFor(t, 2*time.Minute, fmt.Sprintf("private module %q version %s to finish processing", moduleLocator.Name, moduleVersion), func(ctx context.Context) (*mcpclient.TerraformModuleVersionDetails, error) {
+		u := fmt.Sprintf("/api/registry/v1/modules/%s/%s/%s/%s",
+			url.PathEscape(moduleLocator.Namespace),
+			url.PathEscape(moduleLocator.Name),
+			url.PathEscape(moduleLocator.Provider),
+			url.PathEscape(moduleVersion),
+		)
+		req, err := client.NewRequest("GET", u, nil)
 		if err != nil {
 			return nil, err
 		}
+		module := &mcpclient.TerraformModuleVersionDetails{}
+		if err := req.DoJSON(ctx, module); err != nil {
+			return nil, err
+		}
 
-		ready := module != nil && len(module.Root.Inputs) > 0 && len(module.Root.Outputs) > 0 && module.Root.Readme != ""
+		ready := len(module.Root.Inputs) > 0 && len(module.Root.Outputs) > 0 && module.Root.Readme != "" &&
+			len(module.Submodules) > 0 && len(module.Submodules[0].Inputs) > 0 && len(module.Submodules[0].Outputs) > 0 &&
+			len(module.Submodules[0].ProviderDependencies) > 0 && len(module.Submodules[0].Resources) > 0 && module.Submodules[0].Readme != ""
 		if !ready {
 			return nil, nil
 		}
@@ -95,6 +109,9 @@ func TestPrivateRegistryModules(t *testing.T) {
 			"private_module_id":      privateModuleAddress,
 			"private_module_version": moduleVersion,
 		})
+
+		t.Logf("Get private module details: %v", resultText)
+
 		require.False(t, result.IsError, "get_private_module_details should not return an error")
 		require.NotEmpty(t, resultText, "get_private_module_details response must not be empty")
 
@@ -108,6 +125,15 @@ func TestPrivateRegistryModules(t *testing.T) {
 		assert.Contains(t, resultText, registryDetails.Root.Outputs[0].Name)
 		assert.Contains(t, resultText, registryDetails.Root.Outputs[0].Description)
 		assert.Contains(t, resultText, strings.TrimSpace(registryDetails.Root.Readme))
+
+		submodule := registryDetails.Submodules[0]
+		assert.Contains(t, resultText, "Submodule: "+submodule.Name)
+		assert.Contains(t, resultText, submodule.Path)
+		assert.Contains(t, resultText, submodule.Inputs[0].Name)
+		assert.Contains(t, resultText, submodule.Outputs[0].Name)
+		assert.Contains(t, resultText, submodule.ProviderDependencies[0].Source)
+		assert.Contains(t, resultText, submodule.Resources[0].Type)
+		assert.Contains(t, resultText, strings.TrimSpace(submodule.Readme))
 	})
 }
 

--- a/test/terraform/private_registry_test.go
+++ b/test/terraform/private_registry_test.go
@@ -115,49 +115,65 @@ func TestPrivateRegistryModules(t *testing.T) {
 		assert.Contains(t, resultText, expectedModuleAddress)
 	})
 
-	t.Run("Get private module details", func(t *testing.T) {
-		result, resultText := callTool(t, s, "get_private_module_details", map[string]any{
-			"terraform_org_name":     tfeOrgName,
-			"private_module_id":      privateModuleAddress,
-			"private_module_version": moduleVersion,
+	getModuleDetailsTestCases := []struct {
+		name           string
+		includeVersion bool
+	}{
+		{name: "with explicit version", includeVersion: true},
+		{name: "with latest version", includeVersion: false},
+	}
+
+	for _, tc := range getModuleDetailsTestCases {
+		t.Run("Get private module details "+tc.name, func(t *testing.T) {
+			arguments := map[string]any{
+				"terraform_org_name": tfeOrgName,
+				"private_module_id":  privateModuleAddress,
+			}
+			if tc.includeVersion {
+				arguments["private_module_version"] = moduleVersion
+			}
+
+			result, resultText := callTool(t, s, "get_private_module_details", arguments)
+
+			t.Logf("Get private module details: %v", resultText)
+
+			require.False(t, result.IsError, "get_private_module_details should not return an error")
+			require.NotEmpty(t, resultText, "get_private_module_details response must not be empty")
+
+			// Verify against the TFE API directly.
+			expectedModuleAddress := strings.Join([]string{registryDetails.Namespace, registryDetails.Name, registryDetails.Provider}, "/")
+
+			// TODO: update this after MCP SKD migration
+			assert.Contains(t, resultText, expectedModuleAddress)
+			assert.Contains(t, resultText, fmt.Sprintf("version = %q", registryDetails.Version))
+			assert.Contains(t, resultText, "- Version: "+registryDetails.Version)
+
+			require.NotEmpty(t, registryDetails.Root.Inputs, "the root module should report inputs")
+			require.NotEmpty(t, registryDetails.Root.Outputs, "the root module should report outputs")
+			assert.Contains(t, resultText, "Root Module:")
+			assert.Contains(t, resultText, registryDetails.Root.Inputs[0].Name)
+			assert.Contains(t, resultText, registryDetails.Root.Inputs[0].Description)
+			assert.Contains(t, resultText, registryDetails.Root.Outputs[0].Name)
+			assert.Contains(t, resultText, registryDetails.Root.Outputs[0].Description)
+			assert.Contains(t, resultText, strings.TrimSpace(registryDetails.Root.Readme))
+
+			// Submodules must be reported the same way as the root module.
+			require.NotEmpty(t, registryDetails.Submodules, "the module should report submodules")
+			submodule := registryDetails.Submodules[0]
+			require.NotEmpty(t, submodule.Inputs, "the submodule should report inputs")
+			require.NotEmpty(t, submodule.Outputs, "the submodule should report outputs")
+			require.NotEmpty(t, submodule.ProviderDependencies, "the submodule should report provider dependencies")
+			require.NotEmpty(t, submodule.Resources, "the submodule should report resources")
+
+			assert.Contains(t, resultText, "Submodule: "+submodule.Name)
+			assert.Contains(t, resultText, submodule.Path)
+			assert.Contains(t, resultText, submodule.Inputs[0].Name)
+			assert.Contains(t, resultText, submodule.Outputs[0].Name)
+			assert.Contains(t, resultText, submodule.ProviderDependencies[0].Source)
+			assert.Contains(t, resultText, submodule.Resources[0].Type)
+			assert.Contains(t, resultText, strings.TrimSpace(submodule.Readme))
 		})
-
-		t.Logf("Get private module details: %v", resultText)
-
-		require.False(t, result.IsError, "get_private_module_details should not return an error")
-		require.NotEmpty(t, resultText, "get_private_module_details response must not be empty")
-
-		// Verify against the TFE API directly.
-		expectedModuleAddress := strings.Join([]string{registryDetails.Namespace, registryDetails.Name, registryDetails.Provider}, "/")
-
-		// TODO: update this after MCP SKD migration
-		assert.Contains(t, resultText, expectedModuleAddress)
-
-		require.NotEmpty(t, registryDetails.Root.Inputs, "the root module should report inputs")
-		require.NotEmpty(t, registryDetails.Root.Outputs, "the root module should report outputs")
-		assert.Contains(t, resultText, "Root Module:")
-		assert.Contains(t, resultText, registryDetails.Root.Inputs[0].Name)
-		assert.Contains(t, resultText, registryDetails.Root.Inputs[0].Description)
-		assert.Contains(t, resultText, registryDetails.Root.Outputs[0].Name)
-		assert.Contains(t, resultText, registryDetails.Root.Outputs[0].Description)
-		assert.Contains(t, resultText, strings.TrimSpace(registryDetails.Root.Readme))
-
-		// Submodules must be reported the same way as the root module.
-		require.NotEmpty(t, registryDetails.Submodules, "the module should report submodules")
-		submodule := registryDetails.Submodules[0]
-		require.NotEmpty(t, submodule.Inputs, "the submodule should report inputs")
-		require.NotEmpty(t, submodule.Outputs, "the submodule should report outputs")
-		require.NotEmpty(t, submodule.ProviderDependencies, "the submodule should report provider dependencies")
-		require.NotEmpty(t, submodule.Resources, "the submodule should report resources")
-
-		assert.Contains(t, resultText, "Submodule: "+submodule.Name)
-		assert.Contains(t, resultText, submodule.Path)
-		assert.Contains(t, resultText, submodule.Inputs[0].Name)
-		assert.Contains(t, resultText, submodule.Outputs[0].Name)
-		assert.Contains(t, resultText, submodule.ProviderDependencies[0].Source)
-		assert.Contains(t, resultText, submodule.Resources[0].Type)
-		assert.Contains(t, resultText, strings.TrimSpace(submodule.Readme))
-	})
+	}
 }
 
 func TestPrivateRegistryProviders(t *testing.T) {

--- a/test/terraform/testdata/private_registry_module/modules/child/README.md
+++ b/test/terraform/testdata/private_registry_module/modules/child/README.md
@@ -1,0 +1,3 @@
+# Private Registry Integration Test Submodule
+
+This submodule verifies that the Terraform MCP server retrieves documentation for individual private registry submodules.

--- a/test/terraform/testdata/private_registry_module/modules/child/main.tf
+++ b/test/terraform/testdata/private_registry_module/modules/child/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
+  }
+}
+
+variable "child_message" {
+  description = "Message used to verify private registry submodule inputs"
+  type        = string
+  default     = "private-registry-submodule-test"
+}
+
+resource "random_pet" "child" {
+  prefix = var.child_message
+}
+
+output "child_pet_name" {
+  description = "Name returned by the private registry test submodule"
+  value       = random_pet.child.id
+}


### PR DESCRIPTION
This PR closes issue [#438](https://github.com/hashicorp/terraform-mcp-server/issues/438) where `get_private_module_details` only returned top-level module information. Private registry submodules are now reported the same way as the root module, each with their own inputs, outputs, dependencies, provider dependencies, resources, and README.

## Changes

- Decoded the registry response into `client.TerraformModuleVersionDetails` instead of `tfe.TerraformRegistryModule`, which has no `Submodules` field and was silently discarding the data.
- Reported each submodule through the same formatting helpers as the root module.
- Labelled the root section `Root Module:` and moved its README there, instead of leaving it at the bottom where nothing identified which module it belonged to.
- Added a `Dependencies` table, applying to the root module and all submodules.
- Reported the module version, and pinned the usage example to the version the details came from rather than the first `version-statuses` entry, which may be unpublished or failed.
- Requested the documented latest-version route when `private_module_version` is omitted, rather than sending an empty version segment.
- Updated the tool description to mention submodules.
- Extended the integration test to cover explicit and omitted versions, added a `modules/child` fixture, and made polling failures report which part never finished processing.

## Workflow

1. Use `search_private_modules` to find the exact `private_module_id`.
2. Call `get_private_module_details`, optionally passing `private_module_version`. When omitted, the registry resolves the latest version and the response states which one it used.
3. The response contains the usage example, basic information, a `Root Module:` section, and one `Submodule:` section per nested module.


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
