### PR TITLE
Migrate official go-sdk server setup to prepare for middleware and hooks

### DIFF
--- a/cmd/terraform-mcp-server/init.go
+++ b/cmd/terraform-mcp-server/init.go
@@ -368,8 +368,8 @@ func streamableHTTPServerInit(ctx context.Context, hcServer *server.MCPServer, l
 
 	// Create the official go-sdk streamable server
 	if enableOfficialSDK := os.Getenv("TF_X_OFFICIAL_SDK_ENABLED"); enableOfficialSDK == "true" {
-		logger.Infof("TF_X_OFFICIAL_SDK_ENABLED set to true in env, enabling the official mcp go-sdk server")
-		officialStreamableServer := getOfficialStreamableServer(ctx, heartbeatInterval, isStateless, tlsConfig, corsConfig, logger, organizationAllowlist, enabledToolsets)
+		logger.Info("TF_X_OFFICIAL_SDK_ENABLED set to true in env, enabling the official mcp go-sdk server")
+		officialStreamableServer := getOfficialStreamableServer(ctx, heartbeatInterval, isStateless, corsConfig, logger, organizationAllowlist, enabledToolsets)
 		// Handle the /mcp endpoint with the official go-sdk streamable server (with security wrapper)
 		mux.Handle(endpointPath+"/official", officialStreamableServer)
 		mux.Handle(endpointPath+"/official/", officialStreamableServer)
@@ -458,13 +458,14 @@ func streamableHTTPServerInit(ctx context.Context, hcServer *server.MCPServer, l
 	return nil
 }
 
-func getOfficialStreamableServer(ctx context.Context, heartbeatInterval time.Duration, isStateless bool, tlsConfig *client.TLSConfig, corsConfig client.CORSConfig, logger *log.Logger, organizationAllowlist []string, enabledToolsets []string) http.Handler {
-	logger.Infof("Creating a go-sdk StreamableHTTP server...")
-	hcServer := mcpofficial.NewServer(heartbeatInterval, logger, enabledToolsets)
+func getOfficialStreamableServer(ctx context.Context, heartbeatInterval time.Duration, isStateless bool, corsConfig client.CORSConfig, logger *log.Logger, organizationAllowlist []string, enabledToolsets []string) http.Handler {
+	logger.Info("Creating a go-sdk StreamableHTTP server...")
+	hcServer := mcpofficial.NewServer(version.Version, instructions, heartbeatInterval, logger, enabledToolsets)
 
 	opts := &mcp.StreamableHTTPOptions{
 		Stateless:             isStateless,
-		CrossOriginProtection: nil, // disables the SDK's built-in cross-origin protection entirely.
+		Logger:                newSlogLogger(logger),
+		CrossOriginProtection: nil, // disables the SDK's built-in cross-origin protection entirely. CORS already enforced by client.NewSecurityHandler below.
 	}
 
 	// Create the base MCP handler

--- a/pkg/mcp-official/server.go
+++ b/pkg/mcp-official/server.go
@@ -3,27 +3,38 @@ package mcpofficial
 import (
 	"time"
 
-	"github.com/hashicorp/terraform-mcp-server/version"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-func NewServer(heartbeatInterval time.Duration, logger *log.Logger, enabledToolsets []string) *mcp.Server {
-	var svrOptions *mcp.ServerOptions
+// serverConfig holds all server config so future phases (middleware, hooks)
+// don't require changing NewServer's signature again.
+type serverConfig struct {
+	mcpOpts     mcp.ServerOptions
+	middlewares []mcp.Middleware           // consumed in Phase 2
+	onSession   []func(*mcp.ServerSession) // consumed in Phase 3
+}
+
+type Option func(*serverConfig)
+
+func NewServer(version, instructions string, heartbeatInterval time.Duration, logger *log.Logger, enabledToolsets []string, opts ...Option) *mcp.Server {
+	cfg := &serverConfig{mcpOpts: mcp.ServerOptions{Instructions: instructions}}
 	if heartbeatInterval > 0 {
-		log.Infof("HTTP heartbeat enabled with interval: %v", heartbeatInterval)
-		svrOptions = &mcp.ServerOptions{
-			KeepAlive: heartbeatInterval,
-		}
+		logger.Infof("HTTP heartbeat enabled with interval: %v", heartbeatInterval)
+		cfg.mcpOpts.KeepAlive = heartbeatInterval
 	}
-	svr := mcp.NewServer(
-		&mcp.Implementation{
-			Name:    "terraform-mcp-official",
-			Version: version.Version,
-		},
-		svrOptions,
-	)
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	svr := mcp.NewServer(&mcp.Implementation{Name: "terraform-mcp-official", Version: version}, &cfg.mcpOpts)
+
+	// TODO - Must attach after construction - AddReceivingMiddleware isn't a ServerOptions field.
+	if len(cfg.middlewares) > 0 {
+		svr.AddReceivingMiddleware(cfg.middlewares...)
+	}
+
 	RegisterTools(svr, logger, enabledToolsets)
 	return svr
 }


### PR DESCRIPTION
This PR cleans up how we build the official MCP go-sdk server (pkg/mcp-official), as a first step before we add middleware and session hooks in follow-up PRs.

**What changed:**
- NewServer now takes version and instructions directly as arguments instead of importing the version package itself. 
- Added a small internal serverConfig struct plus an Option pattern (like mcp.NewServer(..., opts...)). This doesn't change any behavior today — it just gives us a clean place to plug in middleware and session hooks later.
- Removed an unused tlsConfig parameter from getOfficialStreamableServer.
- Hooked up a logger to the go-sdk's StreamableHTTPOptions, so the SDK's internal logs go through via newSlogLogger.


**We're planning two follow-up changes:**
1. Middleware — adding request/response middleware (e.g. logging, auth checks) via AddReceivingMiddleware.
2. Hooks — running custom logic when a session starts/ends (onSession hooks).



## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
