### PR TITLE
Migrate official MCP SDK logging from Logrus to slog

### DIFF
--- a/cmd/terraform-mcp-server/config_test.go
+++ b/cmd/terraform-mcp-server/config_test.go
@@ -4,7 +4,10 @@
 package main
 
 import (
+	"context"
+	"log/slog"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -12,6 +15,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetHTTPHost(t *testing.T) {
@@ -383,6 +387,135 @@ func TestGetLogLevelWithNilCommand(t *testing.T) {
 	}
 }
 
+func TestGetSlogLevel(t *testing.T) {
+	tests := []struct {
+		name        string
+		envValue    string
+		flagValue   string
+		expected    slog.Level
+		description string
+	}{
+		{
+			name:        "env var takes precedence",
+			envValue:    "debug",
+			flagValue:   "error",
+			expected:    slog.LevelDebug,
+			description: "when both are set, LOG_LEVEL=debug should take precedence over --log-level=error",
+		},
+		{
+			name:        "flag used when env not set",
+			envValue:    "",
+			flagValue:   "warn",
+			expected:    slog.LevelWarn,
+			description: "when LOG_LEVEL is unset, --log-level=warn should select the warn level",
+		},
+		{
+			name:        "default when neither set",
+			envValue:    "",
+			flagValue:   "",
+			expected:    slog.LevelInfo,
+			description: "when neither LOG_LEVEL nor --log-level is set, the level should default to info",
+		},
+		{
+			name:        "trace maps to debug",
+			envValue:    "trace",
+			flagValue:   "",
+			expected:    slog.LevelDebug,
+			description: "because slog has no trace level, LOG_LEVEL=trace should use the debug level",
+		},
+		{
+			name:        "level is case insensitive and trimmed",
+			envValue:    " WARN ",
+			flagValue:   "",
+			expected:    slog.LevelWarn,
+			description: "LOG_LEVEL should ignore letter case and surrounding whitespace, so ' WARN ' should select warn",
+		},
+		{
+			name:        "fatal maps to error",
+			envValue:    "fatal",
+			flagValue:   "",
+			expected:    slog.LevelError,
+			description: "because slog has no fatal level, LOG_LEVEL=fatal should use the error level",
+		},
+		{
+			name:        "panic maps to error",
+			envValue:    "panic",
+			flagValue:   "",
+			expected:    slog.LevelError,
+			description: "because slog has no panic level, LOG_LEVEL=panic should use the error level",
+		},
+		{
+			name:        "invalid env falls back to default",
+			envValue:    "invalid",
+			flagValue:   "",
+			expected:    slog.LevelInfo,
+			description: "when LOG_LEVEL contains an unsupported value, the level should fall back to info",
+		},
+		{
+			name:        "invalid flag falls back to default",
+			envValue:    "",
+			flagValue:   "invalid",
+			expected:    slog.LevelInfo,
+			description: "when LOG_LEVEL is unset and --log-level is unsupported, the level should fall back to info",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save and restore original env var
+			originalEnv := os.Getenv("LOG_LEVEL")
+			defer func() {
+				if originalEnv != "" {
+					os.Setenv("LOG_LEVEL", originalEnv)
+				} else {
+					os.Unsetenv("LOG_LEVEL")
+				}
+			}()
+
+			// Set up test environment
+			if tt.envValue != "" {
+				os.Setenv("LOG_LEVEL", tt.envValue)
+			} else {
+				os.Unsetenv("LOG_LEVEL")
+			}
+
+			cmd := &cobra.Command{}
+			cmd.Flags().String("log-level", tt.flagValue, "test flag")
+
+			level := getSlogLevel(cmd)
+			if level != tt.expected {
+				t.Errorf("%s: expected level %v, got %v", tt.description, tt.expected, level)
+			}
+		})
+	}
+}
+
+func TestGetSlogLevelWithNilCommand(t *testing.T) {
+	// Save and restore original env var
+	originalEnv := os.Getenv("LOG_LEVEL")
+	defer func() {
+		if originalEnv != "" {
+			os.Setenv("LOG_LEVEL", originalEnv)
+		} else {
+			os.Unsetenv("LOG_LEVEL")
+		}
+	}()
+
+	// Test with nil command and no env var
+	os.Unsetenv("LOG_LEVEL")
+	level := getSlogLevel(nil)
+	if level != slog.LevelInfo {
+		t.Errorf("expected default info level with nil command, got %v", level)
+	}
+
+	// Test with nil command but env var set
+	os.Setenv("LOG_LEVEL", "debug")
+	level = getSlogLevel(nil)
+	if level != slog.LevelDebug {
+		t.Errorf("expected debug level from env var with nil command, got %v", level)
+	}
+}
+
 func TestInitLoggerWithLevel(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -439,6 +572,65 @@ func TestInitLoggerWithFormat(t *testing.T) {
 				if _, ok := logger.Formatter.(*log.TextFormatter); !ok {
 					t.Errorf("expected TextFormatter, got %T", logger.Formatter)
 				}
+			}
+		})
+	}
+}
+
+func TestInitSlogWithLevel(t *testing.T) {
+	tests := []struct {
+		name  string
+		level slog.Level
+	}{
+		{"debug level", slog.LevelDebug},
+		{"info level", slog.LevelInfo},
+		{"warn level", slog.LevelWarn},
+		{"error level", slog.LevelError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logPath := filepath.Join(t.TempDir(), "official.log")
+			logger, logFile, err := initSlog(logPath, tt.level, "")
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				require.NoError(t, logFile.Close())
+			})
+
+			assert.True(t, logger.Enabled(context.Background(), tt.level))
+			assert.False(t, logger.Enabled(context.Background(), tt.level-4))
+		})
+	}
+}
+
+func TestInitSlogWithFormat(t *testing.T) {
+	tests := []struct {
+		name      string
+		logFormat string
+		wantJSON  bool
+	}{
+		{"empty format", "", false},
+		{"text format", "text", false},
+		{"json format", "json", true},
+		{"TEXT format", "TEXT", false},
+		{"JSON format", "JSON", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logPath := filepath.Join(t.TempDir(), "official.log")
+			logger, logFile, err := initSlog(logPath, slog.LevelInfo, tt.logFormat)
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				require.NoError(t, logFile.Close())
+			})
+
+			if tt.wantJSON {
+				_, ok := logger.Handler().(*slog.JSONHandler)
+				assert.True(t, ok, "expected JSONHandler, got %T", logger.Handler())
+			} else {
+				_, ok := logger.Handler().(*slog.TextHandler)
+				assert.True(t, ok, "expected TextHandler, got %T", logger.Handler())
 			}
 		})
 	}

--- a/cmd/terraform-mcp-server/init.go
+++ b/cmd/terraform-mcp-server/init.go
@@ -40,7 +40,7 @@ type healthResponse struct {
 	Version   string `json:"version"`
 }
 
-const officialSlogOutputPath = "terraform-mcp-official.log"
+const officialSlogOutputFileName = "terraform-mcp-official.log"
 
 var (
 	rootCmd = &cobra.Command{
@@ -419,13 +419,13 @@ func streamableHTTPServerInit(ctx context.Context, hcServer *server.MCPServer, l
 		logger.Info("TF_X_OFFICIAL_SDK_ENABLED set to true in env, enabling the official mcp go-sdk server")
 		slogLevel := getSlogLevel(rootCmd)
 		slogFormat := getLogFormat(rootCmd)
-		officialLogger, officialLogFile, err := initSlog(officialSlogOutputPath, slogLevel, slogFormat)
+		officialLogger, officialLogFile, err := initSlog(officialSlogOutputFileName, slogLevel, slogFormat)
 		if err != nil {
-			return fmt.Errorf("failed to initialize official MCP slog logger at %s: %w", officialSlogOutputPath, err)
+			return fmt.Errorf("failed to initialize official MCP slog logger at %s: %w", officialSlogOutputFileName, err)
 		}
 		defer func() {
 			if err := officialLogFile.Close(); err != nil {
-				logger.Errorf("Failed to close official MCP log file at %s: %v", officialSlogOutputPath, err)
+				logger.Errorf("Failed to close official MCP log file at %s: %v", officialSlogOutputFileName, err)
 			}
 		}()
 

--- a/cmd/terraform-mcp-server/init.go
+++ b/cmd/terraform-mcp-server/init.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	stdlog "log"
+	"log/slog"
 	"net/http"
 	"os"
 	"path"
@@ -38,6 +39,8 @@ type healthResponse struct {
 	Endpoint  string `json:"endpoint"`
 	Version   string `json:"version"`
 }
+
+const officialSlogOutputPath = "terraform-mcp-official.log"
 
 var (
 	rootCmd = &cobra.Command{
@@ -196,6 +199,31 @@ func getLogLevel(cmd *cobra.Command) log.Level {
 	return log.InfoLevel
 }
 
+// getSlogLevel determines the slog level from the environment or CLI flag.
+func getSlogLevel(cmd *cobra.Command) slog.Level {
+	configuredLevel := os.Getenv("LOG_LEVEL")
+	if configuredLevel == "" && cmd != nil {
+		flagLevel, err := cmd.Flags().GetString("log-level")
+		if err == nil {
+			configuredLevel = flagLevel
+		}
+	}
+
+	switch strings.ToLower(strings.TrimSpace(configuredLevel)) {
+	case "trace", "debug":
+		return slog.LevelDebug
+	case "", "info":
+		return slog.LevelInfo
+	case "warn":
+		return slog.LevelWarn
+	case "error", "fatal", "panic":
+		return slog.LevelError
+	default:
+		stdlog.Printf("Warning: invalid slog level %q, using default 'info' level\n", configuredLevel)
+		return slog.LevelInfo
+	}
+}
+
 // getLogFormat determines the log format from environment variable or CLI flag
 func getLogFormat(cmd *cobra.Command) string {
 	// Check environment variable first
@@ -247,6 +275,25 @@ func initLogger(outPath string, level log.Level, format string) (*log.Logger, er
 	logger.SetOutput(file)
 
 	return logger, nil
+}
+
+func initSlog(outPath string, level slog.Level, format string) (*slog.Logger, *os.File, error) {
+	file, err := os.OpenFile(outPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o666)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to open log file: %w", err)
+	}
+
+	opts := &slog.HandlerOptions{
+		Level: level,
+	}
+	var handler slog.Handler
+	// Set formatter based on format parameter
+	if strings.ToLower(format) == "json" {
+		handler = slog.NewJSONHandler(file, opts)
+	} else {
+		handler = slog.NewTextHandler(file, opts)
+	}
+	return slog.New(handler), file, nil
 }
 
 // registerToolsAndResources registers tools and resources with the MCP server
@@ -370,7 +417,20 @@ func streamableHTTPServerInit(ctx context.Context, hcServer *server.MCPServer, l
 	// Create the official go-sdk streamable server
 	if enableOfficialSDK := os.Getenv("TF_X_OFFICIAL_SDK_ENABLED"); enableOfficialSDK == "true" {
 		logger.Info("TF_X_OFFICIAL_SDK_ENABLED set to true in env, enabling the official mcp go-sdk server")
-		officialStreamableServer := getOfficialStreamableServer(ctx, heartbeatInterval, isStateless, corsConfig, logger, organizationAllowlist, filter, rateLimiter, metricsConfig)
+		slogLevel := getSlogLevel(rootCmd)
+		slogFormat := getLogFormat(rootCmd)
+		officialLogger, officialLogFile, err := initSlog(officialSlogOutputPath, slogLevel, slogFormat)
+		if err != nil {
+			return fmt.Errorf("failed to initialize official MCP slog logger at %s: %w", officialSlogOutputPath, err)
+		}
+		defer func() {
+			if err := officialLogFile.Close(); err != nil {
+				logger.Errorf("Failed to close official MCP log file at %s: %v", officialSlogOutputPath, err)
+			}
+		}()
+
+		officialLogger = officialLogger.With("component", "mcp-official")
+		officialStreamableServer := getOfficialStreamableServer(ctx, heartbeatInterval, isStateless, corsConfig, logger, officialLogger, organizationAllowlist, filter, rateLimiter, metricsConfig)
 		// Handle the /mcp endpoint with the official go-sdk streamable server (with security wrapper)
 		mux.Handle(endpointPath+"/official", officialStreamableServer)
 		mux.Handle(endpointPath+"/official/", officialStreamableServer)
@@ -459,9 +519,8 @@ func streamableHTTPServerInit(ctx context.Context, hcServer *server.MCPServer, l
 	return nil
 }
 
-func getOfficialStreamableServer(ctx context.Context, heartbeatInterval time.Duration, isStateless bool, corsConfig client.CORSConfig, logger *log.Logger, organizationAllowlist []string, filter toolsets.ToolFilter, rateLimiter *client.RateLimitMiddleware, metricsConfig client.MetricsConfig) http.Handler {
-	logger.Info("Creating a go-sdk StreamableHTTP server...")
-	slogLogger := newSlogLogger(logger)
+func getOfficialStreamableServer(ctx context.Context, heartbeatInterval time.Duration, isStateless bool, corsConfig client.CORSConfig, logger *log.Logger, officialLogger *slog.Logger, organizationAllowlist []string, filter toolsets.ToolFilter, rateLimiter *client.RateLimitMiddleware, metricsConfig client.MetricsConfig) http.Handler {
+	officialLogger.Info("Creating a go-sdk StreamableHTTP server...")
 
 	// Metrics is added first so it wraps every other middleware, measuring
 	// the full round trip and always recording the result — the go-sdk
@@ -470,10 +529,10 @@ func getOfficialStreamableServer(ctx context.Context, heartbeatInterval time.Dur
 	middlewares := []mcp.Middleware{
 		middleware.Metrics(metricsConfig, logger),
 		middleware.RateLimit(rateLimiter),
-		middleware.ToolLogging(slogLogger),
+		middleware.ToolLogging(officialLogger),
 	}
 	if len(organizationAllowlist) > 0 {
-		middlewares = append(middlewares, middleware.OrganizationAllowlist(organizationAllowlist, slogLogger))
+		middlewares = append(middlewares, middleware.OrganizationAllowlist(organizationAllowlist, officialLogger))
 	}
 	serverOpts := []mcpofficial.Option{
 		mcpofficial.WithMiddlewares(middlewares...),
@@ -495,11 +554,11 @@ func getOfficialStreamableServer(ctx context.Context, heartbeatInterval time.Dur
 			}()
 		}),
 	}
-	hcServer := mcpofficial.NewServer(version.Version, instructions, heartbeatInterval, logger, filter, serverOpts...)
+	hcServer := mcpofficial.NewServer(version.Version, instructions, heartbeatInterval, officialLogger, filter, serverOpts...)
 
 	opts := &mcp.StreamableHTTPOptions{
 		Stateless:             isStateless,
-		Logger:                slogLogger,
+		Logger:                officialLogger,
 		CrossOriginProtection: nil, // disables the SDK's built-in cross-origin protection entirely. CORS already enforced by client.NewSecurityHandler below.
 	}
 

--- a/cmd/terraform-mcp-server/init.go
+++ b/cmd/terraform-mcp-server/init.go
@@ -40,8 +40,6 @@ type healthResponse struct {
 	Version   string `json:"version"`
 }
 
-const officialSlogOutputFileName = "terraform-mcp-official.log"
-
 var (
 	rootCmd = &cobra.Command{
 		Use:     "terraform-mcp-server",
@@ -278,9 +276,16 @@ func initLogger(outPath string, level log.Level, format string) (*log.Logger, er
 }
 
 func initSlog(outPath string, level slog.Level, format string) (*slog.Logger, *os.File, error) {
-	file, err := os.OpenFile(outPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o666)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to open log file: %w", err)
+	out := io.Writer(os.Stderr)
+	var file *os.File
+
+	if outPath != "" {
+		var err error
+		file, err = os.OpenFile(outPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o666)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to open log file: %w", err)
+		}
+		out = file
 	}
 
 	opts := &slog.HandlerOptions{
@@ -289,9 +294,9 @@ func initSlog(outPath string, level slog.Level, format string) (*slog.Logger, *o
 	var handler slog.Handler
 	// Set formatter based on format parameter
 	if strings.ToLower(format) == "json" {
-		handler = slog.NewJSONHandler(file, opts)
+		handler = slog.NewJSONHandler(out, opts)
 	} else {
-		handler = slog.NewTextHandler(file, opts)
+		handler = slog.NewTextHandler(out, opts)
 	}
 	return slog.New(handler), file, nil
 }
@@ -417,17 +422,23 @@ func streamableHTTPServerInit(ctx context.Context, hcServer *server.MCPServer, l
 	// Create the official go-sdk streamable server
 	if enableOfficialSDK := os.Getenv("TF_X_OFFICIAL_SDK_ENABLED"); enableOfficialSDK == "true" {
 		logger.Info("TF_X_OFFICIAL_SDK_ENABLED set to true in env, enabling the official mcp go-sdk server")
+		logFile, err := rootCmd.PersistentFlags().GetString("log-file")
+		if err != nil {
+			return fmt.Errorf("failed to get log file: %w", err)
+		}
 		slogLevel := getSlogLevel(rootCmd)
 		slogFormat := getLogFormat(rootCmd)
-		officialLogger, officialLogFile, err := initSlog(officialSlogOutputFileName, slogLevel, slogFormat)
+		officialLogger, officialLogFile, err := initSlog(logFile, slogLevel, slogFormat)
 		if err != nil {
-			return fmt.Errorf("failed to initialize official MCP slog logger at %s: %w", officialSlogOutputFileName, err)
+			return fmt.Errorf("failed to initialize official MCP slog logger: %w", err)
 		}
-		defer func() {
-			if err := officialLogFile.Close(); err != nil {
-				logger.Errorf("Failed to close official MCP log file at %s: %v", officialSlogOutputFileName, err)
-			}
-		}()
+		if officialLogFile != nil {
+			defer func() {
+				if err := officialLogFile.Close(); err != nil {
+					logger.Errorf("Failed to close official MCP log file at %s: %v", logFile, err)
+				}
+			}()
+		}
 
 		officialLogger = officialLogger.With("component", "mcp-official")
 		officialStreamableServer := getOfficialStreamableServer(ctx, heartbeatInterval, isStateless, corsConfig, logger, officialLogger, organizationAllowlist, filter, rateLimiter, metricsConfig)

--- a/cmd/terraform-mcp-server/session_lifecycle_test.go
+++ b/cmd/terraform-mcp-server/session_lifecycle_test.go
@@ -5,6 +5,8 @@ package main
 
 import (
 	"context"
+	"io"
+	"log/slog"
 	"net/http/httptest"
 	"reflect"
 	"sync"
@@ -64,6 +66,7 @@ func TestGetOfficialStreamableServer_SessionLifecycle(t *testing.T) {
 		false, // isStateless
 		client.CORSConfig{Mode: "disabled"},
 		logger,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
 		nil, // organizationAllowlist
 		toolsets.NewToolsetFilter([]string{"list_workspaces"}),
 		rateLimiter,

--- a/pkg/mcp-official/server.go
+++ b/pkg/mcp-official/server.go
@@ -5,13 +5,13 @@ package mcpofficial
 
 import (
 	"context"
+	"log/slog"
 	"time"
 
 	"github.com/hashicorp/terraform-mcp-server/pkg/mcp-official/tools"
 	"github.com/hashicorp/terraform-mcp-server/pkg/toolsets"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	log "github.com/sirupsen/logrus"
 )
 
 // serverConfig holds server settings, set via Options like WithMiddlewares
@@ -44,10 +44,10 @@ func WithMiddlewares(mw ...mcp.Middleware) Option {
 	}
 }
 
-func NewServer(version, instructions string, heartbeatInterval time.Duration, logger *log.Logger, filter toolsets.ToolFilter, opts ...Option) *mcp.Server {
-	cfg := &serverConfig{mcpOpts: mcp.ServerOptions{Instructions: instructions}}
+func NewServer(version, instructions string, heartbeatInterval time.Duration, logger *slog.Logger, filter toolsets.ToolFilter, opts ...Option) *mcp.Server {
+	cfg := &serverConfig{mcpOpts: mcp.ServerOptions{Instructions: instructions, Logger: logger}}
 	if heartbeatInterval > 0 {
-		logger.Infof("HTTP heartbeat enabled with interval: %v", heartbeatInterval)
+		logger.Info("HTTP heartbeat enabled", "interval", heartbeatInterval)
 		cfg.mcpOpts.KeepAlive = heartbeatInterval
 	}
 	for _, opt := range opts {

--- a/pkg/mcp-official/tools/middleware/tool_logging.go
+++ b/pkg/mcp-official/tools/middleware/tool_logging.go
@@ -15,7 +15,7 @@ import (
 func ToolLogging(logger *slog.Logger) mcp.Middleware {
 	return func(next mcp.MethodHandler) mcp.MethodHandler {
 		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
-			if method != "tools/call" {
+			if method != "tools/call" || logger == nil {
 				return next(ctx, method, req)
 			}
 

--- a/pkg/mcp-official/tools/middleware/tool_logging.go
+++ b/pkg/mcp-official/tools/middleware/tool_logging.go
@@ -19,11 +19,42 @@ func ToolLogging(logger *slog.Logger) mcp.Middleware {
 				return next(ctx, method, req)
 			}
 
-			if params, ok := req.GetParams().(*mcp.CallToolParamsRaw); ok && logger != nil {
-				logger.InfoContext(ctx, "tool call executed", "tool", params.Name, "arguments", string(params.Arguments))
+			toolName := "unknown"
+			arguments := ""
+			if params, ok := req.GetParams().(*mcp.CallToolParamsRaw); ok {
+				toolName = params.Name
+				arguments = string(params.Arguments)
 			}
 
-			return next(ctx, method, req)
+			result, err := next(ctx, method, req)
+			// Protocol method error
+			if err != nil {
+				logger.ErrorContext(ctx, "tool call failed",
+					"tool", toolName,
+					"arguments", arguments,
+					"error", err)
+				return result, err
+			}
+
+			// Tool execution error
+			if toolResult, ok := result.(*mcp.CallToolResult); ok && toolResult.IsError {
+				if toolErr := toolResult.GetError(); toolErr != nil {
+					logger.ErrorContext(ctx, "tool call failed",
+						"tool", toolName,
+						"arguments", arguments,
+						"error", toolErr)
+				} else {
+					logger.WarnContext(ctx, "tool call returned an error result",
+						"tool", toolName,
+						"arguments", arguments)
+				}
+				return result, nil
+			}
+
+			logger.InfoContext(ctx, "tool call completed",
+				"tool", toolName,
+				"arguments", arguments)
+			return result, nil
 		}
 	}
 }

--- a/pkg/mcp-official/tools/middleware/tool_logging.go
+++ b/pkg/mcp-official/tools/middleware/tool_logging.go
@@ -19,15 +19,12 @@ func ToolLogging(logger *slog.Logger) mcp.Middleware {
 				return next(ctx, method, req)
 			}
 
-			toolName := "unknown"
-			arguments := ""
-			if params, ok := req.GetParams().(*mcp.CallToolParamsRaw); ok {
-				toolName = params.Name
-				arguments = string(params.Arguments)
-			}
+			params := req.GetParams().(*mcp.CallToolParamsRaw)
+			toolName := params.Name
+			arguments := params.Arguments
 
 			result, err := next(ctx, method, req)
-			// Protocol method error
+			// Protocol-level error
 			if err != nil {
 				logger.ErrorContext(ctx, "tool call failed",
 					"tool", toolName,
@@ -36,18 +33,12 @@ func ToolLogging(logger *slog.Logger) mcp.Middleware {
 				return result, err
 			}
 
-			// Tool execution error
+			// Tool-level error
 			if toolResult, ok := result.(*mcp.CallToolResult); ok && toolResult.IsError {
-				if toolErr := toolResult.GetError(); toolErr != nil {
-					logger.ErrorContext(ctx, "tool call failed",
-						"tool", toolName,
-						"arguments", arguments,
-						"error", toolErr)
-				} else {
-					logger.WarnContext(ctx, "tool call returned an error result",
-						"tool", toolName,
-						"arguments", arguments)
-				}
+				logger.ErrorContext(ctx, "tool call failed",
+					"tool", toolName,
+					"arguments", arguments,
+					"error", toolResult.GetError())
 				return result, nil
 			}
 

--- a/pkg/mcp-official/tools/middleware/tool_logging_test.go
+++ b/pkg/mcp-official/tools/middleware/tool_logging_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"testing"
 
@@ -43,9 +44,61 @@ func TestToolLoggingMiddleware(t *testing.T) {
 	logOutput := buf.String()
 	t.Logf("Captured log output:\n%s", logOutput)
 	assert.Contains(t, logOutput, "level=INFO")
+	assert.Contains(t, logOutput, "msg=\"tool call completed\"")
 	assert.Contains(t, logOutput, "list_workspaces")
 	assert.Contains(t, logOutput, "terraform_org_name")
 	assert.Contains(t, logOutput, "my-org")
+}
+
+func TestToolLoggingMiddleware_ToolError(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+
+	toolErr := errors.New("listing workspaces: permission denied")
+	next := func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+		result := &mcp.CallToolResult{}
+		result.SetError(toolErr)
+		return result, nil
+	}
+
+	request := &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{Name: "list_workspaces"},
+	}
+
+	handler := ToolLogging(logger)(next)
+	result, err := handler(context.Background(), "tools/call", request)
+	require.NoError(t, err)
+	assert.True(t, result.(*mcp.CallToolResult).IsError)
+
+	logOutput := buf.String()
+	assert.Contains(t, logOutput, "level=ERROR")
+	assert.Contains(t, logOutput, "msg=\"tool call failed\"")
+	assert.Contains(t, logOutput, "list_workspaces")
+	assert.Contains(t, logOutput, "listing workspaces: permission denied")
+}
+
+func TestToolLoggingMiddleware_MethodError(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+
+	methodErr := errors.New("method handler unavailable")
+	next := func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+		return nil, methodErr
+	}
+
+	request := &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{Name: "list_workspaces"},
+	}
+
+	handler := ToolLogging(logger)(next)
+	_, err := handler(context.Background(), "tools/call", request)
+	require.ErrorIs(t, err, methodErr)
+
+	logOutput := buf.String()
+	assert.Contains(t, logOutput, "level=ERROR")
+	assert.Contains(t, logOutput, "msg=\"tool call failed\"")
+	assert.Contains(t, logOutput, "list_workspaces")
+	assert.Contains(t, logOutput, "method handler unavailable")
 }
 
 func TestToolLoggingMiddleware_IgnoresNonToolCalls(t *testing.T) {

--- a/pkg/mcp-official/tools/tfe/workspace.go
+++ b/pkg/mcp-official/tools/tfe/workspace.go
@@ -42,7 +42,7 @@ type ListWorkspacesArguments struct {
 	WildcardName string `json:"wildcard_name,omitempty" jsonschema:"Wildcard pattern"`
 }
 
-func ListWorkpsacesTool() *mcp.Tool {
+func ListWorkspacesTool() *mcp.Tool {
 	return &mcp.Tool{
 		Name:        "list_workspaces",
 		Description: "Search and list Terraform workspaces within a specified organization. Returns all workspaces when no filters are applied, or filters results based on name patterns, tags, or search queries. Supports pagination for large result sets. Returns a truncated summary of the workspace, use get_workspace_details to get the full details for a specific workspace.",
@@ -79,12 +79,12 @@ func ListWorkspacesFunc(ctx context.Context, request *mcp.CallToolRequest, input
 		}
 	}
 
-	client, err := client.GetTfeClient(ctx, client.SessionIDFromRequest(request))
+	tfeClient, err := client.GetTfeClient(ctx, client.SessionIDFromRequest(request))
 	if err != nil {
 		return nil, nil, err
 	}
 
-	workspaces, err := client.Workspaces.List(ctx, terraformOrgName, &tfe.WorkspaceListOptions{
+	workspaces, err := tfeClient.Workspaces.List(ctx, terraformOrgName, &tfe.WorkspaceListOptions{
 		ProjectID:    projectID,
 		Search:       searchQuery,
 		Tags:         strings.Join(tags, ","),

--- a/pkg/mcp-official/tools/tools.go
+++ b/pkg/mcp-official/tools/tools.go
@@ -1,10 +1,11 @@
 package tools
 
 import (
+	"log/slog"
+
 	tfeTools "github.com/hashicorp/terraform-mcp-server/pkg/mcp-official/tools/tfe"
 	"github.com/hashicorp/terraform-mcp-server/pkg/toolsets"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	log "github.com/sirupsen/logrus"
 )
 
 // officialFactories has one entry per tool actually ported to the official
@@ -18,14 +19,14 @@ var officialFactories = map[string]func(svr *mcp.Server){
 	// Tools not yet migrated simply have no entry and are silently skipped
 	// below — no other code needs to change.
 	"list_workspaces": func(svr *mcp.Server) {
-		mcp.AddTool(svr, tfeTools.ListWorkpsacesTool(), tfeTools.ListWorkspacesFunc)
+		mcp.AddTool(svr, tfeTools.ListWorkspacesTool(), tfeTools.ListWorkspacesFunc)
 	},
 	"list_terraform_orgs": func(svr *mcp.Server) {
 		mcp.AddTool(svr, tfeTools.ListTerraformOrganizationsTool(), tfeTools.ListTerraformOrganizationsFunc)
 	},
 }
 
-func RegisterTools(svr *mcp.Server, logger *log.Logger, filter toolsets.ToolFilter) {
+func RegisterTools(svr *mcp.Server, logger *slog.Logger, filter toolsets.ToolFilter) {
 	for _, td := range toolsets.AllTools {
 		if !filter.IsToolEnabled(td.Name) {
 			continue


### PR DESCRIPTION
**This PR:**
- Initializes a slog logger for the official MCP server in HTTP mode, defaulting to stderr and preserve the existing `log-file` flag — NO longer writing to a separate `terraform-mcp-official.log`.
- Passes the logger to the official SDK for server and tool call logging.
-  Simplifies the tool-logging middleware to record successful calls, protocol-level errors, and tool-level errors (IsError) as structured slog records.

**What hasn’t changed:**
- Stdio logging remains on Logrus.
-  Shared pkg/client helpers continue using Logrus, since they're also used by the legacy mark3labs server.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
