### PR TITLE
Fix session-scoped TFE/HTTP client caching

### DIFF
--- a/pkg/client/registry_client.go
+++ b/pkg/client/registry_client.go
@@ -44,15 +44,25 @@ func GetHttpClientFromContext(ctx context.Context, logger *log.Logger) (*http.Cl
 	if session == nil {
 		return nil, fmt.Errorf("no active session")
 	}
+	return GetHttpClientForSession(ctx, session.SessionID(), logger), nil
+}
+
+// GetHttpClientForSession adds the same stateless (empty sessionID) check and builds without caching a fresh client, instead of every
+// stateless request sharing one cached entry
+func GetHttpClientForSession(ctx context.Context, sessionID string, logger *log.Logger) *http.Client {
+	skipTLSVerify := parseTerraformSkipTLSVerify(ctx)
+
+	if sessionID == "" {
+		return CreateHTTPClient(skipTLSVerify, logger)
+	}
 
 	// Try to get existing client
-	client := GetHttpClient(session.SessionID())
-	if client != nil {
-		return client, nil
+	if client := GetHttpClient(sessionID); client != nil {
+		return client
 	}
 
 	logger.Warnf("HTTP client not found, creating a new one")
-	return CreateHttpClientForSession(ctx, session.SessionID(), logger), nil
+	return NewHttpClient(sessionID, skipTLSVerify, logger)
 }
 
 // CreateHttpClientForSession creates only an HTTP client for the session

--- a/pkg/client/registry_client_test.go
+++ b/pkg/client/registry_client_test.go
@@ -1,0 +1,57 @@
+// Copyright IBM Corp. 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package client
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetHttpClientForSession(t *testing.T) {
+	logger := log.New()
+	logger.SetOutput(io.Discard)
+
+	t.Run("different sessions get independently cached clients", func(t *testing.T) {
+		sessionA := "http-session-a"
+		sessionB := "http-session-b"
+		t.Cleanup(func() {
+			DeleteHttpClient(sessionA)
+			DeleteHttpClient(sessionB)
+		})
+
+		clientA := GetHttpClientForSession(context.Background(), sessionA, logger)
+		clientB := GetHttpClientForSession(context.Background(), sessionB, logger)
+		require.NotNil(t, clientA)
+		require.NotNil(t, clientB)
+		assert.NotSame(t, clientA, clientB, "different sessions must not share a cached HTTP client")
+
+		// Both clients must be reachable directly via the cache too.
+		assert.Same(t, clientA, GetHttpClient(sessionA))
+		assert.Same(t, clientB, GetHttpClient(sessionB))
+
+		// A second call for session A must return the cached client, not rebuild it.
+		clientAAgain := GetHttpClientForSession(context.Background(), sessionA, logger)
+		assert.Same(t, clientA, clientAAgain)
+	})
+
+	t.Run("empty sessionID bypasses the cache entirely (stateless mode)", func(t *testing.T) {
+		_, alreadyCached := activeHttpClients.Load("")
+		require.False(t, alreadyCached, "test precondition: empty key must not already be cached")
+
+		clientOne := GetHttpClientForSession(context.Background(), "", logger)
+		clientTwo := GetHttpClientForSession(context.Background(), "", logger)
+		require.NotNil(t, clientOne)
+		require.NotNil(t, clientTwo)
+
+		assert.NotSame(t, clientOne, clientTwo, "stateless requests must always build a fresh client, never share one")
+
+		_, ok := activeHttpClients.Load("")
+		assert.False(t, ok, "an empty sessionID must never be used as a cache key")
+	})
+}

--- a/pkg/client/tfe_client.go
+++ b/pkg/client/tfe_client.go
@@ -158,18 +158,25 @@ func DeleteTfeClient(sessionId string) {
 func GetTfeClientFromContext(ctx context.Context, logger *log.Logger) (*tfe.Client, error) {
 	session := server.ClientSessionFromContext(ctx)
 	if session == nil {
-		return nil, fmt.Errorf("no active session")
+		return nil, fmt.Errorf("No active session found")
 	}
+	return GetTfeClientForSession(ctx, session.SessionID(), logger)
+}
 
-	// Try to get token from the current request
+// GetTfeClientForSession allows both transports (mark3labs' server.ClientSession and the official
+// go-sdk's *mcp.ServerSession) supply their own session ID. The actual
+// address/token/skip-TLS-verify lookups still happen against ctx, using
+// this package's contextKey type - the same type TerraformContextMiddleware
+// writes into ctx, so both transports have the same per-request values
+func GetTfeClientForSession(ctx context.Context, sessionID string, logger *log.Logger) (*tfe.Client, error) {
 	currentToken, _ := ctx.Value(contextKey(TerraformToken)).(string)
 	if currentToken == "" {
 		currentToken = utils.GetEnv(TerraformToken, "")
 	}
 
-	// In a stateless mode the server does not assign any session ID to requests. We need to create new TF clients for every request in that case.
-	if session.SessionID() == "" {
-		logger.Info("Session ID is empty. Creating a new TF client.")
+	// In a stateless mode the server does not assign any session ID to requests. We need to create new TF clients for every request in that case
+	if sessionID == "" {
+		logger.Info("Session ID is empty. Creating a new TF client")
 		currentAddress, _ := ctx.Value(contextKey(TerraformAddress)).(string)
 		if currentAddress == "" {
 			currentAddress = utils.GetEnv(TerraformAddress, DefaultTerraformAddress)
@@ -179,17 +186,16 @@ func GetTfeClientFromContext(ctx context.Context, logger *log.Logger) (*tfe.Clie
 	}
 
 	// Check if the cached session ID's token+address match the current token+address
-	if value, ok := activeTfeClients.Load(session.SessionID()); ok {
+	if value, ok := activeTfeClients.Load(sessionID); ok {
 		cachedClient := value.(cachedTfeClient)
-		currentTokenHash := sha256.Sum256([]byte(currentToken))
-		if cachedClient.token == currentTokenHash {
+		if cachedClient.token == sha256.Sum256([]byte(currentToken)) {
 			return cachedClient.client, nil
 		}
 		// Current request token and address not found in cache. Delete the session ID from the sync map.
-		activeTfeClients.Delete(session.SessionID())
+		activeTfeClients.Delete(sessionID)
 	}
 	logger.Warnf("TFE client not found, creating a new one")
-	return CreateTfeClientForSession(ctx, session.SessionID(), logger)
+	return CreateTfeClientForSession(ctx, sessionID, logger)
 }
 
 // CreateTfeClientForSession creates only a TFE client for the session

--- a/pkg/client/tfe_client_test.go
+++ b/pkg/client/tfe_client_test.go
@@ -4,12 +4,14 @@
 package client
 
 import (
+	"context"
 	"io"
 	"testing"
 
 	"github.com/hashicorp/go-tfe"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // This tests the buildTFEConfig directly due to tfe.NewClient consuming the config and
@@ -80,5 +82,71 @@ func TestHumanReadableTokenPermissions(t *testing.T) {
 
 	t.Run("nil permissions", func(t *testing.T) {
 		assert.Nil(t, HumanReadableTokenPermissions(nil))
+	})
+}
+
+// ctxWithTfeValues builds a context carrying the token/address the way
+// TerraformContextMiddleware does, using this package's own contextKey type -
+// the same type both the mark3labs and official-SDK transports read through.
+func ctxWithTfeValues(token string) context.Context {
+	ctx := context.WithValue(context.Background(), contextKey(TerraformAddress), "https://app.terraform.io")
+	ctx = context.WithValue(ctx, contextKey(TerraformToken), token)
+	return ctx
+}
+
+func TestGetTfeClientForSession(t *testing.T) {
+	logger := log.New()
+	logger.SetOutput(io.Discard)
+
+	t.Run("different sessions with different tokens get independently cached clients", func(t *testing.T) {
+		sessionA := "session-a"
+		sessionB := "session-b"
+		t.Cleanup(func() {
+			DeleteTfeClient(sessionA)
+			DeleteTfeClient(sessionB)
+		})
+
+		clientA, err := GetTfeClientForSession(ctxWithTfeValues("token-a"), sessionA, logger)
+		require.NoError(t, err)
+		require.NotNil(t, clientA)
+
+		clientB, err := GetTfeClientForSession(ctxWithTfeValues("token-b"), sessionB, logger)
+		require.NoError(t, err)
+		require.NotNil(t, clientB)
+
+		assert.NotSame(t, clientA, clientB, "different sessions must not share a cached client")
+
+		// Each session's client must be reachable directly via the cache too.
+		v, ok := activeTfeClients.Load(sessionA)
+		require.True(t, ok)
+		assert.Same(t, clientA, v.(cachedTfeClient).client)
+
+		v, ok = activeTfeClients.Load(sessionB)
+		require.True(t, ok)
+		assert.Same(t, clientB, v.(cachedTfeClient).client)
+
+		// A second call for session A with the same token must return the cached client, not rebuild it.
+		clientAAgain, err := GetTfeClientForSession(ctxWithTfeValues("token-a"), sessionA, logger)
+		require.NoError(t, err)
+		assert.Same(t, clientA, clientAAgain)
+	})
+
+	t.Run("token change on the same session invalidates the cached client", func(t *testing.T) {
+		sessionID := "session-rotate"
+		t.Cleanup(func() { DeleteTfeClient(sessionID) })
+
+		original, err := GetTfeClientForSession(ctxWithTfeValues("token-v1"), sessionID, logger)
+		require.NoError(t, err)
+		require.NotNil(t, original)
+
+		rotated, err := GetTfeClientForSession(ctxWithTfeValues("token-v2"), sessionID, logger)
+		require.NoError(t, err)
+		require.NotNil(t, rotated)
+
+		assert.NotSame(t, original, rotated, "a token change must invalidate the previously cached client")
+
+		v, ok := activeTfeClients.Load(sessionID)
+		require.True(t, ok)
+		assert.Same(t, rotated, v.(cachedTfeClient).client, "the cache must hold the newest client after rotation")
 	})
 }

--- a/pkg/mcp-official/client/http_client.go
+++ b/pkg/mcp-official/client/http_client.go
@@ -1,0 +1,17 @@
+// Copyright IBM Corp. 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package client
+
+import (
+	"context"
+	"net/http"
+
+	tfeclient "github.com/hashicorp/terraform-mcp-server/pkg/client"
+	log "github.com/sirupsen/logrus"
+)
+
+// GetHttpClient returns the session-scoped HTTP client for sessionID.
+func GetHttpClient(ctx context.Context, sessionID string) (*http.Client, error) {
+	return tfeclient.GetHttpClientForSession(ctx, sessionID, log.StandardLogger()), nil
+}

--- a/pkg/mcp-official/client/session.go
+++ b/pkg/mcp-official/client/session.go
@@ -1,0 +1,15 @@
+// Copyright IBM Corp. 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package client
+
+import "github.com/modelcontextprotocol/go-sdk/mcp"
+
+// SessionIDFromRequest returns the session ID attached to a request, or ""
+// when the request has no session (stateless mode)
+func SessionIDFromRequest(request *mcp.CallToolRequest) string {
+	if request == nil || request.Session == nil {
+		return ""
+	}
+	return request.Session.ID()
+}

--- a/pkg/mcp-official/client/tfe_client.go
+++ b/pkg/mcp-official/client/tfe_client.go
@@ -5,92 +5,15 @@ package client
 
 import (
 	"context"
-	"fmt"
-	"net/http"
-	"strconv"
-	"sync"
 
 	"github.com/hashicorp/go-tfe"
 	tfeclient "github.com/hashicorp/terraform-mcp-server/pkg/client"
-	"github.com/hashicorp/terraform-mcp-server/pkg/utils"
-	"github.com/hashicorp/terraform-mcp-server/version"
 	log "github.com/sirupsen/logrus"
 )
 
-type contextKey string
-
-const (
-	TerraformAddress        = "TFE_ADDRESS"
-	TerraformToken          = "TFE_TOKEN"
-	TerraformSkipTLSVerify  = "TFE_SKIP_TLS_VERIFY"
-	DefaultTerraformAddress = "https://app.terraform.io"
-)
-
-var (
-	tfeClient     *tfe.Client
-	tfeClientOnce sync.Once // To make the client singleton since credentials are read from env.
-	tfeClientErr  error
-)
-
-func NewTfeClient(terraformAddress string, terraformSkipTLSVerify bool, terraformToken string) (*tfe.Client, error) {
-	if terraformToken == "" {
-		log.Print("No Terraform token provided, TFE client will not be available")
-		return nil, fmt.Errorf("required input: no Terraform token provided")
-	}
-
-	config := &tfe.Config{
-		Address:           terraformAddress,
-		Token:             terraformToken,
-		RetryServerErrors: true,
-		Headers:           make(http.Header),
-	}
-
-	config.Headers.Set("User-Agent", fmt.Sprintf("terraform-mcp-server/%s", version.GetHumanVersion()))
-	config.HTTPClient = tfeclient.CreateHTTPClient(terraformSkipTLSVerify, log.StandardLogger())
-
-	client, err := tfe.NewClient(config)
-	if err != nil {
-		log.Printf("Failed to create a Terraform Cloud/Enterprise client: %v", err)
-		return nil, err
-	}
-
-	log.Print("Created new TFE client...")
-	return client, nil
-}
-
-// GetTfeClient returns the singleton TFE client, creating it on first call.
-func GetTfeClient(ctx context.Context) (*tfe.Client, error) {
-	tfeClientOnce.Do(func() {
-		terraformAddress, ok := ctx.Value(contextKey(TerraformAddress)).(string)
-		if !ok || terraformAddress == "" {
-			terraformAddress = utils.GetEnv(TerraformAddress, DefaultTerraformAddress)
-		}
-
-		terraformToken, ok := ctx.Value(contextKey(TerraformToken)).(string)
-		if !ok || terraformToken == "" {
-			terraformToken = utils.GetEnv(TerraformToken, "")
-		}
-
-		if terraformToken == "" {
-			log.Print("Terraform token is empty")
-			tfeClientErr = fmt.Errorf("terraform token is required but not found in context or environment variables")
-			return
-		}
-		tfeClient, tfeClientErr = NewTfeClient(terraformAddress, parseTerraformSkipTLSVerify(ctx), terraformToken)
-	})
-	return tfeClient, tfeClientErr
-}
-
-func parseTerraformSkipTLSVerify(ctx context.Context) bool {
-	terraformSkipTLSVerifyStr, ok := ctx.Value(contextKey(TerraformSkipTLSVerify)).(string)
-	if !ok || terraformSkipTLSVerifyStr == "" {
-		terraformSkipTLSVerifyStr = utils.GetEnv(TerraformSkipTLSVerify, "")
-	}
-	if terraformSkipTLSVerifyStr != "" {
-		terraformSkipTLSVerify, err := strconv.ParseBool(terraformSkipTLSVerifyStr)
-		if err == nil {
-			return terraformSkipTLSVerify
-		}
-	}
-	return false
+// GetTfeClient returns the session-scoped TFE client for sessionID. Caching,
+// token-rotation handling, and the stateless bypass all live in pkg/client
+// so both the mark3labs and official-SDK transports share one cache and one contextKey type
+func GetTfeClient(ctx context.Context, sessionID string) (*tfe.Client, error) {
+	return tfeclient.GetTfeClientForSession(ctx, sessionID, log.StandardLogger())
 }

--- a/pkg/mcp-official/client/tfe_client_test.go
+++ b/pkg/mcp-official/client/tfe_client_test.go
@@ -1,0 +1,72 @@
+// Copyright IBM Corp. 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package client
+
+import (
+	"context"
+	"testing"
+
+	tfeclient "github.com/hashicorp/terraform-mcp-server/pkg/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests prove the delegation from pkg/mcp-official/client to pkg/client
+// actually wires through: distinct sessionIDs must not collide, and the same
+// sessionID must consistently hit the shared cache in pkg/client.
+//
+// The token/address are supplied via env vars (TerraformToken/TerraformAddress
+// are exported from pkg/client) rather than context values, since pkg/client's
+// contextKey type is unexported and unreachable from this package - exactly
+// the boundary GetTfeClientForSession/GetHttpClientForSession are meant to
+// cross on behalf of any transport.
+
+func TestGetTfeClient_DelegatesPerSession(t *testing.T) {
+	t.Setenv(tfeclient.TerraformToken, "delegation-test-token")
+	t.Setenv(tfeclient.TerraformAddress, "https://app.terraform.io")
+
+	sessionA := "official-tfe-session-a"
+	sessionB := "official-tfe-session-b"
+	t.Cleanup(func() {
+		tfeclient.DeleteTfeClient(sessionA)
+		tfeclient.DeleteTfeClient(sessionB)
+	})
+
+	clientA, err := GetTfeClient(context.Background(), sessionA)
+	require.NoError(t, err)
+	require.NotNil(t, clientA)
+
+	clientB, err := GetTfeClient(context.Background(), sessionB)
+	require.NoError(t, err)
+	require.NotNil(t, clientB)
+
+	assert.NotSame(t, clientA, clientB, "different sessionIDs must get independently cached TFE clients")
+
+	clientAAgain, err := GetTfeClient(context.Background(), sessionA)
+	require.NoError(t, err)
+	assert.Same(t, clientA, clientAAgain, "the same sessionID must return the client cached by pkg/client")
+}
+
+func TestGetHttpClient_DelegatesPerSession(t *testing.T) {
+	sessionA := "official-http-session-a"
+	sessionB := "official-http-session-b"
+	t.Cleanup(func() {
+		tfeclient.DeleteHttpClient(sessionA)
+		tfeclient.DeleteHttpClient(sessionB)
+	})
+
+	clientA, err := GetHttpClient(context.Background(), sessionA)
+	require.NoError(t, err)
+	require.NotNil(t, clientA)
+
+	clientB, err := GetHttpClient(context.Background(), sessionB)
+	require.NoError(t, err)
+	require.NotNil(t, clientB)
+
+	assert.NotSame(t, clientA, clientB, "different sessionIDs must get independently cached HTTP clients")
+
+	clientAAgain, err := GetHttpClient(context.Background(), sessionA)
+	require.NoError(t, err)
+	assert.Same(t, clientA, clientAAgain, "the same sessionID must return the client cached by pkg/client")
+}

--- a/pkg/mcp-official/tools/tfe/organizations.go
+++ b/pkg/mcp-official/tools/tfe/organizations.go
@@ -43,8 +43,12 @@ func ListTerraformOrganizationsTool() *mcp.Tool {
 }
 
 func ListTerraformOrganizationsFunc(ctx context.Context, request *mcp.CallToolRequest, input ListOrganizationsArguments) (*mcp.CallToolResult, *OrganizationSummaryList, error) {
+	var sessionID string
+	if request.Session != nil {
+		sessionID = request.Session.ID()
+	}
 
-	tfeClient, err := client.GetTfeClient(ctx)
+	tfeClient, err := client.GetTfeClient(ctx, sessionID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -78,5 +82,5 @@ func ListTerraformOrganizationsFunc(ctx context.Context, request *mcp.CallToolRe
 }
 
 func ptr[T any](v T) *T {
-    return &v
+	return &v
 }

--- a/pkg/mcp-official/tools/tfe/organizations.go
+++ b/pkg/mcp-official/tools/tfe/organizations.go
@@ -43,12 +43,7 @@ func ListTerraformOrganizationsTool() *mcp.Tool {
 }
 
 func ListTerraformOrganizationsFunc(ctx context.Context, request *mcp.CallToolRequest, input ListOrganizationsArguments) (*mcp.CallToolResult, *OrganizationSummaryList, error) {
-	var sessionID string
-	if request.Session != nil {
-		sessionID = request.Session.ID()
-	}
-
-	tfeClient, err := client.GetTfeClient(ctx, sessionID)
+	tfeClient, err := client.GetTfeClient(ctx, client.SessionIDFromRequest(request))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/mcp-official/tools/tfe/workspace.go
+++ b/pkg/mcp-official/tools/tfe/workspace.go
@@ -79,7 +79,11 @@ func ListWorkspacesFunc(ctx context.Context, request *mcp.CallToolRequest, input
 		}
 	}
 
-	client, err := client.GetTfeClient(ctx)
+	var sessionID string
+	if request.Session != nil {
+		sessionID = request.Session.ID()
+	}
+	client, err := client.GetTfeClient(ctx, sessionID)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/mcp-official/tools/tfe/workspace.go
+++ b/pkg/mcp-official/tools/tfe/workspace.go
@@ -79,11 +79,7 @@ func ListWorkspacesFunc(ctx context.Context, request *mcp.CallToolRequest, input
 		}
 	}
 
-	var sessionID string
-	if request.Session != nil {
-		sessionID = request.Session.ID()
-	}
-	client, err := client.GetTfeClient(ctx, sessionID)
+	client, err := client.GetTfeClient(ctx, client.SessionIDFromRequest(request))
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
## What are we solving?

- The official SDK transport was using a single global TFE client for every session — the first user's token got cached once and then reused for everyone else's requests until the server restarted. 
- The HTTP client had a similar issue: in stateless mode, every request reused one cached client instead of getting its own.

## What changed?

- This PR moves the caching/invalidation logic into pkg/client so both the old (mark3labs) and new (official SDK) transports share the same per-session cache. 
- Each session gets its own TFE/HTTP client, a token change on a session correctly replaces its cached client, and stateless requests never share a cached client with each other. 
- The official SDK's client code is now just a thin wrapper that calls into this shared logic.
- Added unit tests covering per-session caching, token rotation, and the stateless case for both transports.














## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
