### PR TITLE
[Official SDK Migration] - Add private registry tools

### DIFF
--- a/pkg/mcp-official/tools/tfe/get_private_module_details.go
+++ b/pkg/mcp-official/tools/tfe/get_private_module_details.go
@@ -1,0 +1,365 @@
+// Copyright IBM Corp. 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package tools
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"path"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/go-tfe"
+	tfeclient "github.com/hashicorp/terraform-mcp-server/pkg/client"
+	"github.com/hashicorp/terraform-mcp-server/pkg/mcp-official/client"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// GetPrivateModuleDetailsArguments holds the input parameters for getting private module details.
+type GetPrivateModuleDetailsArguments struct {
+	// Required fields
+	TerraformOrgName string `json:"terraform_org_name" jsonschema:"The Terraform organization name"`
+	PrivateModuleID  string `json:"private_module_id" jsonschema:"The private module ID should be in the format 'module-namespace/module-name/module-provider-name' (for example, 'my-tfc-org/vpc/aws' or 'my-module-namespace/vm/azurerm'). The module-namespace is usually the name of the Terraform organization. Obtain this ID by calling 'search_private_modules'."`
+
+	// Optional fields (will be zero values if not provided)
+	RegistryName         string `json:"registry_name,omitempty" jsonschema:"The type of Terraform registry to search within Terraform Cloud/Enterprise ('private' or 'public'). Defaults to 'private'"`
+	PrivateModuleVersion string `json:"private_module_version,omitempty" jsonschema:"Specific version of the module to retrieve details for. If not provided, the latest version will be used"`
+}
+
+func GetPrivateModuleDetailsTool() *mcp.Tool {
+	return &mcp.Tool{
+		Name: "get_private_module_details",
+		Description: `This tool retrieves detailed information about a specific private module in your Terraform Cloud/Enterprise organization. It provides comprehensive details including inputs, outputs, dependencies, versions, and usage examples. It also reports every submodule (nested module) published with the module, each with its own inputs, outputs, provider dependencies, resources, and README. The private_module_id format is 'module-namespace/module-name/module-provider-name'. This can be obtained by calling 'search_private_modules' first to obtain the exact private_module_id required to use this tool`,
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "Get detailed information about a private module",
+			OpenWorldHint:   ptr(true),
+			ReadOnlyHint:    true,
+			DestructiveHint: ptr(false),
+		},
+	}
+}
+
+func GetPrivateModuleDetailsFunc(ctx context.Context, request *mcp.CallToolRequest, input GetPrivateModuleDetailsArguments) (*mcp.CallToolResult, any, error) {
+	terraformOrgName := strings.TrimSpace(input.TerraformOrgName)
+	if terraformOrgName == "" {
+		return nil, nil, fmt.Errorf("terraform_org_name is required")
+	}
+	moduleID := strings.TrimSpace(input.PrivateModuleID)
+	if moduleID == "" {
+		return nil, nil, fmt.Errorf("private_module_id is required")
+	}
+
+	registryName := strings.TrimSpace(input.RegistryName)
+	if registryName == "" {
+		registryName = "private"
+	}
+	moduleVersion := strings.TrimSpace(input.PrivateModuleVersion)
+
+	tfeClient, err := client.GetTfeClient(ctx, client.SessionIDFromRequest(request))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	parts := strings.Split(moduleID, "/")
+	if len(parts) != 3 {
+		return nil, nil, fmt.Errorf("private_module_id must be in format 'module-namespace/module-name/module-provider-name'")
+	}
+
+	tfeModuleID := tfe.RegistryModuleID{
+		Organization: terraformOrgName,
+		Namespace:    parts[0],
+		Name:         parts[1],
+		Provider:     parts[2],
+		RegistryName: tfe.RegistryName(registryName),
+	}
+
+	module, err := tfeClient.RegistryModules.Read(ctx, tfeModuleID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("module not found: %s - use search_private_modules to find valid module IDs: %w", moduleID, err)
+	}
+
+	terraformRegistryModule, err := readTerraformRegistryModuleDetails(ctx, tfeClient, tfeModuleID, moduleVersion)
+	if err != nil {
+		terraformRegistryModule = nil
+	}
+
+	result := buildPrivateModuleDetailsResponse(module, terraformRegistryModule, tfeClient.BaseURL().Host)
+	return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: result}}}, nil, nil
+}
+
+func readTerraformRegistryModuleDetails(ctx context.Context, tfeClient *tfe.Client, moduleID tfe.RegistryModuleID, moduleVersion string) (*tfeclient.TerraformModuleVersionDetails, error) {
+	basePath := "/api/registry/v1/modules"
+	if moduleID.RegistryName == tfe.PublicRegistry {
+		basePath = "/api/registry/public/v1/modules"
+	}
+
+	u := fmt.Sprintf("%s/%s/%s/%s",
+		basePath,
+		url.PathEscape(moduleID.Namespace),
+		url.PathEscape(moduleID.Name),
+		url.PathEscape(moduleID.Provider),
+	)
+
+	// The registry uses /{namespace}/{name}/{provider} for the latest version
+	// and appends /{version} when a specific version is requested.
+	if moduleVersion != "" {
+		u += "/" + url.PathEscape(moduleVersion)
+	}
+
+	req, err := tfeClient.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	module := &tfeclient.TerraformModuleVersionDetails{}
+	if err := req.DoJSON(ctx, module); err != nil {
+		return nil, err
+	}
+
+	return module, nil
+}
+
+func buildPrivateModuleDetailsResponse(registryModule *tfe.RegistryModule, terraformRegistryModule *tfeclient.TerraformModuleVersionDetails, tfeHostAddress string) string {
+	registryPath := path.Join(tfeHostAddress, registryModule.Namespace, registryModule.Name, registryModule.Provider)
+
+	// Use the exact version represented by the details response so the generated
+	// Terraform usage example matches the inputs, outputs, and submodules below.
+	moduleVersion := ""
+	if terraformRegistryModule != nil && terraformRegistryModule.Version != "" {
+		moduleVersion = terraformRegistryModule.Version
+	}
+
+	var builder strings.Builder
+	builder.WriteString("Usage:\n")
+	builder.WriteString("To use this private module in your Terraform configuration:\n\n")
+	builder.WriteString("```hcl\n")
+	builder.WriteString(fmt.Sprintf("module %q {\n", registryModule.Name))
+	builder.WriteString(fmt.Sprintf("  source = %q\n", registryPath))
+
+	if moduleVersion != "" {
+		builder.WriteString(fmt.Sprintf("  version = %q\n", moduleVersion))
+	}
+
+	builder.WriteString("\n")
+	builder.WriteString("  # Add your module inputs here\n")
+	builder.WriteString("}\n")
+	builder.WriteString("```\n\n")
+
+	builder.WriteString("Basic Information:\n")
+	builder.WriteString(fmt.Sprintf("- Name: %s\n", registryModule.Name))
+	builder.WriteString(fmt.Sprintf("- Namespace: %s\n", registryModule.Namespace))
+	builder.WriteString(fmt.Sprintf("- Provider: %s\n", registryModule.Provider))
+	builder.WriteString(fmt.Sprintf("- Registry: %s\n", registryModule.RegistryName))
+	if moduleVersion != "" {
+		builder.WriteString(fmt.Sprintf("- Version: %s\n", moduleVersion))
+	}
+	builder.WriteString(fmt.Sprintf("- Created: %s\n", registryModule.CreatedAt))
+	builder.WriteString(fmt.Sprintf("- Updated: %s\n", registryModule.UpdatedAt))
+	builder.WriteString(fmt.Sprintf("- No Code Module: %t\n", registryModule.NoCode))
+
+	if terraformRegistryModule != nil && terraformRegistryModule.Description != "" {
+		builder.WriteString(fmt.Sprintf("- Description: %s\n", terraformRegistryModule.Description))
+	}
+	builder.WriteString("\n")
+
+	if terraformRegistryModule != nil {
+		if modulePartHasDetails(terraformRegistryModule.Root) {
+			builder.WriteString("Root Module:\n")
+			writeModulePartDetails(&builder, terraformRegistryModule.Root)
+			writeModulePartReadme(&builder, terraformRegistryModule.Root)
+		}
+
+		// Submodules are reported the same way as the root module so that each one
+		// documents its own inputs, outputs, dependencies, resources, and README.
+		for _, submodule := range terraformRegistryModule.Submodules {
+			builder.WriteString(fmt.Sprintf("Submodule: %s\n", submodule.Name))
+			builder.WriteString(fmt.Sprintf("- Path: %s\n\n", submodule.Path))
+			writeModulePartDetails(&builder, submodule)
+			writeModulePartReadme(&builder, submodule)
+		}
+	}
+
+	if registryModule.Organization != nil {
+		builder.WriteString("Organization:\n")
+		builder.WriteString(fmt.Sprintf("- Name: %s\n", registryModule.Organization.Name))
+		builder.WriteString("\n")
+	}
+
+	if registryModule.Permissions != nil {
+		builder.WriteString("Permissions:\n")
+		builder.WriteString(fmt.Sprintf("- Can Delete: %t\n", registryModule.Permissions.CanDelete))
+		builder.WriteString(fmt.Sprintf("- Can Resync: %t\n", registryModule.Permissions.CanResync))
+		builder.WriteString(fmt.Sprintf("- Can Retry: %t\n", registryModule.Permissions.CanRetry))
+		builder.WriteString("\n")
+	}
+
+	if registryModule.VCSRepo != nil {
+		builder.WriteString("VCS Repository:\n")
+		builder.WriteString(fmt.Sprintf("- Identifier: %s\n", registryModule.VCSRepo.Identifier))
+		builder.WriteString(fmt.Sprintf("- Display Identifier: %s\n", registryModule.VCSRepo.DisplayIdentifier))
+		builder.WriteString(fmt.Sprintf("- Branch: %s\n", registryModule.VCSRepo.Branch))
+		if registryModule.VCSRepo.IngressSubmodules {
+			builder.WriteString("- Ingress Submodules: Yes\n")
+		}
+		if registryModule.VCSRepo.RepositoryHTTPURL != "" {
+			builder.WriteString(fmt.Sprintf("- Repository URL: %s\n", registryModule.VCSRepo.RepositoryHTTPURL))
+		}
+		if registryModule.VCSRepo.ServiceProvider != "" {
+			builder.WriteString(fmt.Sprintf("- Service Provider: %s\n", registryModule.VCSRepo.ServiceProvider))
+		}
+		builder.WriteString("\n")
+	}
+
+	return builder.String()
+}
+
+// modulePartHasDetails reports whether a module part has anything worth writing,
+// so that a heading is never emitted for a part the registry reported as empty.
+func modulePartHasDetails(modulePart tfeclient.ModulePart) bool {
+	return len(modulePart.Inputs) > 0 ||
+		len(modulePart.Outputs) > 0 ||
+		len(modulePart.Dependencies) > 0 ||
+		len(modulePart.ProviderDependencies) > 0 ||
+		len(modulePart.Resources) > 0 ||
+		modulePart.Readme != ""
+}
+
+func writeModulePartDetails(builder *strings.Builder, modulePart tfeclient.ModulePart) {
+	if len(modulePart.Inputs) > 0 {
+		builder.WriteString("Inputs:\n")
+		builder.WriteString(strings.Repeat("-", 20))
+		builder.WriteByte('\n')
+		builder.WriteString("| Name | Type | Description | Default | Required |\n")
+		builder.WriteString("|------|------|-------------|---------|----------|\n")
+		for _, input := range modulePart.Inputs {
+			builder.WriteString(fmt.Sprintf("| %s | %s | %s | `%s` | %t |\n",
+				input.Name,
+				input.Type,
+				input.Description,
+				formatModuleInputDefault(input.Default),
+				input.Required,
+			))
+		}
+		builder.WriteString("\n")
+	}
+
+	if len(modulePart.Outputs) > 0 {
+		builder.WriteString("Outputs:\n")
+		builder.WriteString(strings.Repeat("-", 20))
+		builder.WriteByte('\n')
+		builder.WriteString("| Name | Description |\n")
+		builder.WriteString("|------|-------------|\n")
+		for _, output := range modulePart.Outputs {
+			builder.WriteString(fmt.Sprintf("| %s | %s |\n",
+				output.Name,
+				output.Description,
+			))
+		}
+		builder.WriteString("\n")
+	}
+
+	if len(modulePart.Dependencies) > 0 {
+		builder.WriteString("Dependencies:\n")
+		builder.WriteString(strings.Repeat("-", 20))
+		builder.WriteByte('\n')
+		builder.WriteString("| Name | Source | Version |\n")
+		builder.WriteString("|------|--------|---------|\n")
+		for _, dep := range modulePart.Dependencies {
+			builder.WriteString(fmt.Sprintf("| %s | %s | %s |\n",
+				dep.Name,
+				dep.Source,
+				dep.Version,
+			))
+		}
+		builder.WriteString("\n")
+	}
+
+	if len(modulePart.ProviderDependencies) > 0 {
+		builder.WriteString("Provider Dependencies:\n")
+		builder.WriteString(strings.Repeat("-", 20))
+		builder.WriteByte('\n')
+		builder.WriteString("| Name | Namespace | Source | Version |\n")
+		builder.WriteString("|------|-----------|--------|----------|\n")
+		for _, dep := range modulePart.ProviderDependencies {
+			builder.WriteString(fmt.Sprintf("| %s | %s | %s | %s |\n",
+				dep.Name,
+				dep.Namespace,
+				dep.Source,
+				dep.Version,
+			))
+		}
+		builder.WriteString("\n")
+	}
+
+	if len(modulePart.Resources) > 0 {
+		builder.WriteString("Resources:\n")
+		builder.WriteString(strings.Repeat("-", 20))
+		builder.WriteByte('\n')
+		builder.WriteString("| Name | Type |\n")
+		builder.WriteString("|------|------|\n")
+		for _, resource := range modulePart.Resources {
+			builder.WriteString(fmt.Sprintf("| %s | %s |\n",
+				resource.Name,
+				resource.Type,
+			))
+		}
+		builder.WriteString("\n")
+	}
+}
+
+func formatModuleInputDefault(value any) string {
+	if value == nil {
+		return ""
+	}
+	return fmt.Sprint(value)
+}
+
+func writeModulePartReadme(builder *strings.Builder, modulePart tfeclient.ModulePart) {
+	if modulePart.Readme == "" {
+		return
+	}
+
+	cleanedReadme := removeReadmeSections(modulePart.Readme)
+	if cleanedReadme == "" {
+		return
+	}
+
+	builder.WriteString("README:\n")
+	builder.WriteString(strings.Repeat("-", 20))
+	builder.WriteByte('\n')
+	builder.WriteString(cleanedReadme)
+	builder.WriteString("\n\n")
+}
+
+func removeReadmeSections(readme string) string {
+	lines := strings.Split(readme, "\n")
+	var result []string
+	skipSection := false
+
+	for _, line := range lines {
+		lowerLine := strings.ToLower(strings.TrimSpace(line))
+		if strings.HasPrefix(lowerLine, "##") || strings.HasPrefix(lowerLine, "###") || strings.HasPrefix(lowerLine, "####") {
+			if strings.Contains(lowerLine, "inputs") ||
+				strings.Contains(lowerLine, "outputs") ||
+				strings.Contains(lowerLine, "dependencies") ||
+				strings.Contains(lowerLine, "provider dependencies") ||
+				strings.Contains(lowerLine, "resources") {
+				skipSection = true
+				continue
+			} else {
+				skipSection = false
+			}
+		}
+
+		if !skipSection {
+			result = append(result, line)
+		}
+	}
+
+	cleaned := strings.Join(result, "\n")
+	cleaned = regexp.MustCompile(`\n{3,}`).ReplaceAllString(cleaned, "\n\n")
+
+	return strings.TrimSpace(cleaned)
+}

--- a/pkg/mcp-official/tools/tfe/get_private_provider_details.go
+++ b/pkg/mcp-official/tools/tfe/get_private_provider_details.go
@@ -1,0 +1,174 @@
+// Copyright IBM Corp. 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-mcp-server/pkg/mcp-official/client"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// GetPrivateProviderDetailsArguments holds the input parameters for getting private provider details.
+type GetPrivateProviderDetailsArguments struct {
+	// Required fields
+	TerraformOrgName         string `json:"terraform_org_name" jsonschema:"The Terraform organization name"`
+	PrivateProviderNamespace string `json:"private_provider_namespace" jsonschema:"The namespace of the private provider in your Terraform Cloud/Enterprise organization. For public registry, use the namespace from the public Terraform registry."`
+	PrivateProviderName      string `json:"private_provider_name" jsonschema:"The name of the private provider"`
+
+	// Optional fields (will be zero values if not provided)
+	RegistryName    string `json:"registry_name,omitempty" jsonschema:"The type of Terraform registry to search within Terraform Cloud/Enterprise ('private' or 'public'). Defaults to 'private'"`
+	IncludeVersions *bool  `json:"include_versions,omitempty" jsonschema:"Whether to include detailed version information. Defaults to true"`
+}
+
+func GetPrivateProviderDetailsTool() *mcp.Tool {
+	return &mcp.Tool{
+		Name: "get_private_provider_details",
+		Description: `This tool retrieves information about a specific private provider in your Terraform Cloud/Enterprise organization.
+It provides details on how to use the provider, permissions, available versions, and more. This tool requires a valid Terraform token to be configured.
+`,
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "Get detailed information about a private provider",
+			OpenWorldHint:   ptr(true),
+			ReadOnlyHint:    true,
+			DestructiveHint: ptr(false),
+		},
+	}
+}
+
+func GetPrivateProviderDetailsFunc(ctx context.Context, request *mcp.CallToolRequest, input GetPrivateProviderDetailsArguments) (*mcp.CallToolResult, *string, error) {
+	terraformOrgName := strings.TrimSpace(input.TerraformOrgName)
+	privateProviderNamespace := strings.TrimSpace(input.PrivateProviderNamespace)
+	privateProviderName := strings.TrimSpace(input.PrivateProviderName)
+
+	registryName := strings.TrimSpace(input.RegistryName)
+	if registryName == "" {
+		registryName = "private"
+	}
+
+	includeVersions := true
+	if input.IncludeVersions != nil {
+		includeVersions = *input.IncludeVersions
+	}
+
+	tfeClient, err := client.GetTfeClient(ctx, client.SessionIDFromRequest(request))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	providerID := tfe.RegistryProviderID{
+		OrganizationName: terraformOrgName,
+		Namespace:        privateProviderNamespace,
+		Name:             privateProviderName,
+		RegistryName:     tfe.RegistryName(registryName),
+	}
+
+	readOptions := &tfe.RegistryProviderReadOptions{}
+	if includeVersions {
+		includeOpts := []tfe.RegistryProviderIncludeOps{tfe.RegistryProviderVersionsInclude}
+		readOptions.Include = includeOpts
+	}
+
+	provider, err := tfeClient.RegistryProviders.Read(ctx, providerID, readOptions)
+	if err != nil {
+		return nil, nil, fmt.Errorf("provider not found: %s/%s - use search_private_providers to find valid providers: %w", privateProviderNamespace, privateProviderName, err)
+	}
+
+	var builder strings.Builder
+	builder.WriteString(fmt.Sprintf("Private Provider Details: %s/%s\n", provider.Namespace, provider.Name))
+	builder.WriteString(strings.Repeat("=", 50) + "\n\n")
+
+	builder.WriteString("Usage:\n")
+	builder.WriteString("To use this private provider in your Terraform configuration:\n\n")
+	builder.WriteString("```hcl\n")
+	builder.WriteString("terraform {\n")
+	builder.WriteString("  required_providers {\n")
+	builder.WriteString(fmt.Sprintf("    %s = {\n", provider.Name))
+	builder.WriteString(fmt.Sprintf("      source = \"%s/%s\"\n", provider.Namespace, provider.Name))
+	if len(provider.RegistryProviderVersions) > 0 {
+		builder.WriteString(fmt.Sprintf("      version = \"%s\"\n", provider.RegistryProviderVersions[0].Version))
+	}
+	builder.WriteString("    }\n")
+	builder.WriteString("  }\n")
+	builder.WriteString("}\n")
+	builder.WriteString("```\n")
+
+	builder.WriteString("Basic Information:\n")
+	builder.WriteString(fmt.Sprintf("- ID: %s\n", provider.ID))
+	builder.WriteString(fmt.Sprintf("- Name: %s\n", provider.Name))
+	builder.WriteString(fmt.Sprintf("- Namespace: %s\n", provider.Namespace))
+	builder.WriteString(fmt.Sprintf("- Registry: %s\n", provider.RegistryName))
+	builder.WriteString(fmt.Sprintf("- Created: %s\n", provider.CreatedAt))
+	builder.WriteString(fmt.Sprintf("- Updated: %s\n", provider.UpdatedAt))
+	builder.WriteString("\n")
+
+	if provider.Organization != nil {
+		builder.WriteString("Organization:\n")
+		builder.WriteString(fmt.Sprintf("- Name: %s\n", provider.Organization.Name))
+		if provider.Organization.Email != "" {
+			builder.WriteString(fmt.Sprintf("- Email: %s\n", provider.Organization.Email))
+		}
+		builder.WriteString("\n")
+	}
+
+	builder.WriteString("Permissions:\n")
+	builder.WriteString(fmt.Sprintf("- Can Delete: %t\n", provider.Permissions.CanDelete))
+	builder.WriteString("\n")
+
+	if includeVersions && len(provider.RegistryProviderVersions) > 0 {
+		builder.WriteString(fmt.Sprintf("Available Versions (%d):\n", len(provider.RegistryProviderVersions)))
+
+		for i, version := range provider.RegistryProviderVersions {
+			builder.WriteString(fmt.Sprintf("%d. Version: %s\n", i+1, version.Version))
+			builder.WriteString(fmt.Sprintf("   ID: %s\n", version.ID))
+			builder.WriteString(fmt.Sprintf("   Created: %s\n", version.CreatedAt))
+			builder.WriteString(fmt.Sprintf("   Updated: %s\n", version.UpdatedAt))
+
+			if version.KeyID != "" {
+				builder.WriteString(fmt.Sprintf("   Key ID: %s\n", version.KeyID))
+			}
+
+			builder.WriteString("   Permissions: ")
+			var perms []string
+			if version.Permissions.CanUploadAsset {
+				perms = append(perms, "upload-asset")
+			}
+			if version.Permissions.CanDelete {
+				perms = append(perms, "delete")
+			}
+			builder.WriteString(strings.Join(perms, ", "))
+			builder.WriteString("\n")
+
+			if len(version.RegistryProviderPlatforms) > 0 {
+				builder.WriteString("   Platforms: ")
+				var platforms []string
+				for _, platform := range version.RegistryProviderPlatforms {
+					platforms = append(platforms, fmt.Sprintf("%s/%s", platform.OS, platform.Arch))
+				}
+				builder.WriteString(strings.Join(platforms, ", "))
+				builder.WriteString("\n")
+			}
+
+			builder.WriteString("\n")
+		}
+	} else if includeVersions {
+		builder.WriteString("No version information is available for this provider.\n\n")
+	}
+
+	if len(provider.Links) > 0 {
+		builder.WriteString("Links:\n")
+		for key, value := range provider.Links {
+			if strValue, ok := value.(string); ok {
+				builder.WriteString(fmt.Sprintf("- %s: %s\n", key, strValue))
+			}
+		}
+		builder.WriteString("\n")
+	}
+
+	result := builder.String()
+	return nil, &result, nil
+}

--- a/pkg/mcp-official/tools/tfe/get_private_provider_details.go
+++ b/pkg/mcp-official/tools/tfe/get_private_provider_details.go
@@ -40,10 +40,19 @@ It provides details on how to use the provider, permissions, available versions,
 	}
 }
 
-func GetPrivateProviderDetailsFunc(ctx context.Context, request *mcp.CallToolRequest, input GetPrivateProviderDetailsArguments) (*mcp.CallToolResult, *string, error) {
+func GetPrivateProviderDetailsFunc(ctx context.Context, request *mcp.CallToolRequest, input GetPrivateProviderDetailsArguments) (*mcp.CallToolResult, any, error) {
 	terraformOrgName := strings.TrimSpace(input.TerraformOrgName)
+	if terraformOrgName == "" {
+		return nil, nil, fmt.Errorf("terraform_org_name is required")
+	}
 	privateProviderNamespace := strings.TrimSpace(input.PrivateProviderNamespace)
+	if privateProviderNamespace == "" {
+		return nil, nil, fmt.Errorf("private_provider_namespace is required")
+	}
 	privateProviderName := strings.TrimSpace(input.PrivateProviderName)
+	if privateProviderName == "" {
+		return nil, nil, fmt.Errorf("private_provider_name is required")
+	}
 
 	registryName := strings.TrimSpace(input.RegistryName)
 	if registryName == "" {
@@ -170,5 +179,5 @@ func GetPrivateProviderDetailsFunc(ctx context.Context, request *mcp.CallToolReq
 	}
 
 	result := builder.String()
-	return nil, &result, nil
+	return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: result}}}, nil, nil
 }

--- a/pkg/mcp-official/tools/tfe/search_private_modules.go
+++ b/pkg/mcp-official/tools/tfe/search_private_modules.go
@@ -38,8 +38,11 @@ It retrieves a list of private modules that match the search criteria. This tool
 	}
 }
 
-func SearchPrivateModulesFunc(ctx context.Context, request *mcp.CallToolRequest, input SearchPrivateModulesArguments) (*mcp.CallToolResult, *string, error) {
+func SearchPrivateModulesFunc(ctx context.Context, request *mcp.CallToolRequest, input SearchPrivateModulesArguments) (*mcp.CallToolResult, any, error) {
 	terraformOrgName := strings.TrimSpace(input.TerraformOrgName)
+	if terraformOrgName == "" {
+		return nil, nil, fmt.Errorf("terraform_org_name is required")
+	}
 	searchQuery := strings.TrimSpace(input.SearchQuery)
 	pageSize := input.PageSize
 	if pageSize == 0 {
@@ -95,7 +98,7 @@ func SearchPrivateModulesFunc(ctx context.Context, request *mcp.CallToolRequest,
 			builder.WriteString("- Verifying that private modules exist in this organization\n")
 		}
 		result := builder.String()
-		return nil, &result, nil
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: result}}}, nil, nil
 	}
 
 	builder.WriteString(fmt.Sprintf("Found %d module(s):\n", len(moduleList.Items)))
@@ -136,5 +139,5 @@ func SearchPrivateModulesFunc(ctx context.Context, request *mcp.CallToolRequest,
 	}
 
 	result := builder.String()
-	return nil, &result, nil
+	return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: result}}}, nil, nil
 }

--- a/pkg/mcp-official/tools/tfe/search_private_modules.go
+++ b/pkg/mcp-official/tools/tfe/search_private_modules.go
@@ -1,0 +1,140 @@
+// Copyright IBM Corp. 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-mcp-server/pkg/mcp-official/client"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// SearchPrivateModulesArguments holds the input parameters for searching private modules.
+type SearchPrivateModulesArguments struct {
+	// Required field
+	TerraformOrgName string `json:"terraform_org_name" jsonschema:"The Terraform organization name to search for private modules in"`
+
+	// Optional fields (will be zero values if not provided)
+	SearchQuery string `json:"search_query,omitempty" jsonschema:"Optional search query to filter modules by name or namespace. If not provided, all modules will be returned"`
+	PageSize    int    `json:"page_size,omitempty" jsonschema:"Number of results to return per page (min 1, max 100)"`
+	PageNumber  int    `json:"page_number,omitempty" jsonschema:"Page number for pagination (starts at 1)"`
+}
+
+func SearchPrivateModulesTool() *mcp.Tool {
+	return &mcp.Tool{
+		Name: "search_private_modules",
+		Description: `This tool searches for private modules in your Terraform Cloud/Enterprise organization.
+It retrieves a list of private modules that match the search criteria. This tool requires a valid Terraform token to be configured.`,
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "Search for private modules in Terraform Cloud/Enterprise",
+			OpenWorldHint:   ptr(true),
+			ReadOnlyHint:    true,
+			DestructiveHint: ptr(false),
+		},
+	}
+}
+
+func SearchPrivateModulesFunc(ctx context.Context, request *mcp.CallToolRequest, input SearchPrivateModulesArguments) (*mcp.CallToolResult, *string, error) {
+	terraformOrgName := strings.TrimSpace(input.TerraformOrgName)
+	searchQuery := strings.TrimSpace(input.SearchQuery)
+	pageSize := input.PageSize
+	if pageSize == 0 {
+		pageSize = 100
+	}
+	pageNumber := input.PageNumber
+	if pageNumber == 0 {
+		pageNumber = 1
+	}
+
+	if pageSize < 1 || pageSize > 100 {
+		return nil, nil, fmt.Errorf("page_size must be between 1 and 100")
+	}
+	if pageNumber < 1 {
+		return nil, nil, fmt.Errorf("page_number must be at least 1")
+	}
+
+	tfeClient, err := client.GetTfeClient(ctx, client.SessionIDFromRequest(request))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	listOptions := &tfe.RegistryModuleListOptions{
+		ListOptions: tfe.ListOptions{
+			PageNumber: pageNumber,
+			PageSize:   pageSize,
+		},
+		Include: []tfe.RegistryModuleListIncludeOpt{tfe.IncludeNoCodeModules},
+	}
+
+	if searchQuery != "" {
+		listOptions.Search = searchQuery
+	}
+
+	moduleList, err := tfeClient.RegistryModules.List(ctx, terraformOrgName, listOptions)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to list private modules in org '%s': %w", terraformOrgName, err)
+	}
+
+	var builder strings.Builder
+	builder.WriteString(fmt.Sprintf("Private Modules in Organization: %s\n", terraformOrgName))
+	if searchQuery != "" {
+		builder.WriteString(fmt.Sprintf("Search Query: %s\n", searchQuery))
+	}
+	builder.WriteString(fmt.Sprintf("Page: %d, Size: %d\n\n", pageNumber, pageSize))
+
+	if len(moduleList.Items) == 0 {
+		builder.WriteString("No private modules found matching the search criteria.\n")
+		if searchQuery != "" {
+			builder.WriteString("Try:\n")
+			builder.WriteString("- Using a broader search query\n")
+			builder.WriteString("- Checking the organization name\n")
+			builder.WriteString("- Verifying that private modules exist in this organization\n")
+		}
+		result := builder.String()
+		return nil, &result, nil
+	}
+
+	builder.WriteString(fmt.Sprintf("Found %d module(s):\n", len(moduleList.Items)))
+	builder.WriteString("(Use the 'private_module_id' value with get_private_module_details tool)\n\n")
+
+	for i, module := range moduleList.Items {
+		moduleID := fmt.Sprintf("%s/%s/%s", module.Namespace, module.Name, module.Provider)
+		builder.WriteString(fmt.Sprintf("%d  private_module_id: %s\n", i+1, moduleID))
+		builder.WriteString(fmt.Sprintf("   Module Name: %s\n", module.Name))
+		builder.WriteString(fmt.Sprintf("   Module Namespace: %s\n", module.Namespace))
+		builder.WriteString(fmt.Sprintf("   Registry: %s\n", module.RegistryName))
+		builder.WriteString(fmt.Sprintf("   Created: %s\n", module.CreatedAt))
+		builder.WriteString(fmt.Sprintf("   Updated: %s\n", module.UpdatedAt))
+		builder.WriteString(fmt.Sprintf("   Provider: %s\n", module.Provider))
+		builder.WriteString(fmt.Sprintf("   No Code Module: %t\n", module.NoCode))
+
+		if module.NoCode {
+			for _, noCodeModule := range module.RegistryNoCodeModule {
+				builder.WriteString(fmt.Sprintf("     - no_code_module_id: %s\n", noCodeModule.ID))
+			}
+		}
+
+		builder.WriteString("\n")
+	}
+
+	if moduleList.Pagination != nil {
+		builder.WriteString("Pagination:\n")
+		builder.WriteString(fmt.Sprintf("- Current Page: %d\n", moduleList.Pagination.CurrentPage))
+		builder.WriteString(fmt.Sprintf("- Total Pages: %d\n", moduleList.Pagination.TotalPages))
+		builder.WriteString(fmt.Sprintf("- Total Count: %d\n", moduleList.Pagination.TotalCount))
+
+		if moduleList.Pagination.NextPage > 0 {
+			builder.WriteString(fmt.Sprintf("- Next Page: %d\n", moduleList.Pagination.NextPage))
+		}
+		if moduleList.Pagination.PreviousPage > 0 {
+			builder.WriteString(fmt.Sprintf("- Previous Page: %d\n", moduleList.Pagination.PreviousPage))
+		}
+	}
+
+	result := builder.String()
+	return nil, &result, nil
+}

--- a/pkg/mcp-official/tools/tfe/search_private_providers.go
+++ b/pkg/mcp-official/tools/tfe/search_private_providers.go
@@ -1,0 +1,151 @@
+// Copyright IBM Corp. 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-mcp-server/pkg/mcp-official/client"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// SearchPrivateProvidersArguments holds the input parameters for searching private providers.
+type SearchPrivateProvidersArguments struct {
+	// Required field
+	TerraformOrgName string `json:"terraform_org_name" jsonschema:"The Terraform organization name to search for private providers in"`
+
+	// Optional fields (will be zero values if not provided)
+	SearchQuery  string `json:"search_query,omitempty" jsonschema:"Optional search query to filter providers by name or namespace. If not provided, all providers will be returned"`
+	RegistryName string `json:"registry_name,omitempty" jsonschema:"The type of Terraform registry to search within Terraform Cloud/Enterprise ('private' or 'public'). Defaults to 'private'"`
+	PageSize     int    `json:"page_size,omitempty" jsonschema:"Number of results to return per page (min 1, max 100)"`
+	PageNumber   int    `json:"page_number,omitempty" jsonschema:"Page number for pagination (starts at 1)"`
+}
+
+func SearchPrivateProvidersTool() *mcp.Tool {
+	return &mcp.Tool{
+		Name: "search_private_providers",
+		Description: `This tool searches for private providers in your Terraform Cloud/Enterprise organization.
+It retrieves a list of private providers that match the search criteria. This tool requires a valid Terraform token to be configured.`,
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "Search for private providers in Terraform Cloud/Enterprise",
+			OpenWorldHint:   ptr(true),
+			ReadOnlyHint:    true,
+			DestructiveHint: ptr(false),
+		},
+	}
+}
+
+func SearchPrivateProvidersFunc(ctx context.Context, request *mcp.CallToolRequest, input SearchPrivateProvidersArguments) (*mcp.CallToolResult, *string, error) {
+	terraformOrgName := strings.TrimSpace(input.TerraformOrgName)
+	searchQuery := strings.TrimSpace(input.SearchQuery)
+	registryName := strings.TrimSpace(input.RegistryName)
+	if registryName == "" {
+		registryName = "private"
+	}
+	pageSize := input.PageSize
+	if pageSize == 0 {
+		pageSize = 20
+	}
+	pageNumber := input.PageNumber
+	if pageNumber == 0 {
+		pageNumber = 1
+	}
+
+	if pageSize < 1 || pageSize > 100 {
+		return nil, nil, fmt.Errorf("page_size must be between 1 and 100")
+	}
+	if pageNumber < 1 {
+		return nil, nil, fmt.Errorf("page_number must be at least 1")
+	}
+
+	tfeClient, err := client.GetTfeClient(ctx, client.SessionIDFromRequest(request))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	listOptions := &tfe.RegistryProviderListOptions{
+		ListOptions: tfe.ListOptions{
+			PageNumber: pageNumber,
+			PageSize:   pageSize,
+		},
+	}
+
+	if registryName != "" {
+		listOptions.RegistryName = tfe.RegistryName(registryName)
+	}
+
+	if searchQuery != "" {
+		listOptions.Search = searchQuery
+	}
+
+	includeOpts := []tfe.RegistryProviderIncludeOps{tfe.RegistryProviderVersionsInclude}
+	listOptions.Include = &includeOpts
+
+	providerList, err := tfeClient.RegistryProviders.List(ctx, terraformOrgName, listOptions)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to list private providers in org '%s': %w", terraformOrgName, err)
+	}
+
+	var builder strings.Builder
+	builder.WriteString(fmt.Sprintf("Private Providers in Organization: %s\n", terraformOrgName))
+	if searchQuery != "" {
+		builder.WriteString(fmt.Sprintf("Search Query: %s\n", searchQuery))
+	}
+	builder.WriteString(fmt.Sprintf("Registry: %s\n", registryName))
+	builder.WriteString(fmt.Sprintf("Page: %d, Size: %d\n\n", pageNumber, pageSize))
+
+	if len(providerList.Items) == 0 {
+		builder.WriteString("No private providers found matching the search criteria.\n")
+		if searchQuery != "" {
+			builder.WriteString("Try:\n")
+			builder.WriteString("- Using a broader search query\n")
+			builder.WriteString("- Checking the organization name\n")
+			builder.WriteString("- Verifying that private providers exist in this organization\n")
+		}
+		result := builder.String()
+		return nil, &result, nil
+	}
+
+	builder.WriteString(fmt.Sprintf("Found %d provider(s):\n\n", len(providerList.Items)))
+
+	for i, provider := range providerList.Items {
+		builder.WriteString(fmt.Sprintf("%d. Provider: %s/%s\n", i+1, provider.Namespace, provider.Name))
+		builder.WriteString(fmt.Sprintf("   ID: %s\n", provider.ID))
+		builder.WriteString(fmt.Sprintf("   Registry: %s\n", provider.RegistryName))
+		builder.WriteString(fmt.Sprintf("   Created: %s\n", provider.CreatedAt))
+		builder.WriteString(fmt.Sprintf("   Updated: %s\n", provider.UpdatedAt))
+
+		if len(provider.RegistryProviderVersions) > 0 {
+			builder.WriteString("   Versions: ")
+			versions := make([]string, len(provider.RegistryProviderVersions))
+			for j, version := range provider.RegistryProviderVersions {
+				versions[j] = version.Version
+			}
+			builder.WriteString(strings.Join(versions, ", "))
+			builder.WriteString("\n")
+		}
+
+		builder.WriteString("\n")
+	}
+
+	if providerList.Pagination != nil {
+		builder.WriteString("Pagination:\n")
+		builder.WriteString(fmt.Sprintf("- Current Page: %d\n", providerList.Pagination.CurrentPage))
+		builder.WriteString(fmt.Sprintf("- Total Pages: %d\n", providerList.Pagination.TotalPages))
+		builder.WriteString(fmt.Sprintf("- Total Count: %d\n", providerList.Pagination.TotalCount))
+
+		if providerList.Pagination.NextPage > 0 {
+			builder.WriteString(fmt.Sprintf("- Next Page: %d\n", providerList.Pagination.NextPage))
+		}
+		if providerList.Pagination.PreviousPage > 0 {
+			builder.WriteString(fmt.Sprintf("- Previous Page: %d\n", providerList.Pagination.PreviousPage))
+		}
+	}
+
+	result := builder.String()
+	return nil, &result, nil
+}

--- a/pkg/mcp-official/tools/tfe/search_private_providers.go
+++ b/pkg/mcp-official/tools/tfe/search_private_providers.go
@@ -39,8 +39,11 @@ It retrieves a list of private providers that match the search criteria. This to
 	}
 }
 
-func SearchPrivateProvidersFunc(ctx context.Context, request *mcp.CallToolRequest, input SearchPrivateProvidersArguments) (*mcp.CallToolResult, *string, error) {
+func SearchPrivateProvidersFunc(ctx context.Context, request *mcp.CallToolRequest, input SearchPrivateProvidersArguments) (*mcp.CallToolResult, any, error) {
 	terraformOrgName := strings.TrimSpace(input.TerraformOrgName)
+	if terraformOrgName == "" {
+		return nil, nil, fmt.Errorf("terraform_org_name is required")
+	}
 	searchQuery := strings.TrimSpace(input.SearchQuery)
 	registryName := strings.TrimSpace(input.RegistryName)
 	if registryName == "" {
@@ -107,7 +110,7 @@ func SearchPrivateProvidersFunc(ctx context.Context, request *mcp.CallToolReques
 			builder.WriteString("- Verifying that private providers exist in this organization\n")
 		}
 		result := builder.String()
-		return nil, &result, nil
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: result}}}, nil, nil
 	}
 
 	builder.WriteString(fmt.Sprintf("Found %d provider(s):\n\n", len(providerList.Items)))
@@ -147,5 +150,5 @@ func SearchPrivateProvidersFunc(ctx context.Context, request *mcp.CallToolReques
 	}
 
 	result := builder.String()
-	return nil, &result, nil
+	return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: result}}}, nil, nil
 }

--- a/pkg/mcp-official/tools/tools.go
+++ b/pkg/mcp-official/tools/tools.go
@@ -27,4 +27,8 @@ func RegisterTools(svr *mcp.Server, logger *log.Logger, enabledToolsets []string
 	if toolsets.IsToolEnabled("get_private_provider_details", enabledToolsets) {
 		mcp.AddTool(svr, tfeTools.GetPrivateProviderDetailsTool(), tfeTools.GetPrivateProviderDetailsFunc)
 	}
+
+	if toolsets.IsToolEnabled("get_private_module_details", enabledToolsets) {
+		mcp.AddTool(svr, tfeTools.GetPrivateModuleDetailsTool(), tfeTools.GetPrivateModuleDetailsFunc)
+	}
 }

--- a/pkg/mcp-official/tools/tools.go
+++ b/pkg/mcp-official/tools/tools.go
@@ -15,4 +15,16 @@ func RegisterTools(svr *mcp.Server, logger *log.Logger, enabledToolsets []string
 	if toolsets.IsToolEnabled("list_terraform_orgs", enabledToolsets) {
 		mcp.AddTool(svr, tfeTools.ListTerraformOrganizationsTool(), tfeTools.ListTerraformOrganizationsFunc)
 	}
+
+	if toolsets.IsToolEnabled("search_private_modules", enabledToolsets) {
+		mcp.AddTool(svr, tfeTools.SearchPrivateModulesTool(), tfeTools.SearchPrivateModulesFunc)
+	}
+
+	if toolsets.IsToolEnabled("search_private_providers", enabledToolsets) {
+		mcp.AddTool(svr, tfeTools.SearchPrivateProvidersTool(), tfeTools.SearchPrivateProvidersFunc)
+	}
+
+	if toolsets.IsToolEnabled("get_private_provider_details", enabledToolsets) {
+		mcp.AddTool(svr, tfeTools.GetPrivateProviderDetailsTool(), tfeTools.GetPrivateProviderDetailsFunc)
+	}
 }


### PR DESCRIPTION
This PR re-implements the following tools using official go-sdk for MCP:

- get_private_module_details
- get_private_provider_details
- search_private_modules
- search_private_providers

get_private_module_details implementation was referred from this [PR](https://github.com/hashicorp/terraform-mcp-server/pull/495)

Question: Is there a reason why we're building huge string outputs rather than returning json response like other tools?