### PR TITLE
add public helm chart

### DIFF
--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -1,0 +1,42 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+name: Helm Chart
+
+on:
+  push:
+    paths:
+      - 'helm/**'
+  pull_request:
+    paths:
+      - 'helm/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  helm-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Set up Helm
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
+
+      - name: Lint chart
+        run: helm lint helm/terraform-mcp-server
+
+      - name: Template chart (defaults)
+        run: helm template helm/terraform-mcp-server
+
+      - name: Template chart (overrides)
+        run: |
+          helm template helm/terraform-mcp-server \
+            --set mcpServer.tfeAddress=https://tfe.example.com \
+            --set mcpServer.allowedOrigins=https://ide.example.com \
+            --set mcpServer.sessionMode=stateless \
+            --set otel.enabled=true \
+            --set otel.metricsEndpoint=http://collector:4318 \
+            --set ingress.enabled=true

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -28,6 +28,16 @@ jobs:
       - name: Lint chart
         run: helm lint helm/terraform-mcp-server
 
+      - name: Check chart version matches appVersion
+        run: |
+          version=$(helm show chart helm/terraform-mcp-server | grep '^version:' | awk '{print $2}')
+          app_version=$(helm show chart helm/terraform-mcp-server | grep '^appVersion:' | awk '{print $2}' | tr -d '"')
+          if [ "$version" != "$app_version" ]; then
+            echo "Chart.yaml version ($version) must match appVersion ($app_version)."
+            echo "The release pipeline pulls the published chart by the release tag, so they have to be equal."
+            exit 1
+          fi
+
       - name: Template chart (defaults)
         run: helm template helm/terraform-mcp-server
 
@@ -37,6 +47,7 @@ jobs:
             --set mcpServer.tfeAddress=https://tfe.example.com \
             --set mcpServer.allowedOrigins=https://ide.example.com \
             --set mcpServer.sessionMode=stateless \
+            --set mcpServer.enableTfOperations=true \
             --set otel.enabled=true \
             --set otel.metricsEndpoint=http://collector:4318 \
             --set ingress.enabled=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ FEATURES
 * [New Tool] `grant_team_access` Grants a team access to a workspace or project by ID. Requires `team_id`, `access_level`, and either `workspace_id` or `project_id` (mutually exclusive). Valid access levels for workspaces: `admin`, `read`, `write`, `plan`, `custom`. Valid access levels for projects: `admin`, `read`, `write`, `maintain`, `custom`.
 * [New Tool] `delete_team` Permanently deletes a Terraform team by its `team_id`. Requires `team_id` (e.g. `team-abc123def456`). This is a destructive operation and must set `ENABLE_TF_OPERATIONS=true`.
 
+IMPROVEMENTS
+
+* Add a Helm chart for deploying the server on Kubernetes, under `helm/terraform-mcp-server`
+
 FIXES
 
 * `get_apply_logs` now checks the apply status before attempting to stream logs. If the apply is not yet in a terminal state (`finished`, `errored`, `canceled`), the tool returns an informative message instead of timing out. [468](https://github.com/hashicorp/terraform-mcp-server/pull/468)

--- a/README.md
+++ b/README.md
@@ -497,6 +497,10 @@ More about using and adding MCP servers tools in Bob IDE or Shell [Using MCP in 
 </tr>
 </table>
 
+### Kubernetes (Helm)
+
+A Helm chart for deploying the server on Kubernetes is available under [`helm/terraform-mcp-server`](helm/terraform-mcp-server/README.md).
+
 ## Install from source
 
 Use the latest release version:

--- a/helm/terraform-mcp-server/.helmignore
+++ b/helm/terraform-mcp-server/.helmignore
@@ -1,0 +1,20 @@
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/terraform-mcp-server/Chart.yaml
+++ b/helm/terraform-mcp-server/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+name: terraform-mcp-server
+description: A Helm chart for running the Terraform MCP Server on Kubernetes
+type: application
+# Chart version. Increment on any change to the chart or its templates,
+# following Semantic Versioning (https://semver.org/).
+version: 0.1.0
+# The version of terraform-mcp-server this chart deploys.
+appVersion: "1.3.0"
+home: https://github.com/hashicorp/terraform-mcp-server
+sources:
+  - https://github.com/hashicorp/terraform-mcp-server
+maintainers:
+  - name: HashiCorp
+    url: https://github.com/hashicorp/terraform-mcp-server

--- a/helm/terraform-mcp-server/Chart.yaml
+++ b/helm/terraform-mcp-server/Chart.yaml
@@ -2,9 +2,10 @@ apiVersion: v2
 name: terraform-mcp-server
 description: A Helm chart for running the Terraform MCP Server on Kubernetes
 type: application
-# Chart version. Increment on any change to the chart or its templates,
-# following Semantic Versioning (https://semver.org/).
-version: 0.1.0
+# Chart version. Has to match appVersion: the release pipeline publishes the
+# chart on the server's production release and then pulls it back by that same
+# tag, so a mismatch fails the smoke test.
+version: 1.3.0
 # The version of terraform-mcp-server this chart deploys.
 appVersion: "1.3.0"
 home: https://github.com/hashicorp/terraform-mcp-server

--- a/helm/terraform-mcp-server/README.md
+++ b/helm/terraform-mcp-server/README.md
@@ -55,10 +55,22 @@ The server is configured through the `mcpServer` values, which map to the server
 | `mcpServer.corsMode` | CORS mode: `strict`, `development`, or `disabled` | `strict` |
 | `mcpServer.allowedOrganizations` | Restrict tool calls to these Terraform organizations. Empty allows any organization the token can reach. | `[]` |
 | `mcpServer.sessionMode` | `stateful` or `stateless`. Use `stateless` when running multiple replicas behind a load balancer without session affinity. | `stateful` |
-| `mcpServer.sharedSecret` | Optional shared secret sent as the `X-Tf-Mcp-Secret` header to identify a hosted deployment. Treat as a credential. | `""` |
+| `mcpServer.existingSecret` | Name of an existing Secret holding the shared secret sent as the `X-Tf-Mcp-Secret` header. Preferred over `sharedSecret`. | `""` |
+| `mcpServer.existingSecretKey` | Key within `existingSecret` holding the shared secret. | `shared-secret` |
+| `mcpServer.sharedSecret` | Shared secret as a plaintext value. Only used when `existingSecret` is unset. Treat as a credential. | `""` |
 | `mcpServer.logLevel` | Log level | `info` |
 | `mcpServer.logFormat` | Log format: `text` or `json` | `json` |
 | `mcpServer.heartbeatInterval` | Heartbeat interval for streamable-http; `0` disables | `"0"` |
+
+To supply the shared secret from an existing Secret:
+
+```bash
+kubectl create secret generic terraform-mcp-server \
+  --from-literal=shared-secret=<value>
+
+helm install terraform-mcp-server ./helm/terraform-mcp-server \
+  --set mcpServer.existingSecret=terraform-mcp-server
+```
 
 ### Ingress
 
@@ -89,4 +101,4 @@ The chart sets `OTEL_INSTANCE_ID` from the pod UID so each replica reports a dis
 - **CORS defaults to strict.** With no `allowedOrigins` set, all cross-origin requests are rejected. Set `mcpServer.allowedOrigins` to your client origin(s).
 - **The Terraform address is server-side only.** Clients cannot override `TFE_ADDRESS` via header or query parameter in streamable-http mode; it is fixed by `mcpServer.tfeAddress`.
 - **Use TLS in front of the server.** Deploy behind an ingress or service that terminates TLS. The shared secret and any tokens are sent in headers and must not traverse plaintext connections.
-- **`mcpServer.sharedSecret` is rendered into the pod environment.** For sensitive deployments, prefer supplying it via a values file you keep out of source control, or set it with `--set` at install time.
+- **Use (preffered over sharedSecret) `mcpServer.existingSecret` for the shared secret.** Create a Kubernetes Secret and reference it by name; the chart reads the key named by `mcpServer.existingSecretKey` (default `shared-secret`). `mcpServer.sharedSecret` puts the value straight into your values file and the pod spec, so it's only appropriate for local testing.

--- a/helm/terraform-mcp-server/README.md
+++ b/helm/terraform-mcp-server/README.md
@@ -1,0 +1,92 @@
+# Terraform MCP Server Helm Chart
+
+A Helm chart for deploying the [Terraform MCP Server](https://github.com/hashicorp/terraform-mcp-server) on Kubernetes in streamable-http mode.
+
+## Prerequisites
+
+- Kubernetes 1.23+
+- Helm 3.8+
+
+## Installing
+
+```bash
+helm install terraform-mcp-server ./helm/terraform-mcp-server
+```
+
+By default this deploys the server pointing at public HCP Terraform (`https://app.terraform.io`) with strict CORS and OpenTelemetry metrics disabled.
+
+To install against a Terraform Enterprise instance and allow a specific client origin:
+
+```bash
+helm install terraform-mcp-server ./helm/terraform-mcp-server \
+  --set mcpServer.tfeAddress=https://tfe.example.com \
+  --set mcpServer.allowedOrigins=https://ide.example.com
+```
+
+## Uninstalling
+
+```bash
+helm uninstall terraform-mcp-server
+```
+
+## Configuration
+
+The server is configured through the `mcpServer` values, which map to the server's environment variables. Only values that are set are passed to the container.
+
+### Common values
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `replicaCount` | Number of server replicas | `1` |
+| `image.repository` | Server image repository | `hashicorp/terraform-mcp-server` |
+| `image.tag` | Image tag (defaults to the chart appVersion) | `""` |
+| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `service.type` | Kubernetes service type | `ClusterIP` |
+| `service.port` | Service port | `8080` |
+| `resources` | Pod resource requests/limits | see values.yaml |
+| `autoscaling.enabled` | Enable a HorizontalPodAutoscaler | `false` |
+
+### Server configuration (`mcpServer`)
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `mcpServer.tfeAddress` | HCP Terraform / TFE address. In streamable-http mode this can only be set here; clients cannot override it. | `https://app.terraform.io` |
+| `mcpServer.allowedOrigins` | Comma-separated CORS allowed origins. Empty with strict mode rejects all cross-origin requests. | `""` |
+| `mcpServer.corsMode` | CORS mode: `strict`, `development`, or `disabled` | `strict` |
+| `mcpServer.allowedOrganizations` | Restrict tool calls to these Terraform organizations. Empty allows any organization the token can reach. | `[]` |
+| `mcpServer.sessionMode` | `stateful` or `stateless`. Use `stateless` when running multiple replicas behind a load balancer without session affinity. | `stateful` |
+| `mcpServer.sharedSecret` | Optional shared secret sent as the `X-Tf-Mcp-Secret` header to identify a hosted deployment. Treat as a credential. | `""` |
+| `mcpServer.logLevel` | Log level | `info` |
+| `mcpServer.logFormat` | Log format: `text` or `json` | `json` |
+| `mcpServer.heartbeatInterval` | Heartbeat interval for streamable-http; `0` disables | `"0"` |
+
+### Ingress
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `ingress.enabled` | Enable an Ingress resource | `false` |
+| `ingress.className` | Ingress class name | `""` |
+| `ingress.annotations` | Ingress annotations (set these to match your ingress controller) | `{}` |
+| `ingress.hosts` | Ingress hosts and paths | see values.yaml |
+| `ingress.tls` | Ingress TLS configuration | `[]` |
+
+Ingress is disabled by default and has no cloud-specific annotations. Set the annotations and class appropriate to your cluster's ingress controller.
+
+### OpenTelemetry metrics
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `otel.enabled` | Export OpenTelemetry metrics | `false` |
+| `otel.metricsEndpoint` | OTLP metrics endpoint. If unset, the server uses its own default. Set this to your OTLP collector. | `""` |
+| `otel.serviceName` | Service name reported in metrics | `terraform-mcp-server` |
+
+Metrics are disabled by default. If you enable them, set `otel.metricsEndpoint` to your OTLP collector endpoint.
+
+The chart sets `OTEL_INSTANCE_ID` from the pod UID so each replica reports a distinct `service.instance.id`. Without it, telemetry from every replica is attributed to a single instance.
+
+## Security notes
+
+- **CORS defaults to strict.** With no `allowedOrigins` set, all cross-origin requests are rejected. Set `mcpServer.allowedOrigins` to your client origin(s).
+- **The Terraform address is server-side only.** Clients cannot override `TFE_ADDRESS` via header or query parameter in streamable-http mode; it is fixed by `mcpServer.tfeAddress`.
+- **Use TLS in front of the server.** Deploy behind an ingress or service that terminates TLS. The shared secret and any tokens are sent in headers and must not traverse plaintext connections.
+- **`mcpServer.sharedSecret` is rendered into the pod environment.** For sensitive deployments, prefer supplying it via a values file you keep out of source control, or set it with `--set` at install time.

--- a/helm/terraform-mcp-server/README.md
+++ b/helm/terraform-mcp-server/README.md
@@ -45,6 +45,8 @@ The server is configured through the `mcpServer` values, which map to the server
 | `service.port` | Service port | `8080` |
 | `resources` | Pod resource requests/limits | see values.yaml |
 | `autoscaling.enabled` | Enable a HorizontalPodAutoscaler | `false` |
+| `volumes` | Extra volumes for the pod | `[]` |
+| `volumeMounts` | Extra volume mounts for the container | `[]` |
 
 ### Server configuration (`mcpServer`)
 
@@ -55,21 +57,33 @@ The server is configured through the `mcpServer` values, which map to the server
 | `mcpServer.corsMode` | CORS mode: `strict`, `development`, or `disabled` | `strict` |
 | `mcpServer.allowedOrganizations` | Restrict tool calls to these Terraform organizations. Empty allows any organization the token can reach. | `[]` |
 | `mcpServer.sessionMode` | `stateful` or `stateless`. Use `stateless` when running multiple replicas behind a load balancer without session affinity. | `stateful` |
-| `mcpServer.existingSecret` | Name of an existing Secret holding the shared secret sent as the `X-Tf-Mcp-Secret` header. Preferred over `sharedSecret`. | `""` |
-| `mcpServer.existingSecretKey` | Key within `existingSecret` holding the shared secret. | `shared-secret` |
-| `mcpServer.sharedSecret` | Shared secret as a plaintext value. Only used when `existingSecret` is unset. Treat as a credential. | `""` |
+| `mcpServer.enableTfOperations` | Enables the destructive tools (`delete_team`, `force_unlock_workspace`, and similar). | `false` |
+| `mcpServer.redirectRootURL` | Where to redirect a browser that hits `/`. Defaults to the Terraform MCP docs page when unset. | `""` |
+| `mcpServer.tls.certFile` | Path to a TLS certificate inside the container. Mount it with `volumes` and `volumeMounts`. | `""` |
+| `mcpServer.tls.keyFile` | Path to the matching TLS key inside the container. | `""` |
 | `mcpServer.logLevel` | Log level | `info` |
 | `mcpServer.logFormat` | Log format: `text` or `json` | `json` |
 | `mcpServer.heartbeatInterval` | Heartbeat interval for streamable-http; `0` disables | `"0"` |
 
-To supply the shared secret from an existing Secret:
+### TLS
 
-```bash
-kubectl create secret generic terraform-mcp-server \
-  --from-literal=shared-secret=<value>
+The server can terminate TLS itself rather than relying on an ingress. Mount a certificate and key, then point the server at the mount paths:
 
-helm install terraform-mcp-server ./helm/terraform-mcp-server \
-  --set mcpServer.existingSecret=terraform-mcp-server
+```yaml
+volumes:
+  - name: tls
+    secret:
+      secretName: terraform-mcp-server-tls
+
+volumeMounts:
+  - name: tls
+    mountPath: /tls
+    readOnly: true
+
+mcpServer:
+  tls:
+    certFile: /tls/tls.crt
+    keyFile: /tls/tls.key
 ```
 
 ### Ingress
@@ -92,7 +106,7 @@ Ingress is disabled by default and has no cloud-specific annotations. Set the an
 | `otel.metricsEndpoint` | OTLP metrics endpoint. If unset, the server uses its own default. Set this to your OTLP collector. | `""` |
 | `otel.serviceName` | Service name reported in metrics | `terraform-mcp-server` |
 
-Metrics are disabled by default. If you enable them, set `otel.metricsEndpoint` to your OTLP collector endpoint.
+Metrics are disabled by default, and none of the `OTEL_` environment variables are set on the container unless `otel.enabled` is true. If you enable them, set `otel.metricsEndpoint` to your OTLP collector endpoint.
 
 The chart sets `OTEL_INSTANCE_ID` from the pod UID so each replica reports a distinct `service.instance.id`. Without it, telemetry from every replica is attributed to a single instance.
 
@@ -100,5 +114,5 @@ The chart sets `OTEL_INSTANCE_ID` from the pod UID so each replica reports a dis
 
 - **CORS defaults to strict.** With no `allowedOrigins` set, all cross-origin requests are rejected. Set `mcpServer.allowedOrigins` to your client origin(s).
 - **The Terraform address is server-side only.** Clients cannot override `TFE_ADDRESS` via header or query parameter in streamable-http mode; it is fixed by `mcpServer.tfeAddress`.
-- **Use TLS in front of the server.** Deploy behind an ingress or service that terminates TLS. The shared secret and any tokens are sent in headers and must not traverse plaintext connections.
-- **Use (preffered over sharedSecret) `mcpServer.existingSecret` for the shared secret.** Create a Kubernetes Secret and reference it by name; the chart reads the key named by `mcpServer.existingSecretKey` (default `shared-secret`). `mcpServer.sharedSecret` puts the value straight into your values file and the pod spec, so it's only appropriate for local testing.
+- **Use TLS.** Either terminate at an ingress or configure `mcpServer.tls` so the server serves TLS itself. Terraform tokens are sent in request headers and must not traverse plaintext connections.
+- **Destructive tools are off by default.** `mcpServer.enableTfOperations` gates the tools that delete or force-unlock Terraform resources. Leave it `false` unless you specifically want those available.

--- a/helm/terraform-mcp-server/templates/NOTES.txt
+++ b/helm/terraform-mcp-server/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "terraform-mcp-server.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "terraform-mcp-server.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "terraform-mcp-server.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "terraform-mcp-server.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/helm/terraform-mcp-server/templates/_helpers.tpl
+++ b/helm/terraform-mcp-server/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "terraform-mcp-server.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as an full name.
+*/}}
+{{- define "terraform-mcp-server.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "terraform-mcp-server.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "terraform-mcp-server.labels" -}}
+helm.sh/chart: {{ include "terraform-mcp-server.chart" . }}
+{{ include "terraform-mcp-server.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "terraform-mcp-server.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "terraform-mcp-server.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "terraform-mcp-server.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "terraform-mcp-server.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/terraform-mcp-server/templates/deployment.yaml
+++ b/helm/terraform-mcp-server/templates/deployment.yaml
@@ -69,7 +69,13 @@ spec:
             - name: MCP_ORGANIZATION_ALLOWLIST
               value: {{ .Values.mcpServer.allowedOrganizations | join "," | quote }}
             {{- end }}
-            {{- if .Values.mcpServer.sharedSecret }}
+            {{- if .Values.mcpServer.existingSecret }}
+            - name: TF_MCP_SHARED_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.mcpServer.existingSecret }}
+                  key: {{ .Values.mcpServer.existingSecretKey | default "shared-secret" }}
+            {{- else if .Values.mcpServer.sharedSecret }}
             - name: TF_MCP_SHARED_SECRET
               value: {{ .Values.mcpServer.sharedSecret | quote }}
             {{- end }}

--- a/helm/terraform-mcp-server/templates/deployment.yaml
+++ b/helm/terraform-mcp-server/templates/deployment.yaml
@@ -69,16 +69,23 @@ spec:
             - name: MCP_ORGANIZATION_ALLOWLIST
               value: {{ .Values.mcpServer.allowedOrganizations | join "," | quote }}
             {{- end }}
-            {{- if .Values.mcpServer.existingSecret }}
-            - name: TF_MCP_SHARED_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.mcpServer.existingSecret }}
-                  key: {{ .Values.mcpServer.existingSecretKey | default "shared-secret" }}
-            {{- else if .Values.mcpServer.sharedSecret }}
-            - name: TF_MCP_SHARED_SECRET
-              value: {{ .Values.mcpServer.sharedSecret | quote }}
+            - name: ENABLE_TF_OPERATIONS
+              value: {{ .Values.mcpServer.enableTfOperations | default false | quote }}
+            {{- if .Values.mcpServer.redirectRootURL }}
+            - name: MCP_REDIRECT_ROOT_URL
+              value: {{ .Values.mcpServer.redirectRootURL | quote }}
             {{- end }}
+            {{- if .Values.mcpServer.tls.certFile }}
+            - name: MCP_TLS_CERT_FILE
+              value: {{ .Values.mcpServer.tls.certFile | quote }}
+            {{- end }}
+            {{- if .Values.mcpServer.tls.keyFile }}
+            - name: MCP_TLS_KEY_FILE
+              value: {{ .Values.mcpServer.tls.keyFile | quote }}
+            {{- end }}
+            {{- if .Values.otel.enabled }}
+            - name: OTEL_METRICS_ENABLED
+              value: "true"
             - name: HOST_IP
               valueFrom:
                 fieldRef:
@@ -87,14 +94,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.uid
-            - name: OTEL_METRICS_ENABLED
-              value: {{ .Values.otel.enabled | quote }}
             {{- if .Values.otel.metricsEndpoint }}
             - name: OTEL_METRICS_ENDPOINT
               value: {{ .Values.otel.metricsEndpoint | quote }}
             {{- end }}
             - name: OTEL_METRICS_SERVICE_NAME
               value: {{ .Values.otel.serviceName | default "terraform-mcp-server" | quote }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/helm/terraform-mcp-server/templates/deployment.yaml
+++ b/helm/terraform-mcp-server/templates/deployment.yaml
@@ -1,0 +1,127 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "terraform-mcp-server.fullname" . }}
+  labels:
+    {{- include "terraform-mcp-server.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "terraform-mcp-server.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "terraform-mcp-server.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "terraform-mcp-server.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "streamable-http"
+            - "--transport-port={{ .Values.service.port }}"
+            - "--transport-host=0.0.0.0"
+          env:
+            - name: MCP_SESSION_MODE
+              value: {{ .Values.mcpServer.sessionMode | default "stateful" | quote }}
+            - name: MCP_HEARTBEAT_INTERVAL
+              value: {{ .Values.mcpServer.heartbeatInterval | default "0" | quote }}
+            - name: LOG_LEVEL
+              value: {{ .Values.mcpServer.logLevel | default "info" | quote }}
+            - name: LOG_FORMAT
+              value: {{ .Values.mcpServer.logFormat | default "json" | quote }}
+            {{- if .Values.mcpServer.tfeAddress }}
+            - name: TFE_ADDRESS
+              value: {{ .Values.mcpServer.tfeAddress | quote }}
+            {{- end }}
+            {{- if .Values.mcpServer.allowedOrigins }}
+            - name: MCP_ALLOWED_ORIGINS
+              value: {{ .Values.mcpServer.allowedOrigins | quote }}
+            {{- end }}
+            {{- if .Values.mcpServer.corsMode }}
+            - name: MCP_CORS_MODE
+              value: {{ .Values.mcpServer.corsMode | quote }}
+            {{- end }}
+            {{- if .Values.mcpServer.allowedOrganizations }}
+            - name: MCP_ORGANIZATION_ALLOWLIST
+              value: {{ .Values.mcpServer.allowedOrganizations | join "," | quote }}
+            {{- end }}
+            {{- if .Values.mcpServer.sharedSecret }}
+            - name: TF_MCP_SHARED_SECRET
+              value: {{ .Values.mcpServer.sharedSecret | quote }}
+            {{- end }}
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_INSTANCE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: OTEL_METRICS_ENABLED
+              value: {{ .Values.otel.enabled | quote }}
+            {{- if .Values.otel.metricsEndpoint }}
+            - name: OTEL_METRICS_ENDPOINT
+              value: {{ .Values.otel.metricsEndpoint | quote }}
+            {{- end }}
+            - name: OTEL_METRICS_SERVICE_NAME
+              value: {{ .Values.otel.serviceName | default "terraform-mcp-server" | quote }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/terraform-mcp-server/templates/hpa.yaml
+++ b/helm/terraform-mcp-server/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "terraform-mcp-server.fullname" . }}
+  labels:
+    {{- include "terraform-mcp-server.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "terraform-mcp-server.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/helm/terraform-mcp-server/templates/ingress.yaml
+++ b/helm/terraform-mcp-server/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "terraform-mcp-server.fullname" . }}
+  labels:
+    {{- include "terraform-mcp-server.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ include "terraform-mcp-server.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/terraform-mcp-server/templates/service.yaml
+++ b/helm/terraform-mcp-server/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "terraform-mcp-server.fullname" . }}
+  labels:
+    {{- include "terraform-mcp-server.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "terraform-mcp-server.selectorLabels" . | nindent 4 }}

--- a/helm/terraform-mcp-server/templates/serviceaccount.yaml
+++ b/helm/terraform-mcp-server/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "terraform-mcp-server.serviceAccountName" . }}
+  labels:
+    {{- include "terraform-mcp-server.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm/terraform-mcp-server/templates/tests/test-connection.yaml
+++ b/helm/terraform-mcp-server/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "terraform-mcp-server.fullname" . }}-test-connection"
+  labels:
+    {{- include "terraform-mcp-server.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "terraform-mcp-server.fullname" . }}:{{ .Values.service.port }}/health']
+  restartPolicy: Never

--- a/helm/terraform-mcp-server/values.yaml
+++ b/helm/terraform-mcp-server/values.yaml
@@ -1,0 +1,85 @@
+# Default values for terraform-mcp-server.
+
+replicaCount: 1
+
+image:
+  repository: hashicorp/terraform-mcp-server
+  pullPolicy: IfNotPresent
+  # Defaults to the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  automount: true
+  # Generated from the fullname template if empty and create is true.
+  name: ""
+
+podAnnotations: {}
+podSecurityContext: {}
+securityContext: {}
+
+service:
+  type: ClusterIP
+  port: 8080
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 250m
+    memory: 256Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# Maps to the server's environment variables.
+mcpServer:
+  # stateful or stateless. stateless is useful with multiple replicas behind a
+  # load balancer that doesn't do session affinity.
+  sessionMode: "stateful"
+  # "0" disables it.
+  heartbeatInterval: "0"
+  # trace, debug, info, warn, error, fatal, panic.
+  logLevel: "info"
+  # text or json.
+  logFormat: "json"
+  # in streamable-http mode this can only be set here. clients can't override it
+  # via header or query param.
+  tfeAddress: "https://app.terraform.io"
+  # comma-separated. empty with strict mode rejects all cross-origin requests.
+  allowedOrigins: ""
+  # strict, development, or disabled.
+  corsMode: "strict"
+  # restrict tool calls to these orgs. empty allows any org the token can reach.
+  allowedOrganizations: []
+  # sent as the X-Tf-Mcp-Secret header. treat as a credential.
+  sharedSecret: ""
+
+otel:
+  enabled: false
+  metricsEndpoint: ""
+  serviceName: "terraform-mcp-server"

--- a/helm/terraform-mcp-server/values.yaml
+++ b/helm/terraform-mcp-server/values.yaml
@@ -56,6 +56,11 @@ nodeSelector: {}
 tolerations: []
 affinity: {}
 
+# Mount a cert and key here to serve TLS directly, then point
+# mcpServer.tls.certFile and keyFile at the mount paths.
+volumes: []
+volumeMounts: []
+
 # Maps to the server's environment variables.
 mcpServer:
   # stateful or stateless. stateless is useful with multiple replicas behind a
@@ -76,11 +81,15 @@ mcpServer:
   corsMode: "strict"
   # restrict tool calls to these orgs. empty allows any org the token can reach.
   allowedOrganizations: []
-  # the shared secret sent as the X-Tf-Mcp-Secret header. prefer existingSecret,
-  # sharedSecret renders the value straight into the pod env.
-  existingSecret: ""
-  existingSecretKey: "shared-secret"
-  sharedSecret: ""
+  # enables the destructive tools (delete_team, force_unlock_workspace, etc).
+  enableTfOperations: false
+  # where to send a browser that hits /. defaults to the terraform mcp docs page.
+  redirectRootURL: ""
+  # paths to a cert and key inside the container. mount them via volumes and
+  # volumeMounts above.
+  tls:
+    certFile: ""
+    keyFile: ""
 
 otel:
   enabled: false

--- a/helm/terraform-mcp-server/values.yaml
+++ b/helm/terraform-mcp-server/values.yaml
@@ -76,7 +76,10 @@ mcpServer:
   corsMode: "strict"
   # restrict tool calls to these orgs. empty allows any org the token can reach.
   allowedOrganizations: []
-  # sent as the X-Tf-Mcp-Secret header. treat as a credential.
+  # the shared secret sent as the X-Tf-Mcp-Secret header. prefer existingSecret,
+  # sharedSecret renders the value straight into the pod env.
+  existingSecret: ""
+  existingSecretKey: "shared-secret"
   sharedSecret: ""
 
 otel:


### PR DESCRIPTION
## PCI review checklist

This PR adds a helm chart for deploying the server on kubernetes, under
helm/terraform-mcp-server. this PR replaces #393, which had drifted quite a bit due to it being stale. A new PR is a lot cleaner than rebasing it.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
