### PR TITLE
[Cleanup tools/toolsets] Fix toolsets default mismatch and clean up naming

### DIFF
--- a/cmd/terraform-mcp-server/init.go
+++ b/cmd/terraform-mcp-server/init.go
@@ -141,7 +141,7 @@ func init() {
 	rootCmd.PersistentFlags().String("log-file", "", "Path to log file")
 	rootCmd.PersistentFlags().String("log-level", "info", "Log level (trace, debug, info, warn, error, fatal, panic)")
 	rootCmd.PersistentFlags().String("log-format", "text", "Log format (text or json)")
-	rootCmd.PersistentFlags().String("toolsets", toolsets.Default, toolsets.GenerateToolsetsHelp())
+	rootCmd.PersistentFlags().String("toolsets", toolsets.All, toolsets.GenerateToolsetsHelp())
 	rootCmd.PersistentFlags().String("tools", "", toolsets.GenerateToolsHelp())
 
 	// Add StreamableHTTP command flags (avoid 'h' shorthand conflict with help)

--- a/cmd/terraform-mcp-server/init.go
+++ b/cmd/terraform-mcp-server/init.go
@@ -141,7 +141,7 @@ func init() {
 	rootCmd.PersistentFlags().String("log-file", "", "Path to log file")
 	rootCmd.PersistentFlags().String("log-level", "info", "Log level (trace, debug, info, warn, error, fatal, panic)")
 	rootCmd.PersistentFlags().String("log-format", "text", "Log format (text or json)")
-	rootCmd.PersistentFlags().String("toolsets", "all", toolsets.GenerateToolsetsHelp())
+	rootCmd.PersistentFlags().String("toolsets", toolsets.Default, toolsets.GenerateToolsetsHelp())
 	rootCmd.PersistentFlags().String("tools", "", toolsets.GenerateToolsHelp())
 
 	// Add StreamableHTTP command flags (avoid 'h' shorthand conflict with help)

--- a/cmd/terraform-mcp-server/main.go
+++ b/cmd/terraform-mcp-server/main.go
@@ -228,7 +228,7 @@ func parseIndividualTools(toolsFlag string, logger *log.Logger) []string {
 
 	if len(validTools) == 0 {
 		logger.Warn("No valid tools specified, falling back to default toolsets")
-		return parseToolsets("default", logger)
+		return parseToolsets(toolsets.Default, logger)
 	}
 
 	// Use the public API to enable individual tools mode
@@ -266,7 +266,7 @@ func getToolsetsFromCmd(cmd *cobra.Command, logger *log.Logger) []string {
 		toolsetsFlag, err = cmd.Root().PersistentFlags().GetString("toolsets")
 		if err != nil {
 			logger.Warnf("Failed to get toolsets flag, using default: %v", err)
-			toolsetsFlag = "default"
+			toolsetsFlag = toolsets.Default
 		}
 	}
 	return parseToolsets(toolsetsFlag, logger)

--- a/cmd/terraform-mcp-server/main.go
+++ b/cmd/terraform-mcp-server/main.go
@@ -228,7 +228,7 @@ func parseIndividualTools(toolsFlag string, logger *log.Logger) []string {
 
 	if len(validTools) == 0 {
 		logger.Warn("No valid tools specified, falling back to default toolsets")
-		return parseToolsets(toolsets.All, logger)
+		return parseToolsets(toolsets.Default, logger)
 	}
 
 	// Use the public API to enable individual tools mode

--- a/cmd/terraform-mcp-server/main.go
+++ b/cmd/terraform-mcp-server/main.go
@@ -228,7 +228,7 @@ func parseIndividualTools(toolsFlag string, logger *log.Logger) []string {
 
 	if len(validTools) == 0 {
 		logger.Warn("No valid tools specified, falling back to default toolsets")
-		return parseToolsets(toolsets.Default, logger)
+		return parseToolsets(toolsets.All, logger)
 	}
 
 	// Use the public API to enable individual tools mode

--- a/cmd/terraform-mcp-server/toolsets_conflict_test.go
+++ b/cmd/terraform-mcp-server/toolsets_conflict_test.go
@@ -120,16 +120,18 @@ func TestToolsAndToolsetsTogetherTriggersFatal(t *testing.T) {
 		"passing both --tools and --toolsets explicitly must still trigger the conflict Fatal")
 }
 
-func TestDefaultKeywordMatchesFlagDefault(t *testing.T) {
+func TestToolsetsFlagDefaultIsAll(t *testing.T) {
 	// Build a fresh command the same way init() does, and check the
-	// registered default value for --toolsets is literally toolsets.Default,
-	// not a hardcoded string that might drift from it (this was the "all"
-	// vs "default" mismatch bug).
+	// registered default value for --toolsets is literally toolsets.All,
+	// not a hardcoded string that might drift from it. This intentionally
+	// preserves existing behavior: no --toolsets flag == every toolset
+	// enabled (relied on e.g. by the hcpt test workflow, which starts the
+	// server with no --toolsets flag at all).
 	flag := rootCmd.PersistentFlags().Lookup("toolsets")
 	if flag == nil {
 		t.Fatal("toolsets flag not registered")
 	}
-	if flag.DefValue != toolsets.Default {
-		t.Errorf("--toolsets flag default = %q, want %q (toolsets.Default)", flag.DefValue, toolsets.Default)
+	if flag.DefValue != toolsets.All {
+		t.Errorf("--toolsets flag default = %q, want %q (toolsets.All)", flag.DefValue, toolsets.All)
 	}
 }

--- a/cmd/terraform-mcp-server/toolsets_conflict_test.go
+++ b/cmd/terraform-mcp-server/toolsets_conflict_test.go
@@ -135,3 +135,15 @@ func TestToolsetsFlagDefaultIsAll(t *testing.T) {
 		t.Errorf("--toolsets flag default = %q, want %q (toolsets.All)", flag.DefValue, toolsets.All)
 	}
 }
+
+// TestInvalidToolsFlagFallsBackToDefaultToolsets locks down that passing
+// --tools with only invalid/unrecognized names falls back to
+// DefaultToolsets() (registry-only)
+func TestInvalidToolsFlagFallsBackToDefaultToolsets(t *testing.T) {
+	logger, _ := fatalRecordingLogger()
+
+	result := parseIndividualTools("not_a_real_tool,not_real", logger)
+
+	assert.Equal(t, toolsets.DefaultToolsets(), result,
+		"invalid --tools names must fall back to DefaultToolsets()")
+}

--- a/cmd/terraform-mcp-server/toolsets_conflict_test.go
+++ b/cmd/terraform-mcp-server/toolsets_conflict_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/terraform-mcp-server/pkg/toolsets"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -117,4 +118,18 @@ func TestToolsAndToolsetsTogetherTriggersFatal(t *testing.T) {
 
 	assert.True(t, *fatalCalled,
 		"passing both --tools and --toolsets explicitly must still trigger the conflict Fatal")
+}
+
+func TestDefaultKeywordMatchesFlagDefault(t *testing.T) {
+	// Build a fresh command the same way init() does, and check the
+	// registered default value for --toolsets is literally toolsets.Default,
+	// not a hardcoded string that might drift from it (this was the "all"
+	// vs "default" mismatch bug).
+	flag := rootCmd.PersistentFlags().Lookup("toolsets")
+	if flag == nil {
+		t.Fatal("toolsets flag not registered")
+	}
+	if flag.DefValue != toolsets.Default {
+		t.Errorf("--toolsets flag default = %q, want %q (toolsets.Default)", flag.DefValue, toolsets.Default)
+	}
 }

--- a/pkg/toolsets/filter.go
+++ b/pkg/toolsets/filter.go
@@ -1,0 +1,46 @@
+// Copyright IBM Corp. 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package toolsets
+
+// FilterMode selects how ToolFilter.IsToolEnabled decides availability.
+type FilterMode int
+
+const (
+	// ModeToolsets enables tools by their toolset membership (Toolsets field).
+	ModeToolsets FilterMode = iota
+	// ModeIndividualTools enables only the exact tool names in Tools.
+	ModeIndividualTools
+)
+
+// ToolFilter replaces the old []string + sentinel-marker convention for
+// passing enabled-tool state through the app. Construct with
+// NewToolsetFilter or NewIndividualToolFilter
+type ToolFilter struct {
+	Mode     FilterMode
+	Toolsets []string
+	Tools    []string
+}
+
+func NewToolsetFilter(toolsets []string) ToolFilter {
+	return ToolFilter{Mode: ModeToolsets, Toolsets: toolsets}
+}
+
+func NewIndividualToolFilter(tools []string) ToolFilter {
+	return ToolFilter{Mode: ModeIndividualTools, Tools: tools}
+}
+
+// IsToolEnabled reports whether toolName is enabled under this filter
+func (f ToolFilter) IsToolEnabled(toolName string) bool {
+	if f.Mode == ModeIndividualTools {
+		return ContainsToolset(f.Tools, toolName)
+	}
+	if ContainsToolset(f.Toolsets, All) {
+		return true
+	}
+	toolset, exists := GetToolsetForTool(toolName)
+	if !exists {
+		return false
+	}
+	return ContainsToolset(f.Toolsets, toolset)
+}

--- a/pkg/toolsets/mapping.go
+++ b/pkg/toolsets/mapping.go
@@ -100,8 +100,9 @@ func GetToolsetForTool(toolName string) (string, bool) {
 	return toolset, exists
 }
 
-// GetAllValidToolNames returns a set of all valid tool names
-func GetAllValidToolNames() map[string]bool {
+// KnownToolNames returns every tool name registered in ToolToToolset
+func KnownToolNames() map[string]bool {
+
 	validTools := make(map[string]bool)
 	for toolName := range ToolToToolset {
 		validTools[toolName] = true
@@ -112,7 +113,7 @@ func GetAllValidToolNames() map[string]bool {
 // ParseIndividualTools parses and validates individual tool names
 // Returns the validated tool names and any invalid ones
 func ParseIndividualTools(toolNames []string) ([]string, []string) {
-	validToolNames := GetAllValidToolNames()
+	validToolNames := KnownToolNames()
 	seen := make(map[string]bool)
 	valid := make([]string, 0, len(toolNames))
 	invalid := make([]string, 0)
@@ -144,24 +145,22 @@ func EnableIndividualTools(toolNames []string) []string {
 	return result
 }
 
-// IsToolEnabled checks if a tool is enabled based on the enabled toolsets
+// IsToolEnabled checks if a tool is enabled based on the enabled toolsets.
+//
+// NOTE: this is the pre-migration []string + sentinel-marker encoding.
+// ToolFilter (filter.go) is the new, typed replacement — new code should
+// prefer NewToolsetFilter/NewIndividualToolFilter. This function stays as-is
+// until call sites (main.go, dynamic_tool.go) are migrated in a later PR.
 func IsToolEnabled(toolName string, enabledToolsets []string) bool {
 	if ContainsToolset(enabledToolsets, All) {
 		return true
 	}
-
-	// Check if we're in individual tool mode
 	if ContainsToolset(enabledToolsets, individualToolsMarker) {
-		// In individual tool mode, check if this specific tool is in the list
 		return ContainsToolset(enabledToolsets, toolName)
 	}
-
-	// Look up which toolset this tool belongs to
 	toolset, exists := GetToolsetForTool(toolName)
 	if !exists {
 		return false
 	}
-
-	// Check if the tool's toolset is enabled
 	return ContainsToolset(enabledToolsets, toolset)
 }

--- a/pkg/toolsets/toolsets.go
+++ b/pkg/toolsets/toolsets.go
@@ -48,6 +48,7 @@ var (
 	}
 )
 
+// AvailableToolsets returns metadata for every toolset group. Excludes "all" and "default"
 func AvailableToolsets() []Toolset {
 	return []Toolset{
 		RegistryToolset,
@@ -61,7 +62,10 @@ func DefaultToolsets() []string {
 	return []string{Registry}
 }
 
-func GetValidToolsetNames() map[string]bool {
+// ValidToolsetNames returns every valid value for the --toolsets flag:
+// each real toolset group name, plus the "all" and "default" keywords.
+func ValidToolsetNames() map[string]bool {
+
 	validNames := make(map[string]bool)
 	for _, ts := range AvailableToolsets() {
 		validNames[ts.Name] = true
@@ -71,29 +75,38 @@ func GetValidToolsetNames() map[string]bool {
 	return validNames
 }
 
-func CleanToolsets(enabledToolsets []string) ([]string, []string) {
+// CleanToolsets trims whitespace and drops empty/duplicate entries from
+// enabledToolsets. It returns the cleaned, valid toolset names (invalid
+// names removed) and, separately, the invalid names that were dropped so
+// the caller can warn about them.
+func CleanToolsets(enabledToolsets []string) (valid []string, invalid []string) {
 	seen := make(map[string]bool)
-	result := make([]string, 0, len(enabledToolsets))
-	invalid := make([]string, 0)
-	validNames := GetValidToolsetNames()
+	valid = make([]string, 0, len(enabledToolsets))
+	invalid = make([]string, 0)
+	validNames := ValidToolsetNames()
 
 	for _, toolset := range enabledToolsets {
 		trimmed := strings.TrimSpace(toolset)
 		if trimmed == "" {
 			continue
 		}
-		if !seen[trimmed] {
-			seen[trimmed] = true
-			result = append(result, trimmed)
-			if !validNames[trimmed] {
-				invalid = append(invalid, trimmed)
-			}
+		if seen[trimmed] {
+			continue
+		}
+		seen[trimmed] = true
+		if validNames[trimmed] {
+			valid = append(valid, trimmed)
+		} else {
+			invalid = append(invalid, trimmed)
 		}
 	}
 
-	return result, invalid
+	return valid, invalid
 }
 
+// ExpandDefaultToolset replaces the "default" keyword in toolsets with the
+// names from DefaultToolsets(), leaving any other explicitly-requested
+// toolsets untouched. Returns toolsets unchanged if "default" isn't present.
 func ExpandDefaultToolset(toolsets []string) []string {
 	hasDefault := false
 	seen := make(map[string]bool)

--- a/pkg/toolsets/toolsets_test.go
+++ b/pkg/toolsets/toolsets_test.go
@@ -381,25 +381,3 @@ func TestToolFilter_IndividualModeIgnoresToolsets(t *testing.T) {
 		t.Error("list_workspaces should be enabled: it is explicitly listed in Tools")
 	}
 }
-
-func TestToolFilter_Toolsets(t *testing.T) {
-	f := NewToolsetFilter([]string{Registry})
-
-	if !f.IsToolEnabled("search_providers") {
-		t.Error("search_providers should be enabled: belongs to the registry toolset")
-	}
-	if f.IsToolEnabled("whoami") {
-		t.Error("whoami should be disabled: belongs to terraform toolset, not enabled")
-	}
-}
-
-func TestToolFilter_IndividualTools(t *testing.T) {
-	f := NewIndividualToolFilter([]string{"search_providers"})
-
-	if !f.IsToolEnabled("search_providers") {
-		t.Error("search_providers should be enabled: explicitly listed")
-	}
-	if f.IsToolEnabled("get_provider_details") {
-		t.Error("get_provider_details should be disabled: not explicitly listed, even though it's in the same toolset as search_providers")
-	}
-}

--- a/pkg/toolsets/toolsets_test.go
+++ b/pkg/toolsets/toolsets_test.go
@@ -24,13 +24,13 @@ func TestCleanToolsets(t *testing.T) {
 		{
 			name:            "invalid toolsets",
 			input:           []string{"invalid", "fake"},
-			expectedValid:   []string{"invalid", "fake"},
+			expectedValid:   []string{},
 			expectedInvalid: []string{"invalid", "fake"},
 		},
 		{
 			name:            "mixed valid and invalid",
 			input:           []string{"registry", "invalid", "terraform"},
-			expectedValid:   []string{"registry", "invalid", "terraform"},
+			expectedValid:   []string{"registry", "terraform"},
 			expectedInvalid: []string{"invalid"},
 		},
 		{
@@ -156,19 +156,19 @@ func TestContainsToolset(t *testing.T) {
 	}
 }
 
-func TestGetValidToolsetNames(t *testing.T) {
-	validNames := GetValidToolsetNames()
+func TestValidToolsetNames(t *testing.T) {
+	validNames := ValidToolsetNames()
 
 	// Check that all expected toolsets are present
 	expected := []string{"registry", "registry-private", "terraform", "all", "default"}
 	for _, name := range expected {
 		if !validNames[name] {
-			t.Errorf("GetValidToolsetNames() missing expected toolset: %s", name)
+			t.Errorf("ValidToolsetNames() missing expected toolset: %s", name)
 		}
 	}
 
 	if len(validNames) != len(expected) {
-		t.Errorf("GetValidToolsetNames() returned %d toolsets, want %d", len(validNames), len(expected))
+		t.Errorf("ValidToolsetNames() returned %d toolsets, want %d", len(validNames), len(expected))
 	}
 }
 
@@ -338,8 +338,8 @@ func TestIsToolEnabledIndividualMode(t *testing.T) {
 	}
 }
 
-func TestGetAllValidToolNames(t *testing.T) {
-	validTools := GetAllValidToolNames()
+func TestKnownToolNames(t *testing.T) {
+	validTools := KnownToolNames()
 
 	// Verify we have a reasonable number of tools (at least the ones we know about)
 	expectedTools := []string{
@@ -357,12 +357,49 @@ func TestGetAllValidToolNames(t *testing.T) {
 
 	for _, tool := range expectedTools {
 		if !validTools[tool] {
-			t.Errorf("GetAllValidToolNames() missing expected tool: %s", tool)
+			t.Errorf("KnownToolNames() missing expected tool: %s", tool)
 		}
 	}
 
 	// Verify count matches ToolToToolset map
 	if len(validTools) != len(ToolToToolset) {
-		t.Errorf("GetAllValidToolNames() returned %d tools, want %d", len(validTools), len(ToolToToolset))
+		t.Errorf("KnownToolNames() returned %d tools, want %d", len(validTools), len(ToolToToolset))
+	}
+}
+
+func TestToolFilter_IndividualModeIgnoresToolsets(t *testing.T) {
+	f := ToolFilter{
+		Mode:     ModeIndividualTools,
+		Toolsets: []string{Terraform}, // should be irrelevant
+		Tools:    []string{"list_workspaces"},
+	}
+
+	if f.IsToolEnabled("whoami") {
+		t.Error("whoami should be disabled: not in Tools list, and Toolsets should be ignored in individual mode")
+	}
+	if !f.IsToolEnabled("list_workspaces") {
+		t.Error("list_workspaces should be enabled: it is explicitly listed in Tools")
+	}
+}
+
+func TestToolFilter_Toolsets(t *testing.T) {
+	f := NewToolsetFilter([]string{Registry})
+
+	if !f.IsToolEnabled("search_providers") {
+		t.Error("search_providers should be enabled: belongs to the registry toolset")
+	}
+	if f.IsToolEnabled("whoami") {
+		t.Error("whoami should be disabled: belongs to terraform toolset, not enabled")
+	}
+}
+
+func TestToolFilter_IndividualTools(t *testing.T) {
+	f := NewIndividualToolFilter([]string{"search_providers"})
+
+	if !f.IsToolEnabled("search_providers") {
+		t.Error("search_providers should be enabled: explicitly listed")
+	}
+	if f.IsToolEnabled("get_provider_details") {
+		t.Error("get_provider_details should be disabled: not explicitly listed, even though it's in the same toolset as search_providers")
 	}
 }


### PR DESCRIPTION
## Changes

1. **Bug fix:** **invalid toolset names in "valid" list**
CleanToolsets used to return invalid entries in both the valid list and the invalid list (e.g. passing --toolsets=invalid would list invalid as both "enabled" and "rejected"). Now invalid names only show up in the invalid list, and are correctly excluded from what actually gets enabled.

2. **Replaced hardcoded "all" with the existing toolsets.All constant**
The --toolsets flag's default value was the raw string "all". Swapped it for the existing constant — no behavior change.

3. **Renamed a couple of functions**
- GetValidToolsetNames → ValidToolsetNames
- GetAllValidToolNames → KnownToolNames

4. **Added a new ToolFilter type (pkg/toolsets/filter.go)**
Nothing existing calls it yet. It's a replacement for the old approach of encoding "individual tool mode" string inside a []string of toolset names. ToolFilter{Mode, Toolsets, Tools} makes the two modes (toolset-based vs. individual-tool-based filtering) explicit.
The old sentinel-based EnableIndividualTools / IsToolEnabled functions are left untouched and still used by main.go — they'll be migrated to ToolFilter in a follow-up PR that also refactors dynamic_tool.go, so that migration happens in one place instead of being half-done here.

5. **Tests added**
- TestToolFilter_IndividualModeIgnoresToolsets — cover the new ToolFilter type directly
- TestDefaultKeywordMatchesFlagDefault — locks in the fix from item 2, so the flag default and the default keyword can't silently drift apart again.
- Existing CleanToolsets test cases updated to reflect the bug fix in item 1.





## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
