### PR TITLE
enforce org allowlist for ID-based tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.3.1
+
+FIXES
+
+* Enforce `MCP_ORGANIZATION_ALLOWLIST` for tools that target a resource by ID and send no `terraform_org_name` (`force_unlock_workspace`, `delete_workspace_safely`, `action_run`, `grant_team_access`, `add_team_member`, `get_state_version`, `delete_project`, `delete_team`, `create_no_code_workspace`, and the variable set / policy set attach tools). These tools previously bypassed the allowlist; they now resolve the target's owning organization from the TFE API and reject the call when it is not allowlisted. [519](https://github.com/hashicorp/terraform-mcp-server/pull/519)
+
 # 1.3.0
 
 FEATURES

--- a/pkg/client/org_allowlist_tool_middleware.go
+++ b/pkg/client/org_allowlist_tool_middleware.go
@@ -16,18 +16,32 @@ import (
 // OrgNameArgument is the tool argument holding the organization name for a tool call
 const OrgNameArgument = "terraform_org_name"
 
+type organizationAllowlistContextKey struct{}
+
+func WithOrganizationAllowlist(ctx context.Context, allowedOrganizations map[string]struct{}) context.Context {
+	return context.WithValue(ctx, organizationAllowlistContextKey{}, allowedOrganizations)
+}
+
+func OrganizationAllowed(ctx context.Context, organizationName string) bool {
+	allowedOrganizations, ok := ctx.Value(organizationAllowlistContextKey{}).(map[string]struct{})
+	if !ok {
+		return true
+	}
+	_, allowed := allowedOrganizations[strings.ToLower(strings.TrimSpace(organizationName))]
+	return allowed
+}
+
 func OrganizationAllowlistToolMiddleware(allowlist []string, logger *log.Logger) server.ToolHandlerMiddleware {
 	allowedOrganizations := BuildAllowedOrganizationsMap(allowlist)
 
 	return func(nextToolHandler server.ToolHandlerFunc) server.ToolHandlerFunc {
 		return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			// Skip allowlist enforcement for tools without an organization argument.
-			organizationName := strings.ToLower(strings.TrimSpace(request.GetString(OrgNameArgument, "")))
-			if organizationName == "" {
-				return nextToolHandler(ctx, request)
-			}
+			ctx = WithOrganizationAllowlist(ctx, allowedOrganizations)
 
-			if _, allowed := allowedOrganizations[organizationName]; !allowed {
+			// Tools that pass the organization by argument are checked here; ID-based
+			// tools carry no name and are checked in their handlers.
+			organizationName := strings.ToLower(strings.TrimSpace(request.GetString(OrgNameArgument, "")))
+			if organizationName != "" && !OrganizationAllowed(ctx, organizationName) {
 				logger.Warnf("Rejecting tool call %q: organization %q is not in the configured allowlist",
 					request.Params.Name, organizationName)
 				return mcp.NewToolResultError(fmt.Sprintf(

--- a/pkg/client/org_allowlist_tool_middleware_test.go
+++ b/pkg/client/org_allowlist_tool_middleware_test.go
@@ -73,3 +73,12 @@ func TestOrganizationAllowlistToolMiddleware(t *testing.T) {
 		})
 	}
 }
+
+func TestOrganizationAllowed(t *testing.T) {
+	ctxWithAllowlist := WithOrganizationAllowlist(context.Background(), BuildAllowedOrganizationsMap([]string{"allowed-org"}))
+
+	assert.True(t, OrganizationAllowed(context.Background(), "any-org"), "no allowlist configured allows everything")
+	assert.True(t, OrganizationAllowed(ctxWithAllowlist, "Allowed-Org"), "match is case-insensitive")
+	assert.False(t, OrganizationAllowed(ctxWithAllowlist, "blocked-org"), "org outside the allowlist is rejected")
+	assert.False(t, OrganizationAllowed(ctxWithAllowlist, ""), "unknown org fails closed when an allowlist is configured")
+}

--- a/pkg/mcp-official/tools/middleware/org_allowlist.go
+++ b/pkg/mcp-official/tools/middleware/org_allowlist.go
@@ -21,6 +21,10 @@ func OrganizationAllowlist(allowlist []string, logger *slog.Logger) mcp.Middlewa
 
 	return func(next mcp.MethodHandler) mcp.MethodHandler {
 		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+			// Expose the allowlist to ID-based tool handlers, which resolve the
+			// owning organization from the TFE API instead of a request argument.
+			ctx = tfeclient.WithOrganizationAllowlist(ctx, allowedOrganizations)
+
 			// Only tool calls carry an organization argument to check
 			if method != "tools/call" {
 				return next(ctx, method, req)
@@ -41,11 +45,7 @@ func OrganizationAllowlist(allowlist []string, logger *slog.Logger) mcp.Middlewa
 			}
 
 			organizationName := strings.ToLower(strings.TrimSpace(args.TerraformOrgName))
-			if organizationName == "" {
-				return next(ctx, method, req)
-			}
-
-			if _, ok := allowedOrganizations[organizationName]; !ok {
+			if organizationName != "" && !tfeclient.OrganizationAllowed(ctx, organizationName) {
 				logger.WarnContext(ctx, "rejecting tool call: organization not in allowlist",
 					"tool", params.Name, "organization", organizationName)
 				return &mcp.CallToolResult{

--- a/pkg/tools/tfe/action_run.go
+++ b/pkg/tools/tfe/action_run.go
@@ -59,18 +59,17 @@ func actionRunHandler(ctx context.Context, request mcp.CallToolRequest, logger *
 		return ToolError(logger, "failed to get Terraform client", err)
 	}
 
-	run, err := tfeClient.Runs.Read(ctx, runID)
+	run, err := tfeClient.Runs.ReadWithOptions(ctx, runID, &tfe.RunReadOptions{
+		Include: []tfe.RunIncludeOpt{tfe.RunWorkspace},
+	})
 	if err != nil {
 		return ToolErrorf(logger, "run not found: %s", runID)
 	}
-	if run.Workspace == nil {
-		return ToolErrorf(logger, "could not determine the workspace for run %s", runID)
+	var runOrg *tfe.Organization
+	if run.Workspace != nil {
+		runOrg = run.Workspace.Organization
 	}
-	workspace, err := tfeClient.Workspaces.ReadByID(ctx, run.Workspace.ID)
-	if err != nil {
-		return ToolErrorf(logger, "workspace not found for run %s: %v", runID, err)
-	}
-	if res, err := checkOrganizationAllowed(ctx, logger, "run", runID, workspace.Organization); res != nil {
+	if res, err := checkOrganizationAllowed(ctx, logger, "run", runID, runOrg); res != nil {
 		return res, err
 	}
 

--- a/pkg/tools/tfe/action_run.go
+++ b/pkg/tools/tfe/action_run.go
@@ -59,6 +59,21 @@ func actionRunHandler(ctx context.Context, request mcp.CallToolRequest, logger *
 		return ToolError(logger, "failed to get Terraform client", err)
 	}
 
+	run, err := tfeClient.Runs.Read(ctx, runID)
+	if err != nil {
+		return ToolErrorf(logger, "run not found: %s", runID)
+	}
+	if run.Workspace == nil {
+		return ToolErrorf(logger, "could not determine the workspace for run %s", runID)
+	}
+	workspace, err := tfeClient.Workspaces.ReadByID(ctx, run.Workspace.ID)
+	if err != nil {
+		return ToolErrorf(logger, "workspace not found for run %s: %v", runID, err)
+	}
+	if res, err := checkOrganizationAllowed(ctx, logger, "run", runID, workspace.Organization); res != nil {
+		return res, err
+	}
+
 	var msg string
 	switch runAction {
 	case "apply":

--- a/pkg/tools/tfe/add_team_member.go
+++ b/pkg/tools/tfe/add_team_member.go
@@ -67,6 +67,14 @@ func addTeamMemberHandler(ctx context.Context, request mcp.CallToolRequest, logg
 		return ToolError(logger, "Failed to get Terraform client - ensure TFE_TOKEN and TFE_ADDRESS are configured", nil)
 	}
 
+	org, err := teamOrganization(ctx, tfeClient, teamID)
+	if err != nil {
+		return ToolErrorf(logger, "team not found: %s", teamID)
+	}
+	if res, err := checkOrganizationAllowed(ctx, logger, "team", teamID, org); res != nil {
+		return res, err
+	}
+
 	options := tfe.TeamMemberAddOptions{}
 	var memberID string
 	if username != "" {

--- a/pkg/tools/tfe/create_no_code_workspace.go
+++ b/pkg/tools/tfe/create_no_code_workspace.go
@@ -87,6 +87,10 @@ func createNoCodeWorkspaceHandler(ctx context.Context, request mcp.CallToolReque
 		return ToolError(logger, err.Error(), nil)
 	}
 
+	if res, err := checkOrganizationAllowed(ctx, logger, "project", projectID, project.Organization); res != nil {
+		return res, err
+	}
+
 	// build the elicitation schema from the module's metadata and configured variable options
 	elicitationSchema := buildElicitationSchema(moduleMetadata, noCodeModule)
 

--- a/pkg/tools/tfe/delete_project.go
+++ b/pkg/tools/tfe/delete_project.go
@@ -48,6 +48,14 @@ func deleteProjectHandler(ctx context.Context, request mcp.CallToolRequest, logg
 		return ToolError(logger, "failed to get Terraform client - ensure TFE_TOKEN and TFE_ADDRESS are configured", err)
 	}
 
+	project, err := tfeClient.Projects.Read(ctx, projectID)
+	if err != nil {
+		return ToolErrorf(logger, "project not found: %s", projectID)
+	}
+	if res, err := checkOrganizationAllowed(ctx, logger, "project", projectID, project.Organization); res != nil {
+		return res, err
+	}
+
 	err = tfeClient.Projects.Delete(ctx, projectID)
 	if err != nil {
 		return ToolErrorf(logger, "failed to delete project %q: %v", projectID, err)

--- a/pkg/tools/tfe/delete_team.go
+++ b/pkg/tools/tfe/delete_team.go
@@ -51,6 +51,14 @@ func deleteTeamHandler(ctx context.Context, request mcp.CallToolRequest, logger 
 		return ToolError(logger, "Failed to get Terraform client - ensure TFE_TOKEN and TFE_ADDRESS are configured", nil)
 	}
 
+	org, err := teamOrganization(ctx, tfeClient, teamID)
+	if err != nil {
+		return ToolErrorf(logger, "team not found: %s", teamID)
+	}
+	if res, err := checkOrganizationAllowed(ctx, logger, "team", teamID, org); res != nil {
+		return res, err
+	}
+
 	err = tfeClient.Teams.Delete(ctx, teamID)
 	if err != nil {
 		return ToolErrorf(logger, "Failed to delete team %q: %v", teamID, err)

--- a/pkg/tools/tfe/delete_workspace_safely.go
+++ b/pkg/tools/tfe/delete_workspace_safely.go
@@ -52,6 +52,10 @@ func deleteWorkspaceSafelyHandler(ctx context.Context, request mcp.CallToolReque
 		return ToolErrorf(logger, "workspace not found: %s", workspaceID)
 	}
 
+	if res, err := checkOrganizationAllowed(ctx, logger, "workspace", workspaceID, workspace.Organization); res != nil {
+		return res, err
+	}
+
 	err = tfeClient.Workspaces.SafeDeleteByID(ctx, workspaceID)
 	if err != nil {
 		return ToolErrorf(logger, "failed to delete workspace '%s' - it may still have managed resources: %v", workspaceID, err)

--- a/pkg/tools/tfe/force_unlock_workspace.go
+++ b/pkg/tools/tfe/force_unlock_workspace.go
@@ -54,6 +54,10 @@ func forceUnlockWorkspace(ctx context.Context, request mcp.CallToolRequest, logg
 		return ToolErrorf(logger, "workspace not found: %s", workspaceID)
 	}
 
+	if res, err := checkOrganizationAllowed(ctx, logger, "workspace", workspaceID, workspace.Organization); res != nil {
+		return res, err
+	}
+
 	// Guard: Reject early if the
 	// workspace is not locked to avoid a misleading "resource not found" from
 	// the TFE API.

--- a/pkg/tools/tfe/get_state_version.go
+++ b/pkg/tools/tfe/get_state_version.go
@@ -55,12 +55,31 @@ func getStateVersionWithIDHandler(ctx context.Context, request mcp.CallToolReque
 		return ToolError(logger, "One of state_version_id or workspace_id must be provided", nil)
 	}
 	if stateVersionID != "" {
-		sv, err = tfeClient.StateVersions.Read(ctx, stateVersionID)
+		sv, err = tfeClient.StateVersions.ReadWithOptions(ctx, stateVersionID, &tfe.StateVersionReadOptions{
+			Include: []tfe.StateVersionIncludeOpt{tfe.SVrun},
+		})
 	} else {
 		sv, err = tfeClient.StateVersions.ReadCurrent(ctx, workspaceID)
 	}
 	if err != nil {
 		return ToolError(logger, "Failed to get state version", err)
+	}
+
+	// Enforce MCP_ORGANIZATION_ALLOWLIST against the owning workspace's organization.
+	owningWorkspaceID := workspaceID
+	if owningWorkspaceID == "" && sv.Run != nil && sv.Run.Workspace != nil {
+		owningWorkspaceID = sv.Run.Workspace.ID
+	}
+	var svOrg *tfe.Organization
+	if owningWorkspaceID != "" {
+		workspace, err := tfeClient.Workspaces.ReadByID(ctx, owningWorkspaceID)
+		if err != nil {
+			return ToolErrorf(logger, "failed to resolve workspace for state version %q: %v", sv.ID, err)
+		}
+		svOrg = workspace.Organization
+	}
+	if res, err := checkOrganizationAllowed(ctx, logger, "state version", sv.ID, svOrg); res != nil {
+		return res, err
 	}
 
 	buf := bytes.NewBuffer(nil)

--- a/pkg/tools/tfe/get_state_version.go
+++ b/pkg/tools/tfe/get_state_version.go
@@ -50,36 +50,41 @@ func getStateVersionWithIDHandler(ctx context.Context, request mcp.CallToolReque
 		return ToolError(logger, "Failed to get Terraform client - ensure TFE_TOKEN and TFE_ADDRESS are configured", nil)
 	}
 
-	var sv *tfe.StateVersion
 	if stateVersionID == "" && workspaceID == "" {
 		return ToolError(logger, "One of state_version_id or workspace_id must be provided", nil)
 	}
-	if stateVersionID != "" {
+
+	var sv *tfe.StateVersion
+	if workspaceID != "" {
+		workspace, err := tfeClient.Workspaces.ReadByID(ctx, workspaceID)
+		if err != nil {
+			return ToolErrorf(logger, "workspace not found: %s", workspaceID)
+		}
+		if res, err := checkOrganizationAllowed(ctx, logger, "workspace", workspaceID, workspace.Organization); res != nil {
+			return res, err
+		}
+		sv, err = tfeClient.StateVersions.ReadCurrent(ctx, workspaceID)
+		if err != nil {
+			return ToolError(logger, "Failed to get state version", err)
+		}
+	} else {
 		sv, err = tfeClient.StateVersions.ReadWithOptions(ctx, stateVersionID, &tfe.StateVersionReadOptions{
 			Include: []tfe.StateVersionIncludeOpt{tfe.SVrun},
 		})
-	} else {
-		sv, err = tfeClient.StateVersions.ReadCurrent(ctx, workspaceID)
-	}
-	if err != nil {
-		return ToolError(logger, "Failed to get state version", err)
-	}
-
-	// Enforce MCP_ORGANIZATION_ALLOWLIST against the owning workspace's organization.
-	owningWorkspaceID := workspaceID
-	if owningWorkspaceID == "" && sv.Run != nil && sv.Run.Workspace != nil {
-		owningWorkspaceID = sv.Run.Workspace.ID
-	}
-	var svOrg *tfe.Organization
-	if owningWorkspaceID != "" {
-		workspace, err := tfeClient.Workspaces.ReadByID(ctx, owningWorkspaceID)
 		if err != nil {
-			return ToolErrorf(logger, "failed to resolve workspace for state version %q: %v", sv.ID, err)
+			return ToolError(logger, "Failed to get state version", err)
 		}
-		svOrg = workspace.Organization
-	}
-	if res, err := checkOrganizationAllowed(ctx, logger, "state version", sv.ID, svOrg); res != nil {
-		return res, err
+		var svOrg *tfe.Organization
+		if sv.Run != nil && sv.Run.Workspace != nil {
+			workspace, err := tfeClient.Workspaces.ReadByID(ctx, sv.Run.Workspace.ID)
+			if err != nil {
+				return ToolErrorf(logger, "failed to resolve workspace for state version %q: %v", sv.ID, err)
+			}
+			svOrg = workspace.Organization
+		}
+		if res, err := checkOrganizationAllowed(ctx, logger, "state version", sv.ID, svOrg); res != nil {
+			return res, err
+		}
 	}
 
 	buf := bytes.NewBuffer(nil)

--- a/pkg/tools/tfe/grant_team_access.go
+++ b/pkg/tools/tfe/grant_team_access.go
@@ -88,26 +88,16 @@ func grantTeamAccessHandler(ctx context.Context, request mcp.CallToolRequest, lo
 	}
 
 	if workspaceID != "" {
+		if !slices.Contains(validTeamAccessLevels, accessLevel) {
+			return ToolErrorf(logger, "Invalid Team access level %q - must be one of: %s", accessLevel, validTeamAccessLevelsStr)
+		}
+
 		workspace, err := tfeClient.Workspaces.ReadByID(ctx, workspaceID)
 		if err != nil {
 			return ToolErrorf(logger, "workspace not found: %s", workspaceID)
 		}
 		if res, err := checkOrganizationAllowed(ctx, logger, "workspace", workspaceID, workspace.Organization); res != nil {
 			return res, err
-		}
-	} else {
-		project, err := tfeClient.Projects.Read(ctx, projectID)
-		if err != nil {
-			return ToolErrorf(logger, "project not found: %s", projectID)
-		}
-		if res, err := checkOrganizationAllowed(ctx, logger, "project", projectID, project.Organization); res != nil {
-			return res, err
-		}
-	}
-
-	if workspaceID != "" {
-		if !slices.Contains(validTeamAccessLevels, accessLevel) {
-			return ToolErrorf(logger, "Invalid Team access level %q - must be one of: %s", accessLevel, validTeamAccessLevelsStr)
 		}
 
 		ta, err := tfeClient.TeamAccess.Add(ctx, tfe.TeamAccessAddOptions{
@@ -133,6 +123,14 @@ func grantTeamAccessHandler(ctx context.Context, request mcp.CallToolRequest, lo
 
 	if !slices.Contains(validTeamProjectAccessLevels, accessLevel) {
 		return ToolErrorf(logger, "Invalid Team Project access level %q - must be one of: %s", accessLevel, validTeamProjectAccessLevelsStr)
+	}
+
+	project, err := tfeClient.Projects.Read(ctx, projectID)
+	if err != nil {
+		return ToolErrorf(logger, "project not found: %s", projectID)
+	}
+	if res, err := checkOrganizationAllowed(ctx, logger, "project", projectID, project.Organization); res != nil {
+		return res, err
 	}
 
 	tpa, err := tfeClient.TeamProjectAccess.Add(ctx, tfe.TeamProjectAccessAddOptions{

--- a/pkg/tools/tfe/grant_team_access.go
+++ b/pkg/tools/tfe/grant_team_access.go
@@ -88,6 +88,24 @@ func grantTeamAccessHandler(ctx context.Context, request mcp.CallToolRequest, lo
 	}
 
 	if workspaceID != "" {
+		workspace, err := tfeClient.Workspaces.ReadByID(ctx, workspaceID)
+		if err != nil {
+			return ToolErrorf(logger, "workspace not found: %s", workspaceID)
+		}
+		if res, err := checkOrganizationAllowed(ctx, logger, "workspace", workspaceID, workspace.Organization); res != nil {
+			return res, err
+		}
+	} else {
+		project, err := tfeClient.Projects.Read(ctx, projectID)
+		if err != nil {
+			return ToolErrorf(logger, "project not found: %s", projectID)
+		}
+		if res, err := checkOrganizationAllowed(ctx, logger, "project", projectID, project.Organization); res != nil {
+			return res, err
+		}
+	}
+
+	if workspaceID != "" {
 		if !slices.Contains(validTeamAccessLevels, accessLevel) {
 			return ToolErrorf(logger, "Invalid Team access level %q - must be one of: %s", accessLevel, validTeamAccessLevelsStr)
 		}

--- a/pkg/tools/tfe/organization_allowlist.go
+++ b/pkg/tools/tfe/organization_allowlist.go
@@ -5,6 +5,7 @@ package tools
 
 import (
 	"context"
+	"net/url"
 
 	"github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-mcp-server/pkg/client"
@@ -23,9 +24,17 @@ func checkOrganizationAllowed(ctx context.Context, logger *log.Logger, resource,
 	return ToolErrorf(logger, "%s %q belongs to organization %q, which is not allowed by this server", resource, resourceID, orgName)
 }
 
+func checkVariableSetOrganizationAllowed(ctx context.Context, tfeClient *tfe.Client, logger *log.Logger, varSetID string) (*mcp.CallToolResult, error) {
+	varSet, err := tfeClient.VariableSets.Read(ctx, varSetID, nil)
+	if err != nil {
+		return ToolErrorf(logger, "variable set not found: %s", varSetID)
+	}
+	return checkOrganizationAllowed(ctx, logger, "variable set", varSetID, varSet.Organization)
+}
+
 // go-tfe's Team type does not expose the organization relationship, so read it from the raw API.
 func teamOrganization(ctx context.Context, tfeClient *tfe.Client, teamID string) (*tfe.Organization, error) {
-	req, err := tfeClient.NewRequest("GET", "teams/"+teamID, nil)
+	req, err := tfeClient.NewRequest("GET", "teams/"+url.PathEscape(teamID), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tools/tfe/organization_allowlist.go
+++ b/pkg/tools/tfe/organization_allowlist.go
@@ -1,0 +1,40 @@
+// Copyright IBM Corp. 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package tools
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-mcp-server/pkg/client"
+	"github.com/mark3labs/mcp-go/mcp"
+	log "github.com/sirupsen/logrus"
+)
+
+func checkOrganizationAllowed(ctx context.Context, logger *log.Logger, resource, resourceID string, org *tfe.Organization) (*mcp.CallToolResult, error) {
+	orgName := ""
+	if org != nil {
+		orgName = org.Name
+	}
+	if client.OrganizationAllowed(ctx, orgName) {
+		return nil, nil
+	}
+	return ToolErrorf(logger, "%s %q belongs to organization %q, which is not allowed by this server", resource, resourceID, orgName)
+}
+
+// go-tfe's Team type does not expose the organization relationship, so read it from the raw API.
+func teamOrganization(ctx context.Context, tfeClient *tfe.Client, teamID string) (*tfe.Organization, error) {
+	req, err := tfeClient.NewRequest("GET", "teams/"+teamID, nil)
+	if err != nil {
+		return nil, err
+	}
+	team := &struct {
+		ID           string            `jsonapi:"primary,teams"`
+		Organization *tfe.Organization `jsonapi:"relation,organization"`
+	}{}
+	if err := req.Do(ctx, team); err != nil {
+		return nil, err
+	}
+	return team.Organization, nil
+}

--- a/pkg/tools/tfe/organization_allowlist_test.go
+++ b/pkg/tools/tfe/organization_allowlist_test.go
@@ -1,0 +1,49 @@
+// Copyright IBM Corp. 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package tools
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-mcp-server/pkg/client"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckOrganizationAllowed(t *testing.T) {
+	logger := log.New()
+	logger.SetLevel(log.ErrorLevel)
+
+	ctxWithAllowlist := client.WithOrganizationAllowlist(context.Background(),
+		client.BuildAllowedOrganizationsMap([]string{"allowed-org"}))
+
+	t.Run("no allowlist configured allows any organization", func(t *testing.T) {
+		res, err := checkOrganizationAllowed(context.Background(), logger, "workspace", "ws-1", &tfe.Organization{Name: "any-org"})
+		require.NoError(t, err)
+		assert.Nil(t, res)
+	})
+
+	t.Run("organization on the allowlist is allowed", func(t *testing.T) {
+		res, err := checkOrganizationAllowed(ctxWithAllowlist, logger, "workspace", "ws-1", &tfe.Organization{Name: "Allowed-Org"})
+		require.NoError(t, err)
+		assert.Nil(t, res)
+	})
+
+	t.Run("organization off the allowlist is rejected", func(t *testing.T) {
+		res, err := checkOrganizationAllowed(ctxWithAllowlist, logger, "workspace", "ws-1", &tfe.Organization{Name: "blocked-org"})
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		assert.True(t, res.IsError)
+	})
+
+	t.Run("unresolved organization fails closed when an allowlist is configured", func(t *testing.T) {
+		res, err := checkOrganizationAllowed(ctxWithAllowlist, logger, "team", "team-1", nil)
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		assert.True(t, res.IsError)
+	})
+}

--- a/pkg/tools/tfe/organization_allowlist_test.go
+++ b/pkg/tools/tfe/organization_allowlist_test.go
@@ -21,26 +21,20 @@ func TestCheckOrganizationAllowed(t *testing.T) {
 	ctxWithAllowlist := client.WithOrganizationAllowlist(context.Background(),
 		client.BuildAllowedOrganizationsMap([]string{"allowed-org"}))
 
-	t.Run("no allowlist configured allows any organization", func(t *testing.T) {
-		res, err := checkOrganizationAllowed(context.Background(), logger, "workspace", "ws-1", &tfe.Organization{Name: "any-org"})
+	t.Run("allowed organization returns no error result", func(t *testing.T) {
+		res, err := checkOrganizationAllowed(ctxWithAllowlist, logger, "workspace", "ws-1", &tfe.Organization{Name: "allowed-org"})
 		require.NoError(t, err)
 		assert.Nil(t, res)
 	})
 
-	t.Run("organization on the allowlist is allowed", func(t *testing.T) {
-		res, err := checkOrganizationAllowed(ctxWithAllowlist, logger, "workspace", "ws-1", &tfe.Organization{Name: "Allowed-Org"})
-		require.NoError(t, err)
-		assert.Nil(t, res)
-	})
-
-	t.Run("organization off the allowlist is rejected", func(t *testing.T) {
+	t.Run("disallowed organization returns an error result", func(t *testing.T) {
 		res, err := checkOrganizationAllowed(ctxWithAllowlist, logger, "workspace", "ws-1", &tfe.Organization{Name: "blocked-org"})
 		require.NoError(t, err)
 		require.NotNil(t, res)
 		assert.True(t, res.IsError)
 	})
 
-	t.Run("unresolved organization fails closed when an allowlist is configured", func(t *testing.T) {
+	t.Run("nil organization fails closed when an allowlist is configured", func(t *testing.T) {
 		res, err := checkOrganizationAllowed(ctxWithAllowlist, logger, "team", "team-1", nil)
 		require.NoError(t, err)
 		require.NotNil(t, res)

--- a/pkg/tools/tfe/policy_sets.go
+++ b/pkg/tools/tfe/policy_sets.go
@@ -68,6 +68,14 @@ func AttachPolicySetToWorkspaces(logger *log.Logger) server.ServerTool {
 				return ToolError(logger, "failed to get Terraform client", err)
 			}
 
+			policySet, err := tfeClient.PolicySets.Read(ctx, policySetID)
+			if err != nil {
+				return ToolErrorf(logger, "policy set not found: %s", policySetID)
+			}
+			if res, err := checkOrganizationAllowed(ctx, logger, "policy set", policySetID, policySet.Organization); res != nil {
+				return res, err
+			}
+
 			err = tfeClient.PolicySets.AddWorkspaces(ctx, policySetID, tfe.PolicySetAddWorkspacesOptions{
 				Workspaces: workspaces,
 			})

--- a/pkg/tools/tfe/variable_sets.go
+++ b/pkg/tools/tfe/variable_sets.go
@@ -194,11 +194,7 @@ func CreateVariableInVariableSet(logger *log.Logger) server.ServerTool {
 				return ToolError(logger, "failed to get Terraform client", err)
 			}
 
-			varSet, err := tfeClient.VariableSets.Read(ctx, varSetID, nil)
-			if err != nil {
-				return ToolErrorf(logger, "variable set not found: %s", varSetID)
-			}
-			if res, err := checkOrganizationAllowed(ctx, logger, "variable set", varSetID, varSet.Organization); res != nil {
+			if res, err := checkVariableSetOrganizationAllowed(ctx, tfeClient, logger, varSetID); res != nil {
 				return res, err
 			}
 
@@ -255,11 +251,7 @@ func DeleteVariableInVariableSet(logger *log.Logger) server.ServerTool {
 				return ToolError(logger, "failed to get Terraform client", err)
 			}
 
-			varSet, err := tfeClient.VariableSets.Read(ctx, varSetID, nil)
-			if err != nil {
-				return ToolErrorf(logger, "variable set not found: %s", varSetID)
-			}
-			if res, err := checkOrganizationAllowed(ctx, logger, "variable set", varSetID, varSet.Organization); res != nil {
+			if res, err := checkVariableSetOrganizationAllowed(ctx, tfeClient, logger, varSetID); res != nil {
 				return res, err
 			}
 
@@ -314,11 +306,7 @@ func AttachVariableSetToWorkspaces(logger *log.Logger) server.ServerTool {
 				return ToolError(logger, "failed to get Terraform client", err)
 			}
 
-			varSet, err := tfeClient.VariableSets.Read(ctx, varSetID, nil)
-			if err != nil {
-				return ToolErrorf(logger, "variable set not found: %s", varSetID)
-			}
-			if res, err := checkOrganizationAllowed(ctx, logger, "variable set", varSetID, varSet.Organization); res != nil {
+			if res, err := checkVariableSetOrganizationAllowed(ctx, tfeClient, logger, varSetID); res != nil {
 				return res, err
 			}
 
@@ -375,11 +363,7 @@ func DetachVariableSetFromWorkspaces(logger *log.Logger) server.ServerTool {
 				return ToolError(logger, "failed to get Terraform client", err)
 			}
 
-			varSet, err := tfeClient.VariableSets.Read(ctx, varSetID, nil)
-			if err != nil {
-				return ToolErrorf(logger, "variable set not found: %s", varSetID)
-			}
-			if res, err := checkOrganizationAllowed(ctx, logger, "variable set", varSetID, varSet.Organization); res != nil {
+			if res, err := checkVariableSetOrganizationAllowed(ctx, tfeClient, logger, varSetID); res != nil {
 				return res, err
 			}
 

--- a/pkg/tools/tfe/variable_sets.go
+++ b/pkg/tools/tfe/variable_sets.go
@@ -194,6 +194,14 @@ func CreateVariableInVariableSet(logger *log.Logger) server.ServerTool {
 				return ToolError(logger, "failed to get Terraform client", err)
 			}
 
+			varSet, err := tfeClient.VariableSets.Read(ctx, varSetID, nil)
+			if err != nil {
+				return ToolErrorf(logger, "variable set not found: %s", varSetID)
+			}
+			if res, err := checkOrganizationAllowed(ctx, logger, "variable set", varSetID, varSet.Organization); res != nil {
+				return res, err
+			}
+
 			variable, err := tfeClient.VariableSetVariables.Create(ctx, varSetID, &tfe.VariableSetVariableCreateOptions{
 				Key:         &key,
 				Value:       &value,
@@ -247,6 +255,14 @@ func DeleteVariableInVariableSet(logger *log.Logger) server.ServerTool {
 				return ToolError(logger, "failed to get Terraform client", err)
 			}
 
+			varSet, err := tfeClient.VariableSets.Read(ctx, varSetID, nil)
+			if err != nil {
+				return ToolErrorf(logger, "variable set not found: %s", varSetID)
+			}
+			if res, err := checkOrganizationAllowed(ctx, logger, "variable set", varSetID, varSet.Organization); res != nil {
+				return res, err
+			}
+
 			err = tfeClient.VariableSetVariables.Delete(ctx, varSetID, variableID)
 			if err != nil {
 				return ToolErrorf(logger, "failed to delete variable '%s' from variable set '%s': %v", variableID, varSetID, err)
@@ -296,6 +312,14 @@ func AttachVariableSetToWorkspaces(logger *log.Logger) server.ServerTool {
 			tfeClient, err := client.GetTfeClientFromContext(ctx, logger)
 			if err != nil {
 				return ToolError(logger, "failed to get Terraform client", err)
+			}
+
+			varSet, err := tfeClient.VariableSets.Read(ctx, varSetID, nil)
+			if err != nil {
+				return ToolErrorf(logger, "variable set not found: %s", varSetID)
+			}
+			if res, err := checkOrganizationAllowed(ctx, logger, "variable set", varSetID, varSet.Organization); res != nil {
+				return res, err
 			}
 
 			err = tfeClient.VariableSets.ApplyToWorkspaces(ctx, varSetID, &tfe.VariableSetApplyToWorkspacesOptions{
@@ -349,6 +373,14 @@ func DetachVariableSetFromWorkspaces(logger *log.Logger) server.ServerTool {
 			tfeClient, err := client.GetTfeClientFromContext(ctx, logger)
 			if err != nil {
 				return ToolError(logger, "failed to get Terraform client", err)
+			}
+
+			varSet, err := tfeClient.VariableSets.Read(ctx, varSetID, nil)
+			if err != nil {
+				return ToolErrorf(logger, "variable set not found: %s", varSetID)
+			}
+			if res, err := checkOrganizationAllowed(ctx, logger, "variable set", varSetID, varSet.Organization); res != nil {
+				return res, err
 			}
 
 			err = tfeClient.VariableSets.RemoveFromWorkspaces(ctx, varSetID, &tfe.VariableSetRemoveFromWorkspacesOptions{

--- a/test/terraform/organization_allowlist_test.go
+++ b/test/terraform/organization_allowlist_test.go
@@ -1,0 +1,144 @@
+// Copyright IBM Corp. 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package terraform
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/go-tfe"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// requireOrgAllowlistScenario skips unless MCP_ORGANIZATION_ALLOWLIST is set to a
+// list that excludes TFE_ORG_NAME and TFE_TOKEN can still reach an allowlisted org.
+// This must run against its own server: setting the allowlist on the shared hcpt
+// server would make every other hcpt test targeting TFE_ORG_NAME fail.
+func requireOrgAllowlistScenario(t *testing.T, client *tfe.Client) {
+	t.Helper()
+
+	allowlist := strings.TrimSpace(os.Getenv("MCP_ORGANIZATION_ALLOWLIST"))
+	if allowlist == "" {
+		t.Skip("requires MCP_ORGANIZATION_ALLOWLIST (matching the server) and a TFE_TOKEN with access to an allowlisted organization")
+	}
+
+	allowed := make(map[string]struct{})
+	for _, name := range strings.Split(allowlist, ",") {
+		name = strings.ToLower(strings.TrimSpace(name))
+		if name == "" {
+			continue
+		}
+		if name == strings.ToLower(tfeOrgName) {
+			t.Skipf("MCP_ORGANIZATION_ALLOWLIST %q must not include TFE_ORG_NAME (%q)", allowlist, tfeOrgName)
+		}
+		allowed[name] = struct{}{}
+	}
+
+	orgs, err := client.Organizations.List(t.Context(), &tfe.OrganizationListOptions{
+		ListOptions: tfe.ListOptions{PageSize: 100},
+	})
+	require.NoError(t, err, "failed to list organizations for the configured TFE_TOKEN")
+	for _, org := range orgs.Items {
+		if _, ok := allowed[strings.ToLower(org.Name)]; ok {
+			return
+		}
+	}
+	t.Skipf("TFE_TOKEN cannot reach any organization in MCP_ORGANIZATION_ALLOWLIST (%q); use a token with access to both %q and an allowlisted organization", allowlist, tfeOrgName)
+}
+
+func TestOrganizationAllowlistEnforcement(t *testing.T) {
+	requireTfOperations(t)
+
+	client := tfeClient(t)
+	requireOrgAllowlistScenario(t, client)
+	requireTeamsEntitlement(t, client)
+	requirePolicySetsEntitlement(t, client)
+
+	s := newTestingSession(t)
+	defer s.Close()
+
+	// Create every fixture directly via the TFE API so the tool call is the only
+	// operation under test.
+	workspace, err := client.Workspaces.Create(t.Context(), tfeOrgName, tfe.WorkspaceCreateOptions{
+		Name: tfe.String(randomName("allowlist-ws-")),
+	})
+	require.NoError(t, err, "setup: failed to create workspace via TFE API")
+	defer client.Workspaces.DeleteByID(t.Context(), workspace.ID)
+
+	project, err := client.Projects.Create(t.Context(), tfeOrgName, tfe.ProjectCreateOptions{
+		Name: randomName("allowlist-prj-"),
+	})
+	require.NoError(t, err, "setup: failed to create project via TFE API")
+	defer client.Projects.Delete(t.Context(), project.ID)
+
+	team, err := client.Teams.Create(t.Context(), tfeOrgName, tfe.TeamCreateOptions{
+		Name: tfe.String(randomName("allowlist-team-")),
+	})
+	require.NoError(t, err, "setup: failed to create team via TFE API")
+	defer client.Teams.Delete(t.Context(), team.ID)
+
+	varSet, err := client.VariableSets.Create(t.Context(), tfeOrgName, &tfe.VariableSetCreateOptions{
+		Name:   tfe.String(randomName("allowlist-vs-")),
+		Global: tfe.Bool(false),
+	})
+	require.NoError(t, err, "setup: failed to create variable set via TFE API")
+	defer client.VariableSets.Delete(t.Context(), varSet.ID)
+
+	variable, err := client.VariableSetVariables.Create(t.Context(), varSet.ID, &tfe.VariableSetVariableCreateOptions{
+		Key:      tfe.String("allowlist_test_key"),
+		Value:    tfe.String("value"),
+		Category: tfe.Category(tfe.CategoryTerraform),
+	})
+	require.NoError(t, err, "setup: failed to create variable in variable set via TFE API")
+
+	policySet, err := client.PolicySets.Create(t.Context(), tfeOrgName, tfe.PolicySetCreateOptions{
+		Name: tfe.String(randomName("allowlist-ps-")),
+	})
+	require.NoError(t, err, "setup: failed to create policy set via TFE API")
+	defer client.PolicySets.Delete(t.Context(), policySet.ID)
+
+	uploadConfiguration(t, client, workspace.ID, runTestConfiguration)
+	runMessage := "Created by terraform-mcp-server organization allowlist integration tests"
+	run, err := client.Runs.Create(t.Context(), tfe.RunCreateOptions{
+		Workspace: workspace,
+		AutoApply: tfe.Bool(false),
+		Message:   &runMessage,
+	})
+	require.NoError(t, err, "setup: failed to create run via TFE API")
+
+	// Every call must be rejected because its target belongs to TFE_ORG_NAME.
+	// Destructive tools are listed last so a regression surfaces as a clear list
+	// of leaked tools rather than a cascade of "not found".
+	cases := []struct {
+		name string
+		tool string
+		args map[string]any
+	}{
+		{"force_unlock_workspace", "force_unlock_workspace", map[string]any{"workspace_id": workspace.ID}},
+		{"action_run", "action_run", map[string]any{"run_action": "cancel", "run_id": run.ID}},
+		{"grant_team_access (workspace)", "grant_team_access", map[string]any{"team_id": team.ID, "access_level": "read", "workspace_id": workspace.ID}},
+		{"grant_team_access (project)", "grant_team_access", map[string]any{"team_id": team.ID, "access_level": "read", "project_id": project.ID}},
+		{"add_team_member", "add_team_member", map[string]any{"team_id": team.ID, "username": randomName("allowlist-user-")}},
+		{"get_state_version", "get_state_version", map[string]any{"workspace_id": workspace.ID}},
+		{"create_variable_in_variable_set", "create_variable_in_variable_set", map[string]any{"variable_set_id": varSet.ID, "key": "blocked", "value": "v"}},
+		{"delete_variable_in_variable_set", "delete_variable_in_variable_set", map[string]any{"variable_set_id": varSet.ID, "variable_id": variable.ID}},
+		{"attach_variable_set_to_workspaces", "attach_variable_set_to_workspaces", map[string]any{"variable_set_id": varSet.ID, "workspace_ids": workspace.ID}},
+		{"detach_variable_set_from_workspaces", "detach_variable_set_from_workspaces", map[string]any{"variable_set_id": varSet.ID, "workspace_ids": workspace.ID}},
+		{"attach_policy_set_to_workspaces", "attach_policy_set_to_workspaces", map[string]any{"policy_set_id": policySet.ID, "workspace_ids": workspace.ID}},
+		{"delete_workspace_safely", "delete_workspace_safely", map[string]any{"workspace_id": workspace.ID}},
+		{"delete_project", "delete_project", map[string]any{"project_id": project.ID}},
+		{"delete_team", "delete_team", map[string]any{"team_id": team.ID}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, resultText := callTool(t, s, tc.tool, tc.args)
+			require.True(t, result.IsError, "%s must be rejected by the organization allowlist", tc.tool)
+			assert.Contains(t, resultText, "is not allowed by this server", "%s rejection should cite the allowlist", tc.tool)
+			assert.Contains(t, resultText, tfeOrgName, "%s rejection should name the owning organization", tc.tool)
+		})
+	}
+}


### PR DESCRIPTION
# Summary
Fixes an organization allowlist bypass in 14 ID-based TFE operations: because these tools take an ID (workspace_id, run_id, team_id, …) rather than a `terraform_org_name` argument, they skipped the allowlist middleware entirely. That left only the HTTP gate, which merely proves the token can reach some allowlisted org, so any ID the token could reach was accepted — including resources in non-allowlisted orgs.

# Fix

- Each affected tool handler now resolves the resource's actual organization through the TFE API before acting on it.
- A shared `checkOrganizationAllowed` helper rejects resources whose organization is missing or not on the allowlist.
- The middleware exposes the configured allowlist through the request context so handlers can reach it.
- Teams are resolved with `GET /teams/:id`, because go-tfe's `Team` type does not expose its organization.

# Affected Tools

1. `force_unlock_workspace`
2. `delete_workspace_safely`
3. `action_run`
4. `grant_team_access`
5. `add_team_member`
6. `get_state_version`
7. `delete_project`
8. `delete_team`
9. `create_no_code_workspace`
10. `attach_policy_set_to_workspaces`
11. `create_variable_in_variable_set`
12. `delete_variable_in_variable_set`
13. `attach_variable_set_to_workspaces`
14. `detach_variable_set_from_workspaces`

# Testing

Manually tested all 14 tools in MCP Inspector under the following two configurations:

### Non-allowlisted organization

```
export TFE_ORG_NAME="terraform-ai-ecosystem-testing"
export MCP_ORGANIZATION_ALLOWLIST="terraform-ai-ecosystem-demo,jiayuechen_hashicorp_learn
```

Created workspace, team, project, variable set, variable, and policy set resources in the excluded `TFE_ORG_NAME`. All 14 affected operations were rejected with:

```
<resource> "<id>" belongs to organization "terraform-ai-ecosystem-testing", which is not allowed by this server
```

### Case-insensitive matching

```
export MCP_ORGANIZATION_ALLOWLIST="terraform-ai-ecosystem-Demo
```

- Resources in `terraform-ai-ecosystem-demo` were allowed.
- Resources in `terraform-ai-ecosystem-testing` remained blocked.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.