### PR TITLE
[Cleanup tools/toolsets] Replace duplicated tool registration logic with a single tool registry

### DIFF
--- a/cmd/terraform-mcp-server/init.go
+++ b/cmd/terraform-mcp-server/init.go
@@ -250,8 +250,8 @@ func initLogger(outPath string, level log.Level, format string) (*log.Logger, er
 }
 
 // registerToolsAndResources registers tools and resources with the MCP server
-func registerToolsAndResources(hcServer *server.MCPServer, logger *log.Logger, enabledToolsets []string) {
-	tools.RegisterTools(hcServer, logger, enabledToolsets)
+func registerToolsAndResources(hcServer *server.MCPServer, logger *log.Logger, filter toolsets.ToolFilter) {
+	tools.RegisterTools(hcServer, logger, filter)
 	resources.RegisterResources(hcServer, logger)
 	resources.RegisterResourceTemplates(hcServer, logger)
 }
@@ -301,7 +301,7 @@ func setupInstana(logger *log.Logger) instana.TracerLogger {
 	})
 }
 
-func streamableHTTPServerInit(ctx context.Context, hcServer *server.MCPServer, logger *log.Logger, host string, port string, endpointPath string, heartbeatInterval time.Duration, organizationAllowlist []string, enabledToolsets []string, rateLimiter *client.RateLimitMiddleware, metricsConfig client.MetricsConfig) error {
+func streamableHTTPServerInit(ctx context.Context, hcServer *server.MCPServer, logger *log.Logger, host string, port string, endpointPath string, heartbeatInterval time.Duration, organizationAllowlist []string, filter toolsets.ToolFilter, rateLimiter *client.RateLimitMiddleware, metricsConfig client.MetricsConfig) error {
 	// Ensure endpoint path starts with /
 	endpointPath = path.Join("/", endpointPath)
 	var handler http.Handler
@@ -370,7 +370,7 @@ func streamableHTTPServerInit(ctx context.Context, hcServer *server.MCPServer, l
 	// Create the official go-sdk streamable server
 	if enableOfficialSDK := os.Getenv("TF_X_OFFICIAL_SDK_ENABLED"); enableOfficialSDK == "true" {
 		logger.Info("TF_X_OFFICIAL_SDK_ENABLED set to true in env, enabling the official mcp go-sdk server")
-		officialStreamableServer := getOfficialStreamableServer(ctx, heartbeatInterval, isStateless, corsConfig, logger, organizationAllowlist, enabledToolsets, rateLimiter, metricsConfig)
+		officialStreamableServer := getOfficialStreamableServer(ctx, heartbeatInterval, isStateless, corsConfig, logger, organizationAllowlist, filter, rateLimiter, metricsConfig)
 		// Handle the /mcp endpoint with the official go-sdk streamable server (with security wrapper)
 		mux.Handle(endpointPath+"/official", officialStreamableServer)
 		mux.Handle(endpointPath+"/official/", officialStreamableServer)
@@ -459,7 +459,7 @@ func streamableHTTPServerInit(ctx context.Context, hcServer *server.MCPServer, l
 	return nil
 }
 
-func getOfficialStreamableServer(ctx context.Context, heartbeatInterval time.Duration, isStateless bool, corsConfig client.CORSConfig, logger *log.Logger, organizationAllowlist []string, enabledToolsets []string, rateLimiter *client.RateLimitMiddleware, metricsConfig client.MetricsConfig) http.Handler {
+func getOfficialStreamableServer(ctx context.Context, heartbeatInterval time.Duration, isStateless bool, corsConfig client.CORSConfig, logger *log.Logger, organizationAllowlist []string, filter toolsets.ToolFilter, rateLimiter *client.RateLimitMiddleware, metricsConfig client.MetricsConfig) http.Handler {
 	logger.Info("Creating a go-sdk StreamableHTTP server...")
 	slogLogger := newSlogLogger(logger)
 
@@ -495,7 +495,7 @@ func getOfficialStreamableServer(ctx context.Context, heartbeatInterval time.Dur
 			}()
 		}),
 	}
-	hcServer := mcpofficial.NewServer(version.Version, instructions, heartbeatInterval, logger, enabledToolsets, serverOpts...)
+	hcServer := mcpofficial.NewServer(version.Version, instructions, heartbeatInterval, logger, filter, serverOpts...)
 
 	opts := &mcp.StreamableHTTPOptions{
 		Stateless:             isStateless,

--- a/cmd/terraform-mcp-server/main.go
+++ b/cmd/terraform-mcp-server/main.go
@@ -36,7 +36,7 @@ import (
 var instructions string
 var sessionClientInfo sync.Map // map[string]client.ClientInfo
 
-func runHTTPServer(logger *log.Logger, host string, port string, endpointPath string, heartbeatInterval time.Duration, enabledToolsets []string, metricsConfig client.MetricsConfig, organizationAllowlist []string) error {
+func runHTTPServer(logger *log.Logger, host string, port string, endpointPath string, heartbeatInterval time.Duration, filter toolsets.ToolFilter, metricsConfig client.MetricsConfig, organizationAllowlist []string) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
@@ -59,11 +59,11 @@ func runHTTPServer(logger *log.Logger, host string, port string, endpointPath st
 	hcServer, rateLimiter := NewServer(
 		version.Version,
 		logger,
-		enabledToolsets,
+		filter,
 		serverOpts...,
 	)
 
-	registerToolsAndResources(hcServer, logger, enabledToolsets)
+	registerToolsAndResources(hcServer, logger, filter)
 
 	hooks.AddOnUnregisterSession(func(ctx context.Context, session server.ClientSession) {
 		// Clean up client info populated in the metrics hooks, for the session
@@ -89,7 +89,7 @@ func runHTTPServer(logger *log.Logger, host string, port string, endpointPath st
 	})
 	attachMetricsHooks(hooks, metricsConfig, logger)
 
-	return streamableHTTPServerInit(ctx, hcServer, logger, host, port, endpointPath, heartbeatInterval, organizationAllowlist, enabledToolsets, rateLimiter, metricsConfig)
+	return streamableHTTPServerInit(ctx, hcServer, logger, host, port, endpointPath, heartbeatInterval, organizationAllowlist, filter, rateLimiter, metricsConfig)
 }
 
 func attachMetricsHooks(hooks *server.Hooks, metricsConfig client.MetricsConfig, logger *log.Logger) {
@@ -158,7 +158,7 @@ func attachMetricsHooks(hooks *server.Hooks, metricsConfig client.MetricsConfig,
 	})
 }
 
-func runStdioServer(logger *log.Logger, enabledToolsets []string) error {
+func runStdioServer(logger *log.Logger, filter toolsets.ToolFilter) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
@@ -167,8 +167,8 @@ func runStdioServer(logger *log.Logger, enabledToolsets []string) error {
 	hooks.AddOnRegisterSession(func(ctx context.Context, session server.ClientSession) {
 		client.NewSessionHandler(ctx, session.SessionID(), logger)
 	})
-	hcServer, rateLimiter := NewServer(version.Version, logger, enabledToolsets, server.WithHooks(hooks))
-	registerToolsAndResources(hcServer, logger, enabledToolsets)
+	hcServer, rateLimiter := NewServer(version.Version, logger, filter, server.WithHooks(hooks))
+	registerToolsAndResources(hcServer, logger, filter)
 
 	hooks.AddOnUnregisterSession(func(ctx context.Context, session server.ClientSession) {
 		client.EndSessionHandler(ctx, session.SessionID(), rateLimiter, logger)
@@ -177,7 +177,9 @@ func runStdioServer(logger *log.Logger, enabledToolsets []string) error {
 	return serverInit(ctx, hcServer, logger)
 }
 
-func NewServer(version string, logger *log.Logger, enabledToolsets []string, opts ...server.ServerOption) (*server.MCPServer, *client.RateLimitMiddleware) {
+func NewServer(version string, logger *log.Logger, filter toolsets.ToolFilter, opts ...server.ServerOption) (*server.MCPServer, *client.RateLimitMiddleware) {
+	// filter is accepted for signature symmetry with runHTTPServer/runStdioServer, actual tool gating happens in registerToolsAndResources -> tools.RegisterTools.
+
 	// Create rate limiting middleware with environment-based configuration
 	rateLimitConfig := client.LoadRateLimitConfigFromEnv()
 	rateLimitMiddleware := client.NewRateLimitMiddleware(rateLimitConfig, logger)
@@ -203,7 +205,7 @@ func NewServer(version string, logger *log.Logger, enabledToolsets []string, opt
 }
 
 // parseToolsets parses and validates the toolsets flag value
-func parseToolsets(toolsetsFlag string, logger *log.Logger) []string {
+func parseToolsets(toolsetsFlag string, logger *log.Logger) toolsets.ToolFilter {
 	rawToolsets := strings.Split(toolsetsFlag, ",")
 
 	cleaned, invalid := toolsets.CleanToolsets(rawToolsets)
@@ -214,11 +216,11 @@ func parseToolsets(toolsetsFlag string, logger *log.Logger) []string {
 	expanded := toolsets.ExpandDefaultToolset(cleaned)
 
 	logger.Infof("Enabled toolsets: %v", expanded)
-	return expanded
+	return toolsets.NewToolsetFilter(expanded)
 }
 
 // parseIndividualTools parses and validates the tools flag value
-func parseIndividualTools(toolsFlag string, logger *log.Logger) []string {
+func parseIndividualTools(toolsFlag string, logger *log.Logger) toolsets.ToolFilter {
 	rawTools := strings.Split(toolsFlag, ",")
 
 	validTools, invalidTools := toolsets.ParseIndividualTools(rawTools)
@@ -230,14 +232,11 @@ func parseIndividualTools(toolsFlag string, logger *log.Logger) []string {
 		logger.Warn("No valid tools specified, falling back to default toolsets")
 		return parseToolsets(toolsets.Default, logger)
 	}
-
-	// Use the public API to enable individual tools mode
-	result := toolsets.EnableIndividualTools(validTools)
 	logger.Infof("Enabled individual tools: %v", validTools)
-	return result
+	return toolsets.NewIndividualToolFilter(validTools)
 }
 
-func getToolsetsFromCmd(cmd *cobra.Command, logger *log.Logger) []string {
+func getToolsetsFromCmd(cmd *cobra.Command, logger *log.Logger) toolsets.ToolFilter {
 	// Check if --tools flag is set (individual tool mode)
 	toolsFlag, err := cmd.Flags().GetString("tools")
 	if err != nil {
@@ -287,9 +286,9 @@ func runDefaultCommand(cmd *cobra.Command, _ []string) {
 	}
 
 	// Get toolsets from the command that was passed in
-	enabledToolsets := getToolsetsFromCmd(cmd, logger)
+	filter := getToolsetsFromCmd(cmd, logger)
 
-	if err := runStdioServer(logger, enabledToolsets); err != nil {
+	if err := runStdioServer(logger, filter); err != nil {
 		stdlog.Fatal("failed to run stdio server:", err)
 	}
 }
@@ -311,13 +310,13 @@ func main() {
 		port := getHTTPPort()
 		host := getHTTPHost()
 		endpointPath := getEndpointPath(nil)
-		enabledToolsets := getToolsetsFromCmd(rootCmd, logger)
+		filter := getToolsetsFromCmd(rootCmd, logger)
 		heartbeatInterval := getHeartbeatInterval()
 		organizationAllowlist, err := getOrganizationAllowlist(rootCmd)
 		if err != nil {
 			stdlog.Fatal(err)
 		}
-		if err := runHTTPServer(logger, host, port, endpointPath, heartbeatInterval, enabledToolsets, metricsConfig, organizationAllowlist); err != nil {
+		if err := runHTTPServer(logger, host, port, endpointPath, heartbeatInterval, filter, metricsConfig, organizationAllowlist); err != nil {
 			stdlog.Fatal("failed to run StreamableHTTP server:", err)
 		}
 		return

--- a/cmd/terraform-mcp-server/main.go
+++ b/cmd/terraform-mcp-server/main.go
@@ -228,7 +228,7 @@ func parseIndividualTools(toolsFlag string, logger *log.Logger) []string {
 
 	if len(validTools) == 0 {
 		logger.Warn("No valid tools specified, falling back to default toolsets")
-		return parseToolsets(toolsets.All, logger)
+		return parseToolsets(toolsets.Default, logger)
 	}
 
 	// Use the public API to enable individual tools mode

--- a/cmd/terraform-mcp-server/main.go
+++ b/cmd/terraform-mcp-server/main.go
@@ -228,7 +228,7 @@ func parseIndividualTools(toolsFlag string, logger *log.Logger) []string {
 
 	if len(validTools) == 0 {
 		logger.Warn("No valid tools specified, falling back to default toolsets")
-		return parseToolsets(toolsets.Default, logger)
+		return parseToolsets(toolsets.All, logger)
 	}
 
 	// Use the public API to enable individual tools mode

--- a/cmd/terraform-mcp-server/main_metrics_test.go
+++ b/cmd/terraform-mcp-server/main_metrics_test.go
@@ -12,6 +12,7 @@ import (
 	"unsafe"
 
 	"github.com/hashicorp/terraform-mcp-server/pkg/client"
+	"github.com/hashicorp/terraform-mcp-server/pkg/toolsets"
 	"github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
 	log "github.com/sirupsen/logrus"
@@ -269,7 +270,7 @@ func TestNewServerWithHooksOptionPassesThrough(t *testing.T) {
 	customHooks := &mcpserver.Hooks{}
 	customHooks.AddBeforeCallTool(func(ctx context.Context, id any, message *mcp.CallToolRequest) {})
 
-	srv, _ := NewServer("test-version", metricsTestLogger(), nil, mcpserver.WithHooks(customHooks))
+	srv, _ := NewServer("test-version", metricsTestLogger(), toolsets.ToolFilter{}, mcpserver.WithHooks(customHooks))
 	hooks := getServerHooksForTest(t, srv)
 
 	require.GreaterOrEqual(t, len(hooks.OnBeforeCallTool), 1)

--- a/cmd/terraform-mcp-server/session_lifecycle_test.go
+++ b/cmd/terraform-mcp-server/session_lifecycle_test.go
@@ -13,6 +13,7 @@ import (
 	"unsafe"
 
 	"github.com/hashicorp/terraform-mcp-server/pkg/client"
+	"github.com/hashicorp/terraform-mcp-server/pkg/toolsets"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -64,7 +65,7 @@ func TestGetOfficialStreamableServer_SessionLifecycle(t *testing.T) {
 		client.CORSConfig{Mode: "disabled"},
 		logger,
 		nil, // organizationAllowlist
-		[]string{"list_workspaces"},
+		toolsets.NewToolsetFilter([]string{"list_workspaces"}),
 		rateLimiter,
 		client.MetricsConfig{Enabled: false},
 	)

--- a/cmd/terraform-mcp-server/toolsets_conflict_test.go
+++ b/cmd/terraform-mcp-server/toolsets_conflict_test.go
@@ -75,7 +75,7 @@ func TestToolsFlagAloneDoesNotConflictWithDefaultToolsets(t *testing.T) {
 	}
 
 	logger, fatalCalled := fatalRecordingLogger()
-	var captured []string
+	var captured toolsets.ToolFilter
 	rootCmd.Run = func(cmd *cobra.Command, _ []string) {
 		captured = getToolsetsFromCmd(cmd, logger)
 	}
@@ -85,8 +85,9 @@ func TestToolsFlagAloneDoesNotConflictWithDefaultToolsets(t *testing.T) {
 	assert.False(t, *fatalCalled,
 		"passing only --tools (with --toolsets at its declared 'all' default) must not "+
 			"trigger the --tools/--toolsets conflict Fatal")
-	assert.Contains(t, captured, "search_providers")
-	assert.Contains(t, captured, "get_provider_details")
+	assert.True(t, captured.IsToolEnabled("search_providers"))
+	assert.True(t, captured.IsToolEnabled("get_provider_details"))
+
 }
 
 // TestToolsAndToolsetsTogetherTriggersFatal locks the negative behavior down:
@@ -144,6 +145,5 @@ func TestInvalidToolsFlagFallsBackToDefaultToolsets(t *testing.T) {
 
 	result := parseIndividualTools("not_a_real_tool,not_real", logger)
 
-	assert.Equal(t, toolsets.DefaultToolsets(), result,
-		"invalid --tools names must fall back to DefaultToolsets()")
+	assert.Equal(t, toolsets.NewToolsetFilter(toolsets.DefaultToolsets()), result, "invalid --tools names must fall back to DefaultToolsets()")
 }

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	golang.org/x/oauth2 v0.36.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260819154853-08b0e4226688 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260819154853-08b0e4226688 // indirect
-	google.golang.org/grpc v1.83.1 // indirect
+	google.golang.org/grpc v1.83.2 // indirect
 	google.golang.org/protobuf v1.36.12 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260819154853-08b0e4226688 h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260819154853-08b0e4226688/go.mod h1:1RJ9BQGyNdZwkGc1eTqkErfRZ6RJyYPHZo73BZ1vQqI=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260819154853-08b0e4226688 h1:cYNAzI2sUwhmCcoj9TxvihSrqsxt6uIkj3rDRhSDmW4=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260819154853-08b0e4226688/go.mod h1:DjtHYE8FKJLivXcBEjGwndXfIC23G0VpXiXKqG179uA=
-google.golang.org/grpc v1.83.1 h1:HIO0+BEtBP6soyqvqC8sNUjZ7bTs+0hFQuFF+RAy++Y=
-google.golang.org/grpc v1.83.1/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
+google.golang.org/grpc v1.83.2 h1:EManeRomTObA0BU7I8vXgg/78uE5MJ9M8B39EX2WscU=
+google.golang.org/grpc v1.83.2/go.mod h1:YPI1hK3kDked6iHvgX3tR0y+nX/qpMFKhPgFsokw1S8=
 google.golang.org/protobuf v1.36.12 h1:pJOKDDOyeXErUroCihFAd5LQuwXBSpVnKGrj5o/fwxc=
 google.golang.org/protobuf v1.36.12/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/mcp-official/server.go
+++ b/pkg/mcp-official/server.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-mcp-server/pkg/mcp-official/tools"
+	"github.com/hashicorp/terraform-mcp-server/pkg/toolsets"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	log "github.com/sirupsen/logrus"
@@ -43,7 +44,7 @@ func WithMiddlewares(mw ...mcp.Middleware) Option {
 	}
 }
 
-func NewServer(version, instructions string, heartbeatInterval time.Duration, logger *log.Logger, enabledToolsets []string, opts ...Option) *mcp.Server {
+func NewServer(version, instructions string, heartbeatInterval time.Duration, logger *log.Logger, filter toolsets.ToolFilter, opts ...Option) *mcp.Server {
 	cfg := &serverConfig{mcpOpts: mcp.ServerOptions{Instructions: instructions}}
 	if heartbeatInterval > 0 {
 		logger.Infof("HTTP heartbeat enabled with interval: %v", heartbeatInterval)
@@ -69,6 +70,6 @@ func NewServer(version, instructions string, heartbeatInterval time.Duration, lo
 		svr.AddReceivingMiddleware(cfg.middlewares...)
 	}
 
-	tools.RegisterTools(svr, logger, enabledToolsets)
+	tools.RegisterTools(svr, logger, filter)
 	return svr
 }

--- a/pkg/mcp-official/tools/tools.go
+++ b/pkg/mcp-official/tools/tools.go
@@ -1,18 +1,37 @@
 package tools
 
 import (
+	tfeTools "github.com/hashicorp/terraform-mcp-server/pkg/mcp-official/tools/tfe"
 	"github.com/hashicorp/terraform-mcp-server/pkg/toolsets"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	log "github.com/sirupsen/logrus"
-	tfeTools "github.com/hashicorp/terraform-mcp-server/pkg/mcp-official/tools/tfe"
 )
 
-func RegisterTools(svr *mcp.Server, logger *log.Logger, enabledToolsets []string) {
-	if toolsets.IsToolEnabled("list_workspaces", enabledToolsets) {
-		mcp.AddTool(svr, tfeTools.ListWorkpsacesTool(), tfeTools.ListWorkspacesFunc)
-	}
+// officialFactories has one entry per tool actually ported to the official
+// go-sdk so far. mcp.AddTool is generic per tool (different Arguments/Result
+// types), so each entry is a closure that calls it directly rather than a
+// plain map[string]func(*log.Logger) server.ServerTool like the mark3labs
+// side uses
 
-	if toolsets.IsToolEnabled("list_terraform_orgs", enabledToolsets) {
+var officialFactories = map[string]func(svr *mcp.Server){
+	// Add entries here as each tool gets ported to the official go-sdk
+	// Tools not yet migrated simply have no entry and are silently skipped
+	// below — no other code needs to change.
+	"list_workspaces": func(svr *mcp.Server) {
+		mcp.AddTool(svr, tfeTools.ListWorkpsacesTool(), tfeTools.ListWorkspacesFunc)
+	},
+	"list_terraform_orgs": func(svr *mcp.Server) {
 		mcp.AddTool(svr, tfeTools.ListTerraformOrganizationsTool(), tfeTools.ListTerraformOrganizationsFunc)
+	},
+}
+
+func RegisterTools(svr *mcp.Server, logger *log.Logger, filter toolsets.ToolFilter) {
+	for _, td := range toolsets.AllTools {
+		if !filter.IsToolEnabled(td.Name) {
+			continue
+		}
+		if register, ok := officialFactories[td.Name]; ok {
+			register(svr)
+		}
 	}
 }

--- a/pkg/tools/dynamic_tool.go
+++ b/pkg/tools/dynamic_tool.go
@@ -24,19 +24,19 @@ type DynamicToolRegistry struct {
 	tfeToolsRegistered bool
 	mcpServer          *server.MCPServer
 	logger             *log.Logger
-	enabledToolsets    []string
+	filter             toolsets.ToolFilter
 }
 
 var globalToolRegistry *DynamicToolRegistry
 
 // registerDynamicTools registers the global tool registry
-func registerDynamicTools(mcpServer *server.MCPServer, logger *log.Logger, enabledToolsets []string) {
+func registerDynamicTools(mcpServer *server.MCPServer, logger *log.Logger, filter toolsets.ToolFilter) {
 	globalToolRegistry = &DynamicToolRegistry{
 		sessionsWithTFE:    make(map[string]bool),
 		tfeToolsRegistered: false,
 		mcpServer:          mcpServer,
 		logger:             logger,
-		enabledToolsets:    enabledToolsets,
+		filter:             filter,
 	}
 
 	// Set the callback in the client package to avoid circular imports
@@ -102,290 +102,45 @@ func (r *DynamicToolRegistry) registerTFETools() {
 	if r.tfeToolsRegistered {
 		return
 	}
-
 	r.logger.Info("Registering TFE tools - first session with valid TFE client detected")
 
-	// Terraform toolset - Organization
-	if toolsets.IsToolEnabled("whoami", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("whoami", tfeTools.WhoAmI)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
+	tfOpsEnabled := isTerraformOperationsEnabled()
 
-	if toolsets.IsToolEnabled("list_terraform_orgs", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("list_terraform_orgs", tfeTools.ListTerraformOrgs)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	// Terraform toolset - Team tools
-	if toolsets.IsToolEnabled("create_team", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("create_team", tfeTools.CreateTeam)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	if toolsets.IsToolEnabled("list_teams", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("list_teams", tfeTools.ListTeams)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	if toolsets.IsToolEnabled("get_team", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("get_team", tfeTools.GetTeam)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	if toolsets.IsToolEnabled("add_team_member", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("add_team_member", tfeTools.AddTeamMember)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	if toolsets.IsToolEnabled("grant_team_access", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("grant_team_access", tfeTools.GrantTeamAccess)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	// Only register delete_team if TF operations are enable AND toolset is enable
-	if isTerraformOperationsEnabled() && toolsets.IsToolEnabled("delete_team", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("delete_team", tfeTools.DeleteTeam)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	// Terraform toolset - Workspace management tools
-	if toolsets.IsToolEnabled("list_workspaces", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("list_workspaces", tfeTools.ListWorkspaces)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	if toolsets.IsToolEnabled("get_workspace_details", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("get_workspace_details", tfeTools.GetWorkspaceDetails)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	if toolsets.IsToolEnabled("create_workspace", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("create_workspace", tfeTools.CreateWorkspace)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	if toolsets.IsToolEnabled("update_workspace", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("update_workspace", tfeTools.UpdateWorkspace)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	// Terraform toolset - Project management tools
-	if toolsets.IsToolEnabled("create_project", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("create_project", tfeTools.CreateProject)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	if toolsets.IsToolEnabled("list_terraform_projects", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("list_terraform_projects", tfeTools.ListTerraformProjects)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	if toolsets.IsToolEnabled("get_project", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("get_project", tfeTools.GetProject)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	// Only register delete_project if TF operations are enabled AND toolset is enabled
-	if isTerraformOperationsEnabled() && toolsets.IsToolEnabled("delete_project", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("delete_project", tfeTools.DeleteProject)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	// Only register delete_workspace_safely if TF operations are enabled AND toolset is enabled
-	if isTerraformOperationsEnabled() && toolsets.IsToolEnabled("delete_workspace_safely", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("delete_workspace_safely", tfeTools.DeleteWorkspaceSafely)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	if isTerraformOperationsEnabled() && toolsets.IsToolEnabled("force_unlock_workspace", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("force_unlock_workspace", tfeTools.ForceUnlockWorkspace)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	// Registry-private toolset - Private provider tools
-	if toolsets.IsToolEnabled("search_private_providers", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("search_private_providers", tfeTools.SearchPrivateProviders)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	if toolsets.IsToolEnabled("get_private_provider_details", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("get_private_provider_details", tfeTools.GetPrivateProviderDetails)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	// Registry-private toolset - Private module tools
-	if toolsets.IsToolEnabled("search_private_modules", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("search_private_modules", tfeTools.SearchPrivateModules)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	if toolsets.IsToolEnabled("get_private_module_details", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("get_private_module_details", tfeTools.GetPrivateModuleDetails)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	// Terraform toolset - Workspace tags tools
-	if toolsets.IsToolEnabled("create_workspace_tags", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("create_workspace_tags", tfeTools.CreateWorkspaceTags)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	if toolsets.IsToolEnabled("read_workspace_tags", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("read_workspace_tags", tfeTools.ReadWorkspaceTags)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	// Terraform toolset - Run tools
-	if toolsets.IsToolEnabled("list_runs", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("list_runs", tfeTools.ListRuns)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	// Create run tool with conditional options based on TF operations setting
-	if toolsets.IsToolEnabled("create_run", r.enabledToolsets) {
-		var tool server.ServerTool
-		if isTerraformOperationsEnabled() {
-			tool = r.createDynamicTFETool("create_run", tfeTools.CreateRun)
-		} else {
-			tool = r.createDynamicTFETool("create_run", tfeTools.CreateRunSafe)
+	for _, td := range toolsets.AllTools {
+		if !td.RequiresTFE || !r.filter.IsToolEnabled(td.Name) {
+			continue
 		}
+		if td.RequiresTFOps && !tfOpsEnabled {
+			continue
+		}
+
+		switch td.Name {
+		case "create_no_code_workspace":
+			// Needs *server.MCPServer too, for elicitation
+			tool := r.createDynamicTFEToolWithElicitation(td.Name, tfeTools.CreateNoCodeWorkspace)
+			r.mcpServer.AddTool(tool.Tool, tool.Handler)
+			continue
+		case "create_run":
+			// create_run is always registered when its toolset is enabled. Unlike the
+			// other RequiresTFOps tools, ENABLE_TF_OPERATIONS doesn't hide it — it just
+			// swaps which factory (safe vs. full) backs it
+			factory := tfeTools.CreateRunSafe
+			if tfOpsEnabled {
+				factory = tfeTools.CreateRun
+			}
+			tool := r.createDynamicTFETool(td.Name, factory)
+			r.mcpServer.AddTool(tool.Tool, tool.Handler)
+			continue
+		}
+		factory, ok := toolFactories[td.Name]
+		if !ok {
+			r.logger.Warnf("no tool factory registered for %q; skipping", td.Name)
+			continue
+		}
+		tool := r.createDynamicTFETool(td.Name, factory)
 		r.mcpServer.AddTool(tool.Tool, tool.Handler)
 	}
 
-	// Only register action_run if TF operations are enabled AND toolset is enabled
-	if isTerraformOperationsEnabled() && toolsets.IsToolEnabled("action_run", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("action_run", tfeTools.ActionRun)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	if toolsets.IsToolEnabled("create_no_code_workspace", r.enabledToolsets) {
-		tool := r.createDynamicTFEToolWithElicitation("create_no_code_workspace", tfeTools.CreateNoCodeWorkspace)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	if toolsets.IsToolEnabled("get_run_details", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("get_run_details", tfeTools.GetRunDetails)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	if toolsets.IsToolEnabled("get_plan_details", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("get_plan_details", tfeTools.GetPlanDetails)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	if toolsets.IsToolEnabled("get_plan_logs", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("get_plan_logs", tfeTools.GetPlanLogs)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	if toolsets.IsToolEnabled("get_plan_json_output", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("get_plan_json_output", tfeTools.GetPlanJSONOutput)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	if toolsets.IsToolEnabled("get_apply_details", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("get_apply_details", tfeTools.GetApplyDetails)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	if toolsets.IsToolEnabled("get_apply_logs", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("get_apply_logs", tfeTools.GetApplyLogs)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-	if toolsets.IsToolEnabled("get_sentinel_mock", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("get_sentinel_mock", tfeTools.GetSentinelMock)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	// Terraform toolset - Variable set tools
-	if toolsets.IsToolEnabled("list_variable_sets", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("list_variable_sets", tfeTools.ListVariableSets)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	if toolsets.IsToolEnabled("create_variable_set", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("create_variable_set", tfeTools.CreateVariableSet)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	if toolsets.IsToolEnabled("create_variable_in_variable_set", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("create_variable_in_variable_set", tfeTools.CreateVariableInVariableSet)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	if toolsets.IsToolEnabled("delete_variable_in_variable_set", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("delete_variable_in_variable_set", tfeTools.DeleteVariableInVariableSet)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	// Attach/detach variable sets to/from workspaces
-	if toolsets.IsToolEnabled("attach_variable_set_to_workspaces", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("attach_variable_set_to_workspaces", tfeTools.AttachVariableSetToWorkspaces)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	if toolsets.IsToolEnabled("detach_variable_set_from_workspaces", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("detach_variable_set_from_workspaces", tfeTools.DetachVariableSetFromWorkspaces)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	if toolsets.IsToolEnabled("attach_policy_set_to_workspaces", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("attach_policy_set_to_workspaces", tfeTools.AttachPolicySetToWorkspaces)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	if toolsets.IsToolEnabled("list_workspace_policy_sets", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("list_workspace_policy_sets", tfeTools.ListWorkspacePolicySets)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	// Terraform toolset - Variable tools
-	if toolsets.IsToolEnabled("list_workspace_variables", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("list_workspace_variables", tfeTools.ListWorkspaceVariables)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	if toolsets.IsToolEnabled("create_workspace_variable", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("create_workspace_variable", tfeTools.CreateWorkspaceVariable)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	if toolsets.IsToolEnabled("update_workspace_variable", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("update_workspace_variable", tfeTools.UpdateWorkspaceVariable)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	if toolsets.IsToolEnabled("get_token_permissions", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("get_token_permissions", tfeTools.GetTokenPermissions)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	// Terraform toolset - Stacks
-	if toolsets.IsToolEnabled("list_stacks", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("list_stacks", tfeTools.ListStacks)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-	if toolsets.IsToolEnabled("get_stack_details", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("get_stack_details", tfeTools.GetStackDetails)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	// Terraform State-Version Toolsets
-	if toolsets.IsToolEnabled("list_state_versions", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("list_state_versions", tfeTools.ListStateVersions)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	if toolsets.IsToolEnabled("get_state_version", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("get_state_version", tfeTools.GetStateVersion)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	// Terraform Toolset - Comments
-	if toolsets.IsToolEnabled("get_run_comments", r.enabledToolsets) {
-		tool := r.createDynamicTFETool("get_run_comments", tfeTools.GetRunComments)
-		r.mcpServer.AddTool(tool.Tool, tool.Handler)
-	}
 	r.tfeToolsRegistered = true
 }
 

--- a/pkg/tools/factories.go
+++ b/pkg/tools/factories.go
@@ -1,0 +1,113 @@
+// Copyright IBM Corp. 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package tools
+
+import (
+	registryTools "github.com/hashicorp/terraform-mcp-server/pkg/tools/registry"
+	tfeTools "github.com/hashicorp/terraform-mcp-server/pkg/tools/tfe"
+	"github.com/mark3labs/mcp-go/server"
+	log "github.com/sirupsen/logrus"
+)
+
+// toolFactory builds a server.ServerTool (Tool + Handler) for one tool.
+type toolFactory func(logger *log.Logger) server.ServerTool
+
+// toolFactories is the single lookup both RegisterTools (tools.go, registry
+// tools) and registerTFETools (dynamic_tool.go, TFE tools) dispatch through,
+// keyed by toolsets.ToolDef.Name. This replaces the copy-pasted
+// `if toolsets.IsToolEnabled(...) { tool := xTools.Y(logger); AddTool(...) }`
+// block that used to appear once per tool in each registration site.
+//
+// Two tools are intentionally NOT here — they don't fit the plain
+// func(*log.Logger) server.ServerTool shape and are handled explicitly where
+// they're registered, in dynamic_tool.go:
+//   - create_no_code_workspace: also needs *server.MCPServer (elicitation).
+//   - create_run: swaps between CreateRun/CreateRunSafe based on
+//     ENABLE_TF_OPERATIONS.
+var toolFactories = map[string]toolFactory{
+	// Public Registry tools
+	"search_providers":            registryTools.ResolveProviderDocID,
+	"get_provider_details":        registryTools.GetProviderDocs,
+	"get_latest_provider_version": registryTools.GetLatestProviderVersion,
+	"get_provider_capabilities":   registryTools.GetProviderCapabilities,
+	"search_modules":              registryTools.SearchModules,
+	"get_module_details":          registryTools.ModuleDetails,
+	"get_latest_module_version":   registryTools.GetLatestModuleVersion,
+	"search_policies":             registryTools.SearchPolicies,
+	"get_policy_details":          registryTools.PolicyDetails,
+
+	// Private Registry tools
+	"search_private_modules":       tfeTools.SearchPrivateModules,
+	"get_private_module_details":   tfeTools.GetPrivateModuleDetails,
+	"search_private_providers":     tfeTools.SearchPrivateProviders,
+	"get_private_provider_details": tfeTools.GetPrivateProviderDetails,
+
+	// Terraform - User
+	"whoami":                tfeTools.WhoAmI,
+	"get_token_permissions": tfeTools.GetTokenPermissions,
+
+	// Terraform - Organization
+	"list_terraform_orgs": tfeTools.ListTerraformOrgs,
+
+	// Terraform - Projects
+	"list_terraform_projects": tfeTools.ListTerraformProjects,
+	"create_project":          tfeTools.CreateProject,
+	"get_project":             tfeTools.GetProject,
+	"delete_project":          tfeTools.DeleteProject,
+
+	// Terraform - Teams
+	"list_teams":        tfeTools.ListTeams,
+	"get_team":          tfeTools.GetTeam,
+	"create_team":       tfeTools.CreateTeam,
+	"add_team_member":   tfeTools.AddTeamMember,
+	"grant_team_access": tfeTools.GrantTeamAccess,
+	"delete_team":       tfeTools.DeleteTeam,
+
+	// Terraform - Workspaces (create_no_code_workspace excepted, see above)
+	"list_workspaces":         tfeTools.ListWorkspaces,
+	"get_workspace_details":   tfeTools.GetWorkspaceDetails,
+	"create_workspace":        tfeTools.CreateWorkspace,
+	"update_workspace":        tfeTools.UpdateWorkspace,
+	"delete_workspace_safely": tfeTools.DeleteWorkspaceSafely,
+	"force_unlock_workspace":  tfeTools.ForceUnlockWorkspace,
+
+	// Terraform - Runs and Plans (create_run excepted, see above)
+	"list_runs":            tfeTools.ListRuns,
+	"get_run_details":      tfeTools.GetRunDetails,
+	"get_run_comments":     tfeTools.GetRunComments,
+	"action_run":           tfeTools.ActionRun,
+	"get_plan_details":     tfeTools.GetPlanDetails,
+	"get_plan_logs":        tfeTools.GetPlanLogs,
+	"get_plan_json_output": tfeTools.GetPlanJSONOutput,
+	"get_apply_details":    tfeTools.GetApplyDetails,
+	"get_apply_logs":       tfeTools.GetApplyLogs,
+	"get_sentinel_mock":    tfeTools.GetSentinelMock,
+
+	// Terraform - Workspace Variables
+	"list_workspace_variables":  tfeTools.ListWorkspaceVariables,
+	"create_workspace_variable": tfeTools.CreateWorkspaceVariable,
+	"update_workspace_variable": tfeTools.UpdateWorkspaceVariable,
+
+	// Terraform - Variable Sets
+	"list_variable_sets":                  tfeTools.ListVariableSets,
+	"create_variable_set":                 tfeTools.CreateVariableSet,
+	"create_variable_in_variable_set":     tfeTools.CreateVariableInVariableSet,
+	"delete_variable_in_variable_set":     tfeTools.DeleteVariableInVariableSet,
+	"attach_variable_set_to_workspaces":   tfeTools.AttachVariableSetToWorkspaces,
+	"detach_variable_set_from_workspaces": tfeTools.DetachVariableSetFromWorkspaces,
+
+	// Terraform - Tags and Policies
+	"create_workspace_tags":           tfeTools.CreateWorkspaceTags,
+	"read_workspace_tags":             tfeTools.ReadWorkspaceTags,
+	"attach_policy_set_to_workspaces": tfeTools.AttachPolicySetToWorkspaces,
+	"list_workspace_policy_sets":      tfeTools.ListWorkspacePolicySets,
+
+	// Terraform - Stacks
+	"list_stacks":       tfeTools.ListStacks,
+	"get_stack_details": tfeTools.GetStackDetails,
+
+	// Terraform - State Versions
+	"list_state_versions": tfeTools.ListStateVersions,
+	"get_state_version":   tfeTools.GetStateVersion,
+}

--- a/pkg/tools/factories_test.go
+++ b/pkg/tools/factories_test.go
@@ -1,0 +1,38 @@
+// Copyright IBM Corp. 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package tools
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-mcp-server/pkg/toolsets"
+)
+
+// toolsHandledOutsideFactoryMap are the two documented exceptions from
+// factories.go that are registered by hand instead of via toolFactories.
+var toolsHandledOutsideFactoryMap = map[string]bool{
+	"create_no_code_workspace": true,
+	"create_run":               true,
+}
+
+// TestToolFactoriesStayInSyncWithAllTools helps keep toolsets.AllTools and toolFactories in sync
+// This test fails when someone adds a tool to registry.go and forgets to add its builder to factories.go or vice versa
+func TestToolFactoriesStayInSyncWithAllTools(t *testing.T) {
+	known := make(map[string]bool, len(toolsets.AllTools))
+	for _, td := range toolsets.AllTools {
+		known[td.Name] = true
+		if toolsHandledOutsideFactoryMap[td.Name] {
+			continue
+		}
+		if _, ok := toolFactories[td.Name]; !ok {
+			t.Errorf("toolsets.AllTools has %q but toolFactories has no entry for it", td.Name)
+		}
+	}
+
+	for name := range toolFactories {
+		if !known[name] {
+			t.Errorf("toolFactories has %q but toolsets.AllTools does not know about it", name)
+		}
+	}
+}

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -4,61 +4,31 @@
 package tools
 
 import (
-	registryTools "github.com/hashicorp/terraform-mcp-server/pkg/tools/registry"
 	"github.com/hashicorp/terraform-mcp-server/pkg/toolsets"
 	"github.com/mark3labs/mcp-go/server"
 	log "github.com/sirupsen/logrus"
 )
 
-func RegisterTools(hcServer *server.MCPServer, logger *log.Logger, enabledToolsets []string) {
+func RegisterTools(hcServer *server.MCPServer, logger *log.Logger, filter toolsets.ToolFilter) {
+
 	// Register the dynamic tools (TFE tools that require authentication)
-	registerDynamicTools(hcServer, logger, enabledToolsets)
+	registerDynamicTools(hcServer, logger, filter)
 
-	// Registry toolset - Provider tools
-	if toolsets.IsToolEnabled("search_providers", enabledToolsets) {
-		tool := registryTools.ResolveProviderDocID(logger)
+	// Every tool that does NOT require a TFE session (i.e. the public
+	// Registry toolset). TFE-gated tools are handled by
+	// registerDynamicTools/registerTFETools instead, since they can only be
+	// registered once a session actually has a valid TFE client.
+	for _, td := range toolsets.AllTools {
+		if td.RequiresTFE || !filter.IsToolEnabled(td.Name) {
+			continue
+		}
+		factory, ok := toolFactories[td.Name]
+		if !ok {
+			logger.Warnf("no tool factory registered for %q; skipping", td.Name)
+			continue
+		}
+		tool := factory(logger)
 		hcServer.AddTool(tool.Tool, tool.Handler)
 	}
 
-	if toolsets.IsToolEnabled("get_provider_details", enabledToolsets) {
-		tool := registryTools.GetProviderDocs(logger)
-		hcServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	if toolsets.IsToolEnabled("get_latest_provider_version", enabledToolsets) {
-		tool := registryTools.GetLatestProviderVersion(logger)
-		hcServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	if toolsets.IsToolEnabled("get_provider_capabilities", enabledToolsets) {
-		tool := registryTools.GetProviderCapabilities(logger)
-		hcServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	// Registry toolset - Module tools
-	if toolsets.IsToolEnabled("search_modules", enabledToolsets) {
-		tool := registryTools.SearchModules(logger)
-		hcServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	if toolsets.IsToolEnabled("get_module_details", enabledToolsets) {
-		tool := registryTools.ModuleDetails(logger)
-		hcServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	if toolsets.IsToolEnabled("get_latest_module_version", enabledToolsets) {
-		tool := registryTools.GetLatestModuleVersion(logger)
-		hcServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	// Registry toolset - Policy tools
-	if toolsets.IsToolEnabled("search_policies", enabledToolsets) {
-		tool := registryTools.SearchPolicies(logger)
-		hcServer.AddTool(tool.Tool, tool.Handler)
-	}
-
-	if toolsets.IsToolEnabled("get_policy_details", enabledToolsets) {
-		tool := registryTools.PolicyDetails(logger)
-		hcServer.AddTool(tool.Tool, tool.Handler)
-	}
 }

--- a/pkg/toolsets/filter.go
+++ b/pkg/toolsets/filter.go
@@ -3,6 +3,8 @@
 
 package toolsets
 
+import "strings"
+
 // FilterMode selects how ToolFilter.IsToolEnabled decides availability.
 type FilterMode int
 
@@ -43,4 +45,13 @@ func (f ToolFilter) IsToolEnabled(toolName string) bool {
 		return false
 	}
 	return ContainsToolset(f.Toolsets, toolset)
+}
+
+// String implements fmt.Stringer so logger.Infof("...: %v", filter) prints
+// something readable instead of the raw struct fields
+func (f ToolFilter) String() string {
+	if f.Mode == ModeIndividualTools {
+		return "tools=" + strings.Join(f.Tools, ",")
+	}
+	return "toolsets=" + strings.Join(f.Toolsets, ",")
 }

--- a/pkg/toolsets/mapping.go
+++ b/pkg/toolsets/mapping.go
@@ -3,108 +3,32 @@
 
 package toolsets
 
-import "strings"
+import (
+	"strings"
+	"sync"
+)
 
-var ToolToToolset = map[string]string{
-	// Public Registry tools (providers, modules, policies)
-	"search_providers":            Registry,
-	"get_provider_details":        Registry,
-	"get_latest_provider_version": Registry,
-	"get_provider_capabilities":   Registry,
-	"search_modules":              Registry,
-	"get_module_details":          Registry,
-	"get_latest_module_version":   Registry,
-	"search_policies":             Registry,
-	"get_policy_details":          Registry,
-
-	// Private Registry tools (TFE/TFC private registry)
-	"search_private_modules":       RegistryPrivate,
-	"get_private_module_details":   RegistryPrivate,
-	"search_private_providers":     RegistryPrivate,
-	"get_private_provider_details": RegistryPrivate,
-
-	// Terraform tools - User
-	"whoami":                Terraform,
-	"get_token_permissions": Terraform,
-
-	// Terraform tools - Organization
-	"list_terraform_orgs": Terraform,
-
-	// Terraform tools - Projects
-	"list_terraform_projects": Terraform,
-	"create_project":          Terraform,
-	"get_project":             Terraform,
-	"delete_project":          Terraform,
-
-	// Terraform tools - Teams
-	"list_teams":        Terraform,
-	"get_team":          Terraform,
-	"create_team":       Terraform,
-	"add_team_member":   Terraform,
-	"grant_team_access": Terraform,
-	"delete_team":       Terraform,
-
-	// Terraform tools - Workspaces
-	"list_workspaces":          Terraform,
-	"get_workspace_details":    Terraform,
-	"create_workspace":         Terraform,
-	"create_no_code_workspace": Terraform,
-	"update_workspace":         Terraform,
-	"delete_workspace_safely":  Terraform,
-	"force_unlock_workspace":   Terraform,
-
-	// Terraform tools - Runs and Plans
-	"list_runs":            Terraform,
-	"get_run_details":      Terraform,
-	"get_run_comments":     Terraform,
-	"create_run":           Terraform,
-	"action_run":           Terraform,
-	"get_plan_details":     Terraform,
-	"get_plan_logs":        Terraform,
-	"get_plan_json_output": Terraform,
-	"get_apply_details":    Terraform,
-	"get_apply_logs":       Terraform,
-	"get_sentinel_mock":    Terraform,
-
-	// Terraform tools - Workspace Variables
-	"list_workspace_variables":  Terraform,
-	"create_workspace_variable": Terraform,
-	"update_workspace_variable": Terraform,
-
-	// Terraform tools - Variable Sets
-	"list_variable_sets":                  Terraform,
-	"create_variable_set":                 Terraform,
-	"create_variable_in_variable_set":     Terraform,
-	"delete_variable_in_variable_set":     Terraform,
-	"attach_variable_set_to_workspaces":   Terraform,
-	"detach_variable_set_from_workspaces": Terraform,
-
-	// Terraform tools - Tags and Policies
-	"create_workspace_tags":           Terraform,
-	"read_workspace_tags":             Terraform,
-	"attach_policy_set_to_workspaces": Terraform,
-	"list_workspace_policy_sets":      Terraform,
-
-	// Terraform tools - Stacks
-	"list_stacks":       Terraform,
-	"get_stack_details": Terraform,
-
-	// Terraform tools - State Versions
-	"list_state_versions": Terraform,
-	"get_state_version":   Terraform,
-}
+// toolsetIndex is a memoized "tool name -> toolset name" lookup, built once
+// from AllTools (registry.go) instead of hand-maintaining a second map
+var toolsetIndex = sync.OnceValue(func() map[string]string {
+	index := make(map[string]string, len(AllTools))
+	for _, td := range AllTools {
+		index[td.Name] = td.Toolset
+	}
+	return index
+})
 
 // GetToolsetForTool returns the toolset name for a given tool name
 func GetToolsetForTool(toolName string) (string, bool) {
-	toolset, exists := ToolToToolset[toolName]
+	toolset, exists := toolsetIndex()[toolName]
 	return toolset, exists
 }
 
-// KnownToolNames returns every tool name registered in ToolToToolset
+// KnownToolNames returns every tool name registered in toolsetIndex
 func KnownToolNames() map[string]bool {
-
-	validTools := make(map[string]bool)
-	for toolName := range ToolToToolset {
+	index := toolsetIndex()
+	validTools := make(map[string]bool, len(index))
+	for toolName := range index {
 		validTools[toolName] = true
 	}
 	return validTools
@@ -134,33 +58,4 @@ func ParseIndividualTools(toolNames []string) ([]string, []string) {
 	}
 
 	return valid, invalid
-}
-
-// EnableIndividualTools creates a toolset list for individual tool filtering mode
-// The returned list includes an internal marker plus the specified tool names
-func EnableIndividualTools(toolNames []string) []string {
-	result := make([]string, 0, len(toolNames)+1)
-	result = append(result, individualToolsMarker)
-	result = append(result, toolNames...)
-	return result
-}
-
-// IsToolEnabled checks if a tool is enabled based on the enabled toolsets.
-//
-// NOTE: this is the pre-migration []string + sentinel-marker encoding.
-// ToolFilter (filter.go) is the new, typed replacement — new code should
-// prefer NewToolsetFilter/NewIndividualToolFilter. This function stays as-is
-// until call sites (main.go, dynamic_tool.go) are migrated in a later PR.
-func IsToolEnabled(toolName string, enabledToolsets []string) bool {
-	if ContainsToolset(enabledToolsets, All) {
-		return true
-	}
-	if ContainsToolset(enabledToolsets, individualToolsMarker) {
-		return ContainsToolset(enabledToolsets, toolName)
-	}
-	toolset, exists := GetToolsetForTool(toolName)
-	if !exists {
-		return false
-	}
-	return ContainsToolset(enabledToolsets, toolset)
 }

--- a/pkg/toolsets/registry.go
+++ b/pkg/toolsets/registry.go
@@ -1,0 +1,105 @@
+// Copyright IBM Corp. 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package toolsets
+
+// ToolDef is the single source of truth for a tool's registration metadata:
+// which toolset it belongs to, and what runtime gates control it.
+type ToolDef struct {
+	Name          string
+	Toolset       string
+	RequiresTFE   bool // needs an authenticated TFE/TFC session before it's registered
+	RequiresTFOps bool // additionally gated behind ENABLE_TF_OPERATIONS=true
+}
+
+// AllTools is the full list of tools known to the server. Both the
+// mark3labs and official-SDK registration code should loop over this
+// instead of hardcoding their own per-tool if-chain.
+var AllTools = []ToolDef{
+	// Public Registry tools (providers, modules, policies) — no TFE session needed
+	{Name: "search_providers", Toolset: Registry},
+	{Name: "get_provider_details", Toolset: Registry},
+	{Name: "get_latest_provider_version", Toolset: Registry},
+	{Name: "get_provider_capabilities", Toolset: Registry},
+	{Name: "search_modules", Toolset: Registry},
+	{Name: "get_module_details", Toolset: Registry},
+	{Name: "get_latest_module_version", Toolset: Registry},
+	{Name: "search_policies", Toolset: Registry},
+	{Name: "get_policy_details", Toolset: Registry},
+
+	// Private Registry tools (TFE/TFC private registry)
+	{Name: "search_private_modules", Toolset: RegistryPrivate, RequiresTFE: true},
+	{Name: "get_private_module_details", Toolset: RegistryPrivate, RequiresTFE: true},
+	{Name: "search_private_providers", Toolset: RegistryPrivate, RequiresTFE: true},
+	{Name: "get_private_provider_details", Toolset: RegistryPrivate, RequiresTFE: true},
+
+	// Terraform - User
+	{Name: "whoami", Toolset: Terraform, RequiresTFE: true},
+	{Name: "get_token_permissions", Toolset: Terraform, RequiresTFE: true},
+
+	// Terraform - Organization
+	{Name: "list_terraform_orgs", Toolset: Terraform, RequiresTFE: true},
+
+	// Terraform - Projects
+	{Name: "list_terraform_projects", Toolset: Terraform, RequiresTFE: true},
+	{Name: "create_project", Toolset: Terraform, RequiresTFE: true},
+	{Name: "get_project", Toolset: Terraform, RequiresTFE: true},
+	{Name: "delete_project", Toolset: Terraform, RequiresTFE: true, RequiresTFOps: true},
+
+	// Terraform - Teams
+	{Name: "list_teams", Toolset: Terraform, RequiresTFE: true},
+	{Name: "get_team", Toolset: Terraform, RequiresTFE: true},
+	{Name: "create_team", Toolset: Terraform, RequiresTFE: true},
+	{Name: "add_team_member", Toolset: Terraform, RequiresTFE: true},
+	{Name: "grant_team_access", Toolset: Terraform, RequiresTFE: true},
+	{Name: "delete_team", Toolset: Terraform, RequiresTFE: true, RequiresTFOps: true},
+
+	// Terraform - Workspaces
+	{Name: "list_workspaces", Toolset: Terraform, RequiresTFE: true},
+	{Name: "get_workspace_details", Toolset: Terraform, RequiresTFE: true},
+	{Name: "create_workspace", Toolset: Terraform, RequiresTFE: true},
+	{Name: "create_no_code_workspace", Toolset: Terraform, RequiresTFE: true},
+	{Name: "update_workspace", Toolset: Terraform, RequiresTFE: true},
+	{Name: "delete_workspace_safely", Toolset: Terraform, RequiresTFE: true, RequiresTFOps: true},
+	{Name: "force_unlock_workspace", Toolset: Terraform, RequiresTFE: true, RequiresTFOps: true},
+
+	// Terraform - Runs and Plans
+	{Name: "list_runs", Toolset: Terraform, RequiresTFE: true},
+	{Name: "get_run_details", Toolset: Terraform, RequiresTFE: true},
+	{Name: "get_run_comments", Toolset: Terraform, RequiresTFE: true},
+	{Name: "create_run", Toolset: Terraform, RequiresTFE: true}, // Handle special case
+	{Name: "action_run", Toolset: Terraform, RequiresTFE: true, RequiresTFOps: true},
+	{Name: "get_plan_details", Toolset: Terraform, RequiresTFE: true},
+	{Name: "get_plan_logs", Toolset: Terraform, RequiresTFE: true},
+	{Name: "get_plan_json_output", Toolset: Terraform, RequiresTFE: true},
+	{Name: "get_apply_details", Toolset: Terraform, RequiresTFE: true},
+	{Name: "get_apply_logs", Toolset: Terraform, RequiresTFE: true},
+	{Name: "get_sentinel_mock", Toolset: Terraform, RequiresTFE: true},
+
+	// Terraform - Workspace Variables
+	{Name: "list_workspace_variables", Toolset: Terraform, RequiresTFE: true},
+	{Name: "create_workspace_variable", Toolset: Terraform, RequiresTFE: true},
+	{Name: "update_workspace_variable", Toolset: Terraform, RequiresTFE: true},
+
+	// Terraform - Variable Sets
+	{Name: "list_variable_sets", Toolset: Terraform, RequiresTFE: true},
+	{Name: "create_variable_set", Toolset: Terraform, RequiresTFE: true},
+	{Name: "create_variable_in_variable_set", Toolset: Terraform, RequiresTFE: true},
+	{Name: "delete_variable_in_variable_set", Toolset: Terraform, RequiresTFE: true},
+	{Name: "attach_variable_set_to_workspaces", Toolset: Terraform, RequiresTFE: true},
+	{Name: "detach_variable_set_from_workspaces", Toolset: Terraform, RequiresTFE: true},
+
+	// Terraform - Tags and Policies
+	{Name: "create_workspace_tags", Toolset: Terraform, RequiresTFE: true},
+	{Name: "read_workspace_tags", Toolset: Terraform, RequiresTFE: true},
+	{Name: "attach_policy_set_to_workspaces", Toolset: Terraform, RequiresTFE: true},
+	{Name: "list_workspace_policy_sets", Toolset: Terraform, RequiresTFE: true},
+
+	// Terraform - Stacks
+	{Name: "list_stacks", Toolset: Terraform, RequiresTFE: true},
+	{Name: "get_stack_details", Toolset: Terraform, RequiresTFE: true},
+
+	// Terraform - State Versions
+	{Name: "list_state_versions", Toolset: Terraform, RequiresTFE: true},
+	{Name: "get_state_version", Toolset: Terraform, RequiresTFE: true},
+}

--- a/pkg/toolsets/toolsets.go
+++ b/pkg/toolsets/toolsets.go
@@ -14,9 +14,6 @@ const (
 	// Special toolsets
 	All     = "all"
 	Default = "default"
-
-	// Internal marker for individual tool filtering
-	individualToolsMarker = "__individual_tools__"
 )
 
 // Toolset represents metadata about a toolset

--- a/pkg/toolsets/toolsets_test.go
+++ b/pkg/toolsets/toolsets_test.go
@@ -172,7 +172,7 @@ func TestValidToolsetNames(t *testing.T) {
 	}
 }
 
-func TestIsToolEnabled(t *testing.T) {
+func TestToolFilter_ToolsetsMode(t *testing.T) {
 	tests := []struct {
 		name            string
 		toolName        string
@@ -219,10 +219,10 @@ func TestIsToolEnabled(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := IsToolEnabled(tt.toolName, tt.enabledToolsets)
+			result := NewToolsetFilter(tt.enabledToolsets).IsToolEnabled(tt.toolName)
 
 			if result != tt.expected {
-				t.Errorf("IsToolEnabled(%s, %v) = %v, want %v", tt.toolName, tt.enabledToolsets, result, tt.expected)
+				t.Errorf("NewToolsetFilter(%v).IsToolEnabled(%s) = %v, want %v", tt.enabledToolsets, tt.toolName, result, tt.expected)
 			}
 		})
 	}
@@ -288,51 +288,45 @@ func TestParseIndividualTools(t *testing.T) {
 	}
 }
 
-func TestIsToolEnabledIndividualMode(t *testing.T) {
+func TestToolFilter_IndividualMode(t *testing.T) {
 	tests := []struct {
-		name            string
-		toolName        string
-		enabledToolsets []string
-		expected        bool
+		name      string
+		toolName  string
+		toolNames []string
+		expected  bool
 	}{
 		{
-			name:            "tool enabled in individual mode",
-			toolName:        "search_providers",
-			enabledToolsets: EnableIndividualTools([]string{"search_providers", "list_workspaces"}),
-			expected:        true,
+			name:      "tool enabled in individual mode",
+			toolName:  "search_providers",
+			toolNames: []string{"search_providers", "list_workspaces"},
+			expected:  true,
 		},
 		{
-			name:            "tool disabled in individual mode",
-			toolName:        "get_provider_details",
-			enabledToolsets: EnableIndividualTools([]string{"search_providers", "list_workspaces"}),
-			expected:        false,
+			name:      "tool disabled in individual mode",
+			toolName:  "get_provider_details",
+			toolNames: []string{"search_providers", "list_workspaces"},
+			expected:  false,
 		},
 		{
-			name:            "all toolset overrides individual mode",
-			toolName:        "get_provider_details",
-			enabledToolsets: append([]string{"all"}, EnableIndividualTools([]string{"search_providers"})...),
-			expected:        true,
+			name:      "terraform tool in individual mode",
+			toolName:  "list_workspaces",
+			toolNames: []string{"list_workspaces"},
+			expected:  true,
 		},
 		{
-			name:            "terraform tool in individual mode",
-			toolName:        "list_workspaces",
-			enabledToolsets: EnableIndividualTools([]string{"list_workspaces"}),
-			expected:        true,
-		},
-		{
-			name:            "private registry tool in individual mode",
-			toolName:        "search_private_modules",
-			enabledToolsets: EnableIndividualTools([]string{"search_private_modules"}),
-			expected:        true,
+			name:      "private registry tool in individual mode",
+			toolName:  "search_private_modules",
+			toolNames: []string{"search_private_modules"},
+			expected:  true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := IsToolEnabled(tt.toolName, tt.enabledToolsets)
+			result := NewIndividualToolFilter(tt.toolNames).IsToolEnabled(tt.toolName)
 
 			if result != tt.expected {
-				t.Errorf("IsToolEnabled(%s, %v) = %v, want %v", tt.toolName, tt.enabledToolsets, result, tt.expected)
+				t.Errorf("NewIndividualToolFilter(%v).IsToolEnabled(%s) = %v, want %v", tt.toolNames, tt.toolName, result, tt.expected)
 			}
 		})
 	}
@@ -361,9 +355,9 @@ func TestKnownToolNames(t *testing.T) {
 		}
 	}
 
-	// Verify count matches ToolToToolset map
-	if len(validTools) != len(ToolToToolset) {
-		t.Errorf("KnownToolNames() returned %d tools, want %d", len(validTools), len(ToolToToolset))
+	// Verify count matches AllTools (the single source of truth in registry.go)
+	if len(validTools) != len(AllTools) {
+		t.Errorf("KnownToolNames() returned %d tools, want %d", len(validTools), len(AllTools))
 	}
 }
 


### PR DESCRIPTION
## What changed
**Cleans up how tools get registered with the MCP server**
Before this change, the same list of ~60 tools was written out by hand, three separate times, each as a long chain of `if this tool is enabled { register it }` blocks (in the mark3labs registry tools, mark3labs TFE tools, and official-SDK tools). There was also a second, hand-maintained map of "which tool belongs to which toolset" that had to be kept in sync by hand with the main list.

Now there is one list of every tool (`pkg/toolsets/registry.go`) that says, per tool: which toolset it's in, whether it needs a TFE session, and whether it needs `ENABLE_TF_OPERATIONS=true`. All three registration spots just loop over this one list instead of repeating themselves. A small map per SDK (`pkg/tools/factories.go`, `pkg/mcp official/tools/tools.go`) says how to actually build each tool.

This also finishes wiring up `ToolFilter` (added in the previous PR) all the way through the app, replacing the old `[]string` + hidden "marker" used to say "individual tool mode."

## What did NOT change
- No tools were added, removed, or renamed.
- No toolset names or defaults changed.
- `ENABLE_TF_OPERATIONS` still gates the exact same 5 tools
  (`delete_team`, `delete_project`, `delete_workspace_safely`,
  `force_unlock_workspace`, `action_run`), and `create_run` still defaults
  to the safe, no-auto-apply version unless that flag is on.

## Notes
- `go.mod`/`go.sum`: bumped, `google.golang.org/grpc` to fix failing build







## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
