### PR TITLE
Migrate server.ClientSession mark3labs type to session ID string

### DIFF
--- a/cmd/terraform-mcp-server/main.go
+++ b/cmd/terraform-mcp-server/main.go
@@ -43,7 +43,7 @@ func runHTTPServer(logger *log.Logger, host string, port string, endpointPath st
 	// Create hooks for session management
 	hooks := &server.Hooks{}
 	hooks.AddOnRegisterSession(func(ctx context.Context, session server.ClientSession) {
-		client.NewSessionHandler(ctx, session, logger)
+		client.NewSessionHandler(ctx, session.SessionID(), logger)
 	})
 
 	serverOpts := []server.ServerOption{
@@ -68,7 +68,7 @@ func runHTTPServer(logger *log.Logger, host string, port string, endpointPath st
 	hooks.AddOnUnregisterSession(func(ctx context.Context, session server.ClientSession) {
 		// Clean up client info populated in the metrics hooks, for the session
 		sessionClientInfo.Delete(session.SessionID())
-		client.EndSessionHandler(ctx, session, rateLimiter, logger)
+		client.EndSessionHandler(ctx, session.SessionID(), rateLimiter, logger)
 	})
 	// When running multiple sessions of the MCP server (load balancing), calling client.NewSessionHandler
 	// in both BeforeListTools and BeforeCallTool ensures that a session that was not initialized during
@@ -78,13 +78,13 @@ func runHTTPServer(logger *log.Logger, host string, port string, endpointPath st
 	hooks.AddBeforeListTools(func(ctx context.Context, id any, message *mcp.ListToolsRequest) {
 		session := server.ClientSessionFromContext(ctx)
 		if session != nil {
-			client.NewSessionHandler(ctx, session, logger)
+			client.NewSessionHandler(ctx, session.SessionID(), logger)
 		}
 	})
 	hooks.AddBeforeCallTool(func(ctx context.Context, id any, message *mcp.CallToolRequest) {
 		session := server.ClientSessionFromContext(ctx)
 		if session != nil {
-			client.NewSessionHandler(ctx, session, logger)
+			client.NewSessionHandler(ctx, session.SessionID(), logger)
 		}
 	})
 	attachMetricsHooks(hooks, metricsConfig, logger)
@@ -165,13 +165,13 @@ func runStdioServer(logger *log.Logger, enabledToolsets []string) error {
 	// Create hooks for session management
 	hooks := &server.Hooks{}
 	hooks.AddOnRegisterSession(func(ctx context.Context, session server.ClientSession) {
-		client.NewSessionHandler(ctx, session, logger)
+		client.NewSessionHandler(ctx, session.SessionID(), logger)
 	})
 	hcServer, rateLimiter := NewServer(version.Version, logger, enabledToolsets, server.WithHooks(hooks))
 	registerToolsAndResources(hcServer, logger, enabledToolsets)
 
 	hooks.AddOnUnregisterSession(func(ctx context.Context, session server.ClientSession) {
-		client.EndSessionHandler(ctx, session, rateLimiter, logger)
+		client.EndSessionHandler(ctx, session.SessionID(), rateLimiter, logger)
 	})
 
 	return serverInit(ctx, hcServer, logger)

--- a/pkg/client/registry_client.go
+++ b/pkg/client/registry_client.go
@@ -52,10 +52,10 @@ func GetHttpClientFromContext(ctx context.Context, logger *log.Logger) (*http.Cl
 	}
 
 	logger.Warnf("HTTP client not found, creating a new one")
-	return CreateHttpClientForSession(ctx, session, logger), nil
+	return CreateHttpClientForSession(ctx, session.SessionID(), logger), nil
 }
 
 // CreateHttpClientForSession creates only an HTTP client for the session
-func CreateHttpClientForSession(ctx context.Context, session server.ClientSession, logger *log.Logger) *http.Client {
-	return NewHttpClient(session.SessionID(), parseTerraformSkipTLSVerify(ctx), logger)
+func CreateHttpClientForSession(ctx context.Context, sessionID string, logger *log.Logger) *http.Client {
+	return NewHttpClient(sessionID, parseTerraformSkipTLSVerify(ctx), logger)
 }

--- a/pkg/client/session.go
+++ b/pkg/client/session.go
@@ -6,7 +6,6 @@ package client
 import (
 	"context"
 
-	"github.com/mark3labs/mcp-go/server"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -14,25 +13,25 @@ import (
 type contextKey string
 
 // NewSessionHandler initializes clients for the session
-func NewSessionHandler(ctx context.Context, session server.ClientSession, logger *log.Logger) {
-	if _, ok := activeTfeClients.Load(session.SessionID()); ok {
+func NewSessionHandler(ctx context.Context, sessionID string, logger *log.Logger) {
+	if _, ok := activeTfeClients.Load(sessionID); ok {
 		return
 	}
 
 	// Create both TFE and HTTP clients for the session
-	tfeClient, err := CreateTfeClientForSession(ctx, session, logger)
+	tfeClient, err := CreateTfeClientForSession(ctx, sessionID, logger)
 	if err != nil {
 		logger.WithError(err).Error("NewSessionHandler failed to create TFE client")
 	}
 
-	CreateHttpClientForSession(ctx, session, logger)
+	CreateHttpClientForSession(ctx, sessionID, logger)
 
 	// Check if the session has a valid TFE client and register with dynamic tool registry
 	if tfeClient != nil {
 		// Import the tools package to access the registry
 		// We need to avoid circular imports, so we'll use a callback approach
 		if registryCallback := getToolRegistryCallback(); registryCallback != nil {
-			registryCallback.RegisterSessionWithTFE(session.SessionID())
+			registryCallback.RegisterSessionWithTFE(sessionID)
 		}
 		logger.Info("Session has valid TFE client - registered with tool registry")
 	} else {
@@ -41,16 +40,16 @@ func NewSessionHandler(ctx context.Context, session server.ClientSession, logger
 }
 
 // EndSessionHandler cleans up clients when the session ends
-func EndSessionHandler(_ context.Context, session server.ClientSession, rateLimiter *RateLimitMiddleware, logger *log.Logger) {
+func EndSessionHandler(_ context.Context, sessionID string, rateLimiter *RateLimitMiddleware, logger *log.Logger) {
 	// Unregister from tool registry if it was registered
 	if registryCallback := getToolRegistryCallback(); registryCallback != nil {
-		registryCallback.UnregisterSessionWithTFE(session.SessionID())
+		registryCallback.UnregisterSessionWithTFE(sessionID)
 	}
 
-	DeleteTfeClient(session.SessionID())
-	DeleteHttpClient(session.SessionID())
+	DeleteTfeClient(sessionID)
+	DeleteHttpClient(sessionID)
 	if rateLimiter != nil {
-		rateLimiter.DeleteSession(session.SessionID())
+		rateLimiter.DeleteSession(sessionID)
 	}
 	logger.Info("Cleaned up clients for session")
 }

--- a/pkg/client/tfe_client.go
+++ b/pkg/client/tfe_client.go
@@ -189,11 +189,11 @@ func GetTfeClientFromContext(ctx context.Context, logger *log.Logger) (*tfe.Clie
 		activeTfeClients.Delete(session.SessionID())
 	}
 	logger.Warnf("TFE client not found, creating a new one")
-	return CreateTfeClientForSession(ctx, session, logger)
+	return CreateTfeClientForSession(ctx, session.SessionID(), logger)
 }
 
 // CreateTfeClientForSession creates only a TFE client for the session
-func CreateTfeClientForSession(ctx context.Context, session server.ClientSession, logger *log.Logger) (*tfe.Client, error) {
+func CreateTfeClientForSession(ctx context.Context, sessionID string, logger *log.Logger) (*tfe.Client, error) {
 	var err error
 	terraformAddress, ok := ctx.Value(contextKey(TerraformAddress)).(string)
 	if !ok || terraformAddress == "" {
@@ -214,6 +214,6 @@ func CreateTfeClientForSession(ctx context.Context, session server.ClientSession
 
 	// Get client IP from context for X-Forwarded-For header
 	clientIP, _ := ctx.Value(contextKey(ClientIPKey)).(string)
-	client, err := NewTfeClient(session.SessionID(), terraformAddress, parseTerraformSkipTLSVerify(ctx), terraformToken, clientIP, logger)
+	client, err := NewTfeClient(sessionID, terraformAddress, parseTerraformSkipTLSVerify(ctx), terraformToken, clientIP, logger)
 	return client, err
 }


### PR DESCRIPTION
## What changed

Change the four session-scoped helper functions in `pkg/client` (`NewSessionHandler`, `EndSessionHandler`, `CreateTfeClientForSession`, `CreateHttpClientForSession`) to take a plain `sessionID string` instead of the mark3labs `server.ClientSession` interface. Also updated the calls in `cmd/terraform-mcp-server/main.go` accordingly, and dropped the`server` import from `pkg/client/session.go`.

## Why

We're migrating the server setup, middleware, and session hooks to the official MCP go-sdk (see #497 for the first step). The go-sdk represents a session as `*mcp.ServerSession`, a different type from mark3labs' `server.ClientSession` — and neither implements the other.

Since these 4 functions never actually needed anything from `server.ClientSession` besides the ID, keeping that type in their signature would force the upcoming middleware and session-hooks PRs to build a fake `server.ClientSession` just to call them. Narrowing the parameter to a `string` removes that dependency, so both the old mark3labs code path and the new go-sdk path can call the same functions directly with their own session's ID.

Doing this as its own small PR keeps it easy to review in isolation and easy to revert independently of the middleware/hooks work that follows.



## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
