### PR TITLE
add helm as a release channel

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -88,3 +88,20 @@ event "promote-production" {
   }
 
 }
+
+event "promote-production-helm" {
+  action "promote-production-helm" {
+    organization = "hashicorp"
+    repository   = "crt-workflows-common"
+    workflow     = "promote-production-helm"
+    depends      = null
+    config       = ""
+  }
+
+  depends = ["promote-production"]
+
+  notification {
+    on = "always"
+  }
+
+}


### PR DESCRIPTION
## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

This PR adds the helm promotion event so the chart can get published to `helm.releases.hashicorp.com` when we cut a production release.

Just an fyi > this PR will need [#916](https://github.com/hashicorp/crt-workflows-common/pull/916) on crt-workflows-common in before the first release that fires it, otherwise the CRT will trigger a publish that looks for the chart at the repo root instead of `helm/terraform-mcp-server`. This [PR](https://github.com/hashicorp/helm-charts/pull/127) in helm-charts adds our slack channel and index entry.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
